### PR TITLE
Better difficulty scaling for Pong.hs

### DIFF
--- a/examples/Pong.hs
+++ b/examples/Pong.hs
@@ -85,8 +85,8 @@ hitPos (x,y) (u,v) = ypos
 accuracy :: Pong -> Float
 accuracy p = g . f . fromIntegral $ p^.score._1 - p^.score._2
   where
-    -- Scaling curve
-    f x = -4.5e-8 * x^3 + 3.7e-6 * x^2 + 0.04 * x + 0.5
+    -- Scaling function
+    f x = 0.04 * x + 0.5
     -- Clamping function
     g = min losingAccuracy . max winningAccuracy
 


### PR DESCRIPTION
The difficulty function is picked so that the CPU will be at 0.9 when you have a 10 point lead, and 0.1 when it has a 10 point lead; interpolated cleanly (with 0.5 for neutral)
