### PR TITLE
Tiny documentation error in Control.Lens.Zipper

### DIFF
--- a/src/Control/Lens/Zipper.hs
+++ b/src/Control/Lens/Zipper.hs
@@ -285,7 +285,7 @@ within l (Zipper h (Level n ls b rs)) = case partsOf l (Context id) b of
 --
 -- You can reason about this function as if the definition was:
 --
--- @'fromWithin' l ≡ 'fromJust ' '.' 'within' l@
+-- @'fromWithin' l ≡ 'fromJust' '.' 'within' l@
 --
 -- but it is lazier in such a way that if this invariant is violated, some code
 -- can still succeed if it is lazy enough in the use of the focused value.


### PR DESCRIPTION
See how `fromJust` isn't linked to by Haddock under `fromWithin` [here](http://hackage.haskell.org/packages/archive/lens/3.2/doc/html/Control-Lens-Zipper.html).
