### PR TITLE
Get rid of swap files, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+.*.swp
+.*.swo


### PR DESCRIPTION
There was quite a bit of stuff lying around in my copy, and I didn't want to have to keep deleting all the .DS_Store files every time just for Mac OS X to fill them in again.
