### PR TITLE
infix 4 `zoom`, `magnify`

### DIFF
--- a/src/Control/Lens/Zoom.hs
+++ b/src/Control/Lens/Zoom.hs
@@ -56,6 +56,8 @@ import Data.Monoid
 -- >>> let g :: Expr -> Expr; g = Vars.g
 -- >>> let h :: Expr -> Expr -> Expr; h = Vars.h
 
+infix 4 `zoom`, `magnify`
+
 -- | This class allows us to use 'zoom' in, changing the State supplied by
 -- many different monad transformers, potentially quite deep in a monad transformer stack.
 class (MonadState s m, MonadState t n) => Zoom m n k s t | m -> s k, n -> t k, m t -> n, n s -> m where


### PR DESCRIPTION
So that we can write them infix and still being able to compose lenses on the left with (.).
