### PR TITLE
Fix formatting of 'cloneLens' documentation

### DIFF
--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -383,9 +383,9 @@ locus f w = (`seek` w) <$> f (pos w)
 --
 -- Note: This only accepts a proper 'Lens'.
 --
--- :t let example l x = set (cloneLens l) (x^.cloneLens l + 1) x in example
---
--- /\"Costate Comonad Coalgebra is equivalent of Java's member variable update technology for Haskell\"/ -- \@PLT_Borat on Twitter
+-- > :t let example l x = set (cloneLens l) (x^.cloneLens l + 1) x in example
+-- > let example l x = set (cloneLens l) (x^.cloneLens l + 1) x in example
+-- >   :: Num b => LensLike (Context b b) s t b b -> s -> t
 cloneLens :: Functor f
   => LensLike (Context a b) s t a b
   -> (a -> f b) -> s -> f t


### PR DESCRIPTION
I don't really get what the example is trying to show, but at least displays properly. The Twitter quote seemed entirely irrelevant so I've removed it..
