### PR TITLE
Added a failing `over` combinator for `Prism`s.

### DIFF
--- a/src/Control/Lens/Prism.hs
+++ b/src/Control/Lens/Prism.hs
@@ -158,7 +158,8 @@ isn't k s = case runPrism k of
 {-# INLINE isn't #-}
 
 -- | Try to map a function over this 'Prism', failing if the 'Prism' does. This
--- actually can more generally be applied to any 'Traversal'.
+-- actually can more generally be applied to any 'Traversal', failing unless at
+-- least one traversal succeeds.
 --
 -- >>> let { nat :: Prism' Int Int; nat = prism' id $ \i -> if (i >= 0) then Just i else Nothing }
 -- >>> tryOver nat (2*) 10 :: Maybe Int


### PR DESCRIPTION
The default behavior for `over` applied to Prisms, to act as `id` if the
prismatic mapping fails, is concerning since it consumes a failure. The
new combinator, `overM` uses `isn't` to fail the computation when the
prism does. I don't think this is a general function, but I can't think
how to observe the failure in `over prism` any other way.
