### PR TITLE
In the doctests, only use the windows.h functions on Windows

### DIFF
--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -31,7 +31,7 @@ import Control.Exception
 import Foreign.C.Types
 foreign import stdcall "windows.h SetConsoleCP" c_SetConsoleCP :: CUInt -> IO Bool
 foreign import stdcall "windows.h GetConsoleCP" c_GetConsoleCP :: IO CUInt
-##elif defined(x64_64_HOST_ARCH)
+##elif defined(x86_64_HOST_ARCH)
 ##define USE_CP
 import Control.Applicative
 import Control.Exception


### PR DESCRIPTION
I _think_ this is the correct define to test for, but I'm not sure.

This fixes a build failure I was seeing on Ubuntu (but should affect any non-Windows build).

Also, the correct define for x86-64 is x86_64_HOST_OS (it was x64… before). This may have masked this failure on x86-64, because that branch would never have been chosen. Also fixed here.
