### PR TITLE
findMOf and ifindMOf

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -84,6 +84,7 @@ module Control.Lens.Fold
   , maximumOf, minimumOf
   , maximumByOf, minimumByOf
   , findOf
+  , findMOf
   , foldrOf', foldlOf'
   , foldr1Of, foldl1Of
   , foldr1Of', foldl1Of'
@@ -106,6 +107,7 @@ module Control.Lens.Fold
   , iforMOf_
   , iconcatMapOf
   , ifindOf
+  , ifindMOf
   , ifoldrOf'
   , ifoldlOf'
   , ifoldrMOf


### PR DESCRIPTION
Added general shortcutting versions of these two functions to
Control.Lens.Fold
This is my first git push ever, so let me know if something is messed
up. I tried to match the style and conventions for findOf and ifindOf.

findMOf :: (Monad m, Iso s a)     -> (a -> m Bool) -> s -> m (Maybe a)
and
ifindMOf :: Monad m => IndexedLens i s a      -> (i -> a -> m Bool) -> s
-> m (Maybe a)
