### PR TITLE
Added `Control.Monad.Primitive.Lens`

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -182,12 +182,13 @@ library
     MonadCatchIO-transformers >= 0.3      && < 0.4,
     mtl                       >= 2.0.1    && < 2.2,
     parallel                  >= 3.1.0.1  && < 3.3,
+    primitive                 >= 0.4.0.1  && < 0.6,
     profunctors               >= 3.2      && < 4,
     profunctor-extras         >= 3.3      && < 4,
     reflection                >= 1.1.6    && < 2,
     semigroupoids             >= 3.0.2    && < 4,
     semigroups                >= 0.8.4    && < 1,
-    split                     == 0.2.*,
+    split                     >= 0.2      && < 0.3,
     tagged                    >= 0.4.4    && < 1,
     template-haskell          >= 2.4      && < 2.10,
     text                      >= 0.11     && < 0.12,
@@ -246,6 +247,7 @@ library
     Control.Lens.Wrapped
     Control.Lens.Zoom
     Control.Monad.Error.Lens
+    Control.Monad.Primitive.Lens
     Control.Parallel.Strategies.Lens
     Control.Seq.Lens
     Data.Array.Lens

--- a/src/Control/Monad/Error/Lens.hs
+++ b/src/Control/Monad/Error/Lens.hs
@@ -221,4 +221,3 @@ catchJust f m k = catchError m $ \ e -> case f e of
   Nothing -> throwError e
   Just x  -> k x
 {-# INLINE catchJust #-}
-

--- a/src/Control/Monad/Primitive/Lens.hs
+++ b/src/Control/Monad/Primitive/Lens.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE UnboxedTuples #-}
+{-# LANGUAGE TypeFamilies #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Primitive.Lens
+-- Copyright   :  (C) 2013 Edward Kmett
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+-- Stability   :  provisional
+-- Portability :  Control.Monad.Primitive
+--
+----------------------------------------------------------------------------
+module Control.Monad.Primitive.Lens
+  (
+    prim
+  ) where
+
+import Control.Lens
+import Control.Monad.Primitive (PrimMonad(..))
+import GHC.Prim (State#)
+
+prim :: (PrimMonad m) => Iso' (m a) (State# (PrimState m) -> (# State# (PrimState m), a #))
+prim = iso internal primitive
+{-# INLINE prim #-}


### PR DESCRIPTION
The `primitive` package is pulled in anyway by `vector`, so we might as well take advantage of it.

I tried to add `Wrapped` instances for the various `Data.Primitive` types, but I couldn't get around the kind mismatch between `*` and `#`.  :(
