### PR TITLE
Add Monoid and Semigroup instance for Accessor

### DIFF
--- a/src/Control/Lens/Internal/Getter.hs
+++ b/src/Control/Lens/Internal/Getter.hs
@@ -85,7 +85,10 @@ instance Monoid r => Applicative (Accessor r) where
 
 instance Semigroup r => Semigroup (Accessor r a) where
   Accessor a <> Accessor b = Accessor $ a <> b
+  {-# INLINE (<>) #-}
 
 instance Monoid r => Monoid (Accessor r a) where
   mempty = Accessor mempty
+  {-# INLINE mempty #-}
   mappend (Accessor a) (Accessor b) = Accessor $ mappend a b
+  {-# INLINE mappend #-}


### PR DESCRIPTION
Added a Monoid and Semigroup instance to Accessor. For example, this allows to write:

``` haskell
> [1,2] ^.. (ix 1 <> ix 0 <> ix 3)
[2,1]
```

This is my first pull request to lens, so let me know if I did anything wrong. 
