### PR TITLE
Made `Data.Map.Lens' work nicely with -Werror.

### DIFF
--- a/src/Data/Map/Lens.hs
+++ b/src/Data/Map/Lens.hs
@@ -1,9 +1,10 @@
 -- | One of most commonly-asked questions about this package is whether
--- it provides lenses for working with 'Map'. It does, but their uses
+-- it provides lenses for working with 'Data.Map.Map'. It does, but their uses
 -- are perhaps obscured by their genericity. This module exists to provide
 -- documentation for them.
 --
--- 'Map' is an instance of 'At', so we have a lenses on values at keys:
+-- 'Data.Map.Map' is an instance of 'Control.Lens.At.At', so we have a lenses
+-- on values at keys:
 --
 -- >>> Map.fromList [(1, "world")] ^.at 1
 -- Just "world"
@@ -14,7 +15,8 @@
 -- >>> at 0 ?~ "hello" $ Map.empty
 -- fromList [(0,"hello")]
 --
--- 'Map' is an instance of 'Contains', and so we can test for membership.
+-- 'Data.Map.Map' is an instance of 'Control.Lens.At.Contains', and so we can
+-- test for membership.
 --
 -- >>> Map.empty ^. contains 12
 -- False
@@ -22,9 +24,10 @@
 -- >>> Map.fromList [(0, "Mercury")] ^. contains 0
 -- True
 --
--- We can traverse, fold over, and map over key-value pairs in a 'Map', 
--- thanks to its 'TraversableWithIndex', 'FoldableWithIndex', and
--- 'FunctorWithIndex' instances.
+-- We can traverse, fold over, and map over key-value pairs in a
+-- 'Data.Map.Map', thanks to its 'Control.Lens.Indexed.TraversableWithIndex',
+-- 'Control.Lens.Indexed.FoldableWithIndex', and
+-- 'Control.Lens.Indexed.FunctorWithIndex' instances.
 --
 -- >>> imap const $ Map.fromList [(1, "Venus")]
 -- fromList [(1,1)]
@@ -38,8 +41,8 @@
 -- >>> itoList $ Map.fromList [(5, "Saturn")]
 -- [(5,"Saturn")]
 --
--- A related class, 'Ixed', allows us to use 'ix' to traverse a value at a
--- particular key.
+-- A related class, 'Control.Lens.At.Ixed', allows us to use
+-- 'Control.Lens.At.ix' to traverse a value at a particular key.
 --
 -- >>> ix 2 %~ ("New " ++) $ Map.fromList [(2, "Earth")]
 -- fromList [(2,"New Earth")]
@@ -47,19 +50,17 @@
 -- >>> preview (ix 8) $ Map.empty
 -- Nothing
 --
--- Additionally, 'Map' has 'TraverseMin' and 'TraverseMax' instances, which let
--- us traverse over the value at the least and greatest keys, respectively.
+-- Additionally, 'Data.Map.Map' has 'Control.Lens.Traversal.TraverseMin' and
+-- 'Control.Lens.Traversal.TraverseMax' instances, which let us traverse over
+-- the value at the least and greatest keys, respectively.
 --
 -- >>> preview traverseMin $ Map.fromList [(5, "Saturn"), (6, "Uranus")]
 -- Just "Saturn"
 --
 -- >>> preview traverseMax $ Map.fromList [(5, "Saturn"), (6, "Uranus")]
 -- Just "Uranus"
-module Data.Map.Lens where
--- base
-import Data.Monoid
--- containers
-import Data.Map (Map)
-import qualified Data.Map as Map
--- lens
-import Control.Lens
+module Data.Map.Lens () where
+-- $setup
+-- >>> import Control.Lens
+-- >>> import Data.Monoid
+-- >>> import qualified Data.Map as Map


### PR DESCRIPTION
It [didn't like](https://travis-ci.org/ekmett/lens/builds/10920193) the extraneous imports; I removed the imports, changed the cross-references to be absolute, and added a `$setup` for doctest.
