### PR TITLE
ensure Control.Lens.Tuple builds with ghc-7.4.2

### DIFF
--- a/src/Control/Lens/Tuple.hs
+++ b/src/Control/Lens/Tuple.hs
@@ -43,7 +43,6 @@ import Control.Lens.Combinators
 import Control.Lens.Indexed
 import Control.Lens.Type
 import Data.Functor.Identity
-import Data.Proxy (Proxy (Proxy))
 import Generics.Deriving (Generic (..), (:*:) (..), K1 (..), M1 (..), U1 (..))
 
 -- $setup
@@ -81,10 +80,10 @@ class Field1 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- @
   _1 :: Lens s t a b
 #ifndef HLINT
-  default _1 :: (Generic s, Generic t, GAt N0 (Rep s) (Rep t) a b)
+  default _1 :: (Generic s, Generic t, GIxed N0 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _1 #-}
-  _1 f = fmap to . gat proxyN0 f . from
+  _1 = ix proxyN0
 #endif
 
 instance Field1 (Identity a) (Identity b) a b where
@@ -146,10 +145,10 @@ class Field2 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- @
   _2 :: Lens s t a b
 #ifndef HLINT
-  default _2 :: (Generic s, Generic t, GAt N1 (Rep s) (Rep t) a b)
+  default _2 :: (Generic s, Generic t, GIxed N1 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _2 #-}
-  _2 f = fmap to . gat proxyN1 f . from
+  _2 = ix proxyN1
 #endif
 
 -- | @
@@ -192,10 +191,10 @@ class Field3 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 3rd field of a tuple.
   _3 :: Lens s t a b
 #ifndef HLINT
-  default _3 :: (Generic s, Generic t, GAt N2 (Rep s) (Rep t) a b)
+  default _3 :: (Generic s, Generic t, GIxed N2 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _3 #-}
-  _3 f = fmap to . gat proxyN2 f . from
+  _3 = ix proxyN2
 #endif
 
 instance Field3 (a,b,c) (a,b,c') c c' where
@@ -231,10 +230,10 @@ class Field4 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 4th field of a tuple.
   _4 :: Lens s t a b
 #ifndef HLINT
-  default _4 :: (Generic s, Generic t, GAt N3 (Rep s) (Rep t) a b)
+  default _4 :: (Generic s, Generic t, GIxed N3 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _4 #-}
-  _4 f = fmap to . gat proxyN3 f . from
+  _4 = ix proxyN3
 #endif
 
 instance Field4 (a,b,c,d) (a,b,c,d') d d' where
@@ -266,10 +265,10 @@ class Field5 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 5th field of a tuple.
   _5 :: Lens s t a b
 #ifndef HLINT
-  default _5 :: (Generic s, Generic t, GAt N4 (Rep s) (Rep t) a b)
+  default _5 :: (Generic s, Generic t, GIxed N4 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _5 #-}
-  _5 f = fmap to . gat proxyN4 f . from
+  _5 = ix proxyN4
 #endif
 
 instance Field5 (a,b,c,d,e) (a,b,c,d,e') e e' where
@@ -297,10 +296,10 @@ class Field6 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 6th field of a tuple.
   _6 :: Lens s t a b
 #ifndef HLINT
-  default _6 :: (Generic s, Generic t, GAt N5 (Rep s) (Rep t) a b)
+  default _6 :: (Generic s, Generic t, GIxed N5 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _6 #-}
-  _6 f = fmap to . gat proxyN5 f . from
+  _6 = ix proxyN5
 #endif
 
 instance Field6 (a,b,c,d,e,f) (a,b,c,d,e,f') f f' where
@@ -324,10 +323,10 @@ class Field7 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 7th field of a tuple.
   _7 :: Lens s t a b
 #ifndef HLINT
-  default _7 :: (Generic s, Generic t, GAt N6 (Rep s) (Rep t) a b)
+  default _7 :: (Generic s, Generic t, GIxed N6 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _7 #-}
-  _7 f = fmap to . gat proxyN6 f . from
+  _7 = ix proxyN6
 #endif
 
 instance Field7 (a,b,c,d,e,f,g) (a,b,c,d,e,f,g') g g' where
@@ -347,10 +346,10 @@ class Field8 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 8th field of a tuple.
   _8 :: Lens s t a b
 #ifndef HLINT
-  default _8 :: (Generic s, Generic t, GAt N7 (Rep s) (Rep t) a b)
+  default _8 :: (Generic s, Generic t, GIxed N7 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _8 #-}
-  _8 f = fmap to . gat proxyN7 f . from
+  _8 = ix proxyN7
 #endif
 
 instance Field8 (a,b,c,d,e,f,g,h) (a,b,c,d,e,f,g,h') h h' where
@@ -366,15 +365,19 @@ class Field9 s t a b | s -> a, t -> b, s b -> t, t a -> s where
   -- | Access the 9th field of a tuple.
   _9 :: Lens s t a b
 #ifndef HLINT
-  default _9 :: (Generic s, Generic t, GAt N8 (Rep s) (Rep t) a b)
+  default _9 :: (Generic s, Generic t, GIxed N8 (Rep s) (Rep t) a b)
              => Lens s t a b
   {-# INLINE _9 #-}
-  _9 f = fmap to . gat proxyN8 f . from
+  _9 = ix proxyN8
 #endif
 
 instance Field9 (a,b,c,d,e,f,g,h,i) (a,b,c,d,e,f,g,h,i') i i' where
   _9 k ~(a,b,c,d,e,f,g,h,i) = k i <&> \i' -> (a,b,c,d,e,f,g,h,i')
   {-# INLINE _9 #-}
+
+ix :: (Generic s, Generic t, GIxed n (Rep s) (Rep t) a b) => f n -> Lens s t a b
+{-# INLINE ix #-}
+ix n f = fmap to . gix n f . from
 
 #ifndef HLINT
 type family GSize (f :: * -> *) :: Nat
@@ -382,13 +385,55 @@ type family GSize (f :: * -> *) :: Nat
 type instance GSize U1 = Z
 type instance GSize (K1 i c) = S Z
 type instance GSize (M1 i c f) = GSize f
-type instance GSize (a :*: b) = GSize a + GSize b
+type instance GSize (a :*: b) = Add (GSize a) (GSize b)
 
 #ifndef HLINT
-type family (x :: Nat) + (y :: Nat) :: Nat
+class GIxed (n :: Nat) s t a b | n s -> a, n t -> b, n s b -> t, n t a -> s where
+  gix :: f n -> Lens (s x) (t x) a b
 #endif
-type instance Z + y = y
-type instance S x + y = S (x + y)
+
+instance GIxed N0 (K1 i a) (K1 i b) a b where
+  {-# INLINE gix #-}
+  gix _ = \ f -> fmap K1 . f . unK1
+
+instance GIxed n s t a b => GIxed n (M1 i c s) (M1 i c t) a b where
+  {-# INLINE gix #-}
+  gix n = \ f -> fmap M1 . gix n f . unM1
+
+instance GIxed' (GT (GSize s) n) n s s' t t' a b
+      => GIxed n (s :*: s') (t :*: t') a b where
+  {-# INLINE gix #-}
+  gix n = \ f ~s@(a :*: _) -> gix' (proxySizeGT a n) n f s
+
+proxySizeGT :: s x -> p n -> BoolP (GT (GSize s) n)
+{-# INLINE proxySizeGT #-}
+proxySizeGT _ _ = BoolP
+
+#ifndef HLINT
+class GIxed' (p :: Bool) (n :: Nat) s s' t t' a b where
+  gix' :: f p -> g n -> Lens ((s :*: s') x) ((t :*: t') x) a b
+#endif
+
+instance GIxed n s t a b => GIxed' True n s s' t s' a b where
+  {-# INLINE gix' #-}
+  gix' _ n = \ f (s :*: s') -> fmap (:*: s') $ gix n f s
+
+instance GIxed (Subtract (GSize s) n) s' t' a b
+      => GIxed' False n s s' s t' a b where
+  {-# INLINE gix' #-}
+  gix' _ n = \ f (s :*: s') -> fmap (s :*:) $ gix (proxySubtractSize s n) f s'
+
+proxySubtractSize :: s x -> p n -> NatP (Subtract (GSize s) n)
+{-# INLINE proxySubtractSize #-}
+proxySubtractSize _ _ = NatP
+
+data Nat = Z | S Nat
+
+#ifndef HLINT
+type family Add (x :: Nat) (y :: Nat) :: Nat
+#endif
+type instance Add Z y = y
+type instance Add (S x) y = S (Add x y)
 
 #ifndef HLINT
 type family Subtract (x :: Nat) (y :: Nat) :: Nat
@@ -397,51 +442,11 @@ type instance Subtract Z x = x
 type instance Subtract (S x) (S y) = Subtract x y
 
 #ifndef HLINT
-type family (x :: Nat) > (y :: Nat) :: Bool
+type family GT (x :: Nat) (y :: Nat) :: Bool
 #endif
-type instance Z > x = False
-type instance S x > Z = True
-type instance S x > S y = x > y
-
-#ifndef HLINT
-class GAt (n :: Nat) s t a b | n s -> a, n t -> b, n s b -> t, n t a -> s where
-  gat :: f n -> Lens (s x) (t x) a b
-#endif
-
-instance GAt N0 (K1 i a) (K1 i b) a b where
-  {-# INLINE gat #-}
-  gat _ = \ f -> fmap K1 . f . unK1
-
-instance GAt n s t a b => GAt n (M1 i c s) (M1 i c t) a b where
-  {-# INLINE gat #-}
-  gat n = \ f -> fmap M1 . gat n f . unM1
-
-instance GAt' (GSize s > n) n s s' t t' a b => GAt n (s :*: s') (t :*: t') a b where
-  {-# INLINE gat #-}
-  gat n = \ f ~s@(a :*: _) -> gat' (proxySizeGT a n) n f s
-
-proxySizeGT :: s x -> p n -> Proxy (GSize s > n)
-{-# INLINE proxySizeGT #-}
-proxySizeGT _ _ = Proxy
-
-#ifndef HLINT
-class GAt' (p :: Bool) (n :: Nat) s s' t t' a b where
-  gat' :: f p -> g n -> Lens ((s :*: s') x) ((t :*: t') x) a b
-#endif
-
-instance GAt n s t a b => GAt' True n s s' t s' a b where
-  {-# INLINE gat' #-}
-  gat' _ n = \ f (s :*: s') -> fmap (:*: s') $ gat n f s
-
-instance GAt (Subtract (GSize s) n) s' t' a b => GAt' False n s s' s t' a b where
-  {-# INLINE gat' #-}
-  gat' _ n = \ f (s :*: s') -> fmap (s :*:) $ gat (proxySubtractSize s n) f s'
-
-proxySubtractSize :: s x -> p n -> Proxy (Subtract (GSize s) n)
-{-# INLINE proxySubtractSize #-}
-proxySubtractSize _ _ = Proxy
-
-data Nat = Z | S Nat
+type instance GT Z x = False
+type instance GT (S x) Z = True
+type instance GT (S x) (S y) = GT x y
 
 type N0 = Z
 type N1 = S N0
@@ -453,38 +458,46 @@ type N6 = S N5
 type N7 = S N6
 type N8 = S N7
 
-proxyN0 :: Proxy N0
+#ifndef HLINT
+data NatP (n :: Nat) = NatP
+#endif
+
+proxyN0 :: NatP N0
 {-# INLINE proxyN0 #-}
-proxyN0 = Proxy
+proxyN0 = NatP
 
-proxyN1 :: Proxy N1
+proxyN1 :: NatP N1
 {-# INLINE proxyN1 #-}
-proxyN1 = Proxy
+proxyN1 = NatP
 
-proxyN2 :: Proxy N2
+proxyN2 :: NatP N2
 {-# INLINE proxyN2 #-}
-proxyN2 = Proxy
+proxyN2 = NatP
 
-proxyN3 :: Proxy N3
+proxyN3 :: NatP N3
 {-# INLINE proxyN3 #-}
-proxyN3 = Proxy
+proxyN3 = NatP
 
-proxyN4 :: Proxy N4
+proxyN4 :: NatP N4
 {-# INLINE proxyN4 #-}
-proxyN4 = Proxy
+proxyN4 = NatP
 
-proxyN5 :: Proxy N5
+proxyN5 :: NatP N5
 {-# INLINE proxyN5 #-}
-proxyN5 = Proxy
+proxyN5 = NatP
 
-proxyN6 :: Proxy N6
+proxyN6 :: NatP N6
 {-# INLINE proxyN6 #-}
-proxyN6 = Proxy
+proxyN6 = NatP
 
-proxyN7 :: Proxy N7
+proxyN7 :: NatP N7
 {-# INLINE proxyN7 #-}
-proxyN7 = Proxy
+proxyN7 = NatP
 
-proxyN8 :: Proxy N8
+proxyN8 :: NatP N8
 {-# INLINE proxyN8 #-}
-proxyN8 = Proxy
+proxyN8 = NatP
+
+#ifndef HLINT
+data BoolP (b :: Bool) = BoolP
+#endif


### PR DESCRIPTION
It looks like `tagged` does not enable `PolyKinds` for ghc-7.4.  It may be worth just removing use of `DataKinds` entirely for ghc-7.4.2.
