### PR TITLE
Reworked `.travis.yml` for GHC 7.6 builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ env:
   #   GHCVER=7.4.2
   #   MODE="-fsafe"
 
+# Ingore 7.4.2 failures for now because of the doctest GHC panic.
+matrix:
+  allow_failures:
+    - env: GHCVER=7.4.2
+
 before_install:
   # If $GHCVER is the one travis has, don't bother reinstalling it.
   # We can also have faster builds by installing some libraries with


### PR DESCRIPTION
I used [hvr's GHC versions PPA](http://permalink.gmane.org/gmane.comp.lang.haskell.libraries/20634). This is nice because a lot of build failures lately have been 7.4-specific. It's a little less configurable than the old one, but it wouldn't be hard to reimplement the benchmarking stuff if someone really wanted to keep it -- on the other hand, it seemed silly for only certain configurations to have `--show-details=always`.

(This branch does build on 7.6.3 -- the only test failure for 7.4.2 is a [weird GHC panic](https://travis-ci.org/ekmett/lens/jobs/12863678#L1552) during `doctests`.)
