### PR TITLE
lens.cabal: add missing Control.Lens.Properties to tarball

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -341,6 +341,8 @@ test-suite templates
 test-suite properties
   type: exitcode-stdio-1.0
   main-is: properties.hs
+  other-modules:
+    Control.Lens.Properties
   ghc-options: -w -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:
     tests


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
