### PR TITLE
fix typo in comment

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -71,7 +71,7 @@ description:
   > bar :: Functor f => (Int -> f Int) -> Foo a -> f (Foo a)
   > bar f (Foo a b c) = fmap (\a' -> Foo a' b c) (f a)
   .
-  > -- baz :: Lens (Foo a) (Foo b) a b
+  > -- quux :: Lens (Foo a) (Foo b) a b
   > quux :: Functor f => (a -> f b) -> Foo a -> f (Foo b)
   > quux f (Foo a b c) = fmap (Foo a b) (f c)
   .


### PR DESCRIPTION
spotted by Sgeo: Typo in lens docs
[11:18am] Sgeo:  -- baz :: Lens (Foo a) (Foo b) a b
[11:18am] Sgeo:  quux :: Functor f => (a -> f b) -> Foo a -> f (Foo b)
[11:18am] Sgeo: http://ekmett.github.io/lens/frames.html

in #haskell
