### PR TITLE
Fix compilation on GHC 7.8.1 RC2

### DIFF
--- a/src/Control/Lens/Internal/Exception.hs
+++ b/src/Control/Lens/Internal/Exception.hs
@@ -38,10 +38,12 @@ import Control.Lens.Internal.Reflection
 import Control.Monad.Catch as Catch
 import Data.Monoid
 import Data.Proxy
-import Data.Typeable
 
 #if defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 707
+import Data.Typeable hiding (Typeable1)
 type Typeable1 = Typeable
+#else
+import Data.Typeable
 #endif
 
 ------------------------------------------------------------------------------


### PR DESCRIPTION
Before this patch, GHC 7.8.0.20140226 would fail with:

```
src/Control/Lens/Internal/Exception.hs:192:61:
Ambiguous occurrence ‘Typeable1’
It could refer to either ‘Control.Lens.Internal.Exception.Typeable1’,
                         defined at src/Control/Lens/Internal/Exception.hs:44:1
                      or ‘Data.Typeable.Typeable1’,
                         imported from ‘Data.Typeable’ at src/Control/Lens/Internal/Exception.hs:41:1-
```
