### PR TITLE
support GHCJS, which does not have a GHC.Event IO manager

### DIFF
--- a/src/Control/Lens/Empty.hs
+++ b/src/Control/Lens/Empty.hs
@@ -38,7 +38,7 @@ import Data.Vector as Vector
 import Data.Vector.Unboxed as Unboxed
 import Data.Vector.Storable as Storable
 
-#ifndef mingw32_HOST_OS
+#if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
 import GHC.Event
 #endif
 
@@ -59,7 +59,7 @@ instance AsEmpty Ordering
 instance AsEmpty ()
 instance AsEmpty Any
 instance AsEmpty All
-#ifndef mingw32_HOST_OS
+#if !defined(mingw32_HOST_OS) && !defined(ghcjs_HOST_OS)
 instance AsEmpty Event
 #endif
 instance (Eq a, Num a) => AsEmpty (Product a)


### PR DESCRIPTION
GHCJS does not have `GHC.Event.Event` when targeting JavaScript (It might have it when compiling native code (which it does for Template Haskell support), depending on the operating system). This small patch makes it work, `ghcjs_HOST_OS` is defined when the target is JS.
