### PR TITLE
Add GHCVER=7.8.1 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: haskell
 env:
   - GHCVER=7.4.2
   - GHCVER=7.6.3
+  - GHCVER=7.8.1
   - GHCVER=head
   # - >
   #   GHCVER=7.4.2


### PR DESCRIPTION
this currently pulls in the soon to be announced 7.8.1-RC2
