### PR TITLE
Follow TH changes in GHC 7.9. Fixes #410.

### DIFF
--- a/src/Control/Lens/Internal/TupleIxedTH.hs
+++ b/src/Control/Lens/Internal/TupleIxedTH.hs
@@ -63,7 +63,11 @@ tupleIxed :: Int -> DecQ
 tupleIxed n = instanceD (cxt eqs) (conT ixedN `appT` fullTupleT n) [funD ixN clauses]
   where
   ty0:tyN = take n tupleVarTypes
+#if __GLASGOW_HASKELL__ >= 709
+  eqs     = [AppT . AppT EqualityT <$> ty0 <*> ty | ty <- tyN]
+#else
   eqs     = [ty0 `equalP` ty | ty <- tyN]
+#endif
   clauses = map nClause [0..n-1] ++ [otherClause]
 
   -- ix i f (a,..) = fmap (\x->(a,..x..)) (f z)

--- a/src/Language/Haskell/TH/Lens.hs
+++ b/src/Language/Haskell/TH/Lens.hs
@@ -249,9 +249,11 @@ module Language.Haskell.TH.Lens
   , _NumTyLit
   , _StrTyLit
 #endif
+#if __GLASGOW_HASKELL__ < 709
   -- ** Pred Prisms
   , _ClassP
   , _EqualP
+#endif
 #if MIN_VERSION_template_haskell(2,9,0)
   -- ** Role Prisms
   , _NominalR
@@ -322,9 +324,11 @@ instance HasTypeVars Type where
        where s' = s `Set.union` setOf typeVars bs
   typeVarsEx _ _ t                   = pure t
 
+#if __GLASGOW_HASKELL__ < 709
 instance HasTypeVars Pred where
   typeVarsEx s f (ClassP n ts) = ClassP n <$> typeVarsEx s f ts
   typeVarsEx s f (EqualP l r)  = EqualP <$> typeVarsEx s f l <*> typeVarsEx s f r
+#endif
 
 instance HasTypeVars Con where
   typeVarsEx s f (NormalC n ts) = NormalC n <$> traverseOf (traverse . _2) (typeVarsEx s f) ts
@@ -361,9 +365,11 @@ instance SubstType Type where
 instance SubstType t => SubstType [t] where
   substType = map . substType
 
+#if __GLASGOW_HASKELL__ < 709
 instance SubstType Pred where
   substType m (ClassP n ts) = ClassP n (substType m ts)
   substType m (EqualP l r)  = substType m (EqualP l r)
+#endif
 
 -- | Provides a 'Traversal' of the types of each field of a constructor.
 conFields :: Traversal' Con StrictType
@@ -1753,6 +1759,7 @@ _StrTyLit
       reviewer x = Left x
 #endif
 
+#if __GLASGOW_HASKELL__ < 709
 _ClassP :: Prism' Pred (Name, [Type])
 _ClassP
   = prism remitter reviewer
@@ -1768,6 +1775,7 @@ _EqualP
       remitter (x, y) = EqualP x y
       reviewer (EqualP x y) = Right (x, y)
       reviewer x = Left x
+#endif
 
 #if MIN_VERSION_template_haskell(2,9,0)
 _NominalR :: Prism' Role ()


### PR DESCRIPTION
Pred data type is now an alias to Type.

Note that you'll at least need https://github.com/bos/aeson/commit/19682fe0a5136eb84e674bda1ab76880bb3281e1 which doesn't seem to be on Hackage yet.

With `cabal configure --enable-tests -f-test-doctests && cabal test` I get 4 out of 4 test-suites passing on GHC 7.6.3 and GHC 7.9.20140308.
