### PR TITLE
Added an `instance IsText String`.

### DIFF
--- a/src/Data/Text/Lens.hs
+++ b/src/Data/Text/Lens.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeSynonymInstances #-}
 #ifdef TRUSTWORTHY
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -53,6 +55,14 @@ class IsText t where
   text = unpacked . traversed
   {-# INLINE text #-}
 
+instance IsText String where
+  packed = id
+  {-# INLINE packed #-}
+  text = indexing traverse
+  {-# INLINE text #-}
+  builder = Lazy.packed . builder
+  {-# INLINE builder #-}
+
 -- | This isomorphism can be used to 'unpack' (or 'pack') both strict or lazy 'Text'.
 --
 -- @
@@ -97,4 +107,3 @@ instance IsText Lazy.Text where
   {-# INLINE builder #-}
   text = Lazy.text
   {-# INLINE text #-}
-


### PR DESCRIPTION
I noticed this was missing, so I added it. I can't think of a reason not to have it.
