### PR TITLE
Fix the type error in C.L.Properties.

### DIFF
--- a/lens-properties/src/Control/Lens/Properties.hs
+++ b/lens-properties/src/Control/Lens/Properties.hs
@@ -44,8 +44,8 @@ isTraversal l = isSetter l .&. traverse_pureMaybe l .&. traverse_pureList l
                   .&. do as <- arbitrary
                          bs <- arbitrary
                          t <- arbitrary
-                         property $ traverse_compose l (\x -> as++[x]++bs)
-                                                       (\x -> if t then Just x else Nothing)
+                         return $ traverse_compose l (\x -> as++[x]++bs)
+                                                     (\x -> if t then Just x else Nothing)
 
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
This one:

```
Preprocessing test suite 'properties' for lens-4.2...
[1 of 2] Compiling Control.Lens.Properties ( lens-properties/src/Control/Lens/Properties.hs, dist/build/properties/properties-tmp/Control/Lens/Properties.o )

lens-properties/src/Control/Lens/Properties.hs:47:26:
    Couldn't match expected type `Gen b0' with actual type `Property'
    In a stmt of a 'do' block:
      property
      $ traverse_compose
          l (\ x -> as ++ [x] ++ bs) (\ x -> if t then Just x else Nothing)
    In the second argument of `(.&.)', namely
      `do { as <- arbitrary;
            bs <- arbitrary;
            t <- arbitrary;
            property
            $ traverse_compose
                l
                (\ x -> as ++ [x] ++ bs)
                (\ x -> if t then Just x else Nothing) }'
    In the second argument of `(.&.)', namely
      `traverse_pureList l
       .&.
         do { as <- arbitrary;
              bs <- arbitrary;
              t <- arbitrary;
              property
              $ traverse_compose
                  l
                  (\ x -> as ++ [x] ++ bs)
                   (\ x -> if t then Just x else Nothing) }'
```
