### PR TITLE
Fix the no instance error in C.L.I.Reflection.

### DIFF
--- a/src/Control/Lens/Internal/Reflection.hs
+++ b/src/Control/Lens/Internal/Reflection.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -fno-cse #-}
 {-# OPTIONS_GHC -fno-full-laziness #-}
 {-# OPTIONS_GHC -fno-float-in #-}
@@ -163,6 +164,7 @@ argument _ = Proxy
 instance (B b0, B b1, B b2, B b3, B b4, B b5, B b6, B b7, w0 ~ W b0 b1 b2 b3, w1 ~ W b4 b5 b6 b7)
     => Reifies (Stable w0 w1 a) a where
   reflect = r where
+      r :: proxy (Stable w0 w1 a) -> a
       r = unsafePerformIO $ const <$> deRefStablePtr p <* freeStablePtr p
       s = argument r
       p = intPtrToStablePtr $


### PR DESCRIPTION
This one:

``` bash
~/C/S/lens> cabal repl
Preprocessing library lens-4.2...
GHCi, version 7.8.2: http://www.haskell.org/ghc/  :? for help
Loading package ghc-prim ... linking ... done.
Loading package integer-gmp ... linking ... done.
Loading package base ... linking ... done.
Loading package array-0.5.0.0 ... linking ... done.
Loading package deepseq-1.3.0.2 ... linking ... done.
Loading package bytestring-0.10.4.0 ... linking ... done.
Loading package zlib-0.5.4.1 ... linking ... done.
Loading package text-1.1.0.1 ... linking ... done.
Loading package hashable-1.2.1.0 ... linking ... done.
Loading package containers-0.5.5.1 ... linking ... done.
Loading package nats-0.1.3 ... linking ... done.
Loading package unordered-containers-0.2.4.0 ... linking ... done.
Loading package semigroups-0.13.0.1 ... linking ... done.
Loading package void-0.6.1 ... linking ... done.
Loading package utf8-string-0.3.7 ... linking ... done.
Loading package split-0.2.2 ... linking ... done.
Loading package tagged-0.7.2 ... linking ... done.
Loading package pretty-1.1.1.1 ... linking ... done.
Loading package template-haskell ... linking ... done.
Loading package reflection-1.4 ... linking ... done.
Loading package parallel-3.2.0.4 ... linking ... done.
Loading package transformers-0.3.0.0 ... linking ... done.
Loading package transformers-compat-0.1.1.1 ... linking ... done.
Loading package contravariant-0.4.4 ... linking ... done.
Loading package distributive-0.4.3.1 ... linking ... done.
Loading package mtl-2.1.3.1 ... linking ... done.
Loading package comonad-4.0.1 ... linking ... done.
Loading package semigroupoids-4.0.1 ... linking ... done.
Loading package bifunctors-4.1.1 ... linking ... done.
Loading package prelude-extras-0.4 ... linking ... done.
Loading package profunctors-4.0.3 ... linking ... done.
Loading package free-4.7.1 ... linking ... done.
Loading package filepath-1.3.0.2 ... linking ... done.
Loading package exceptions-0.5 ... linking ... done.
Loading package scientific-0.2.0.2 ... linking ... done.
Loading package attoparsec-0.11.2.1 ... linking ... done.
Loading package dlist-0.7.0.1 ... linking ... done.
Loading package old-locale-1.0.0.6 ... linking ... done.
Loading package syb-0.4.1 ... linking ... done.
Loading package time-1.4.2 ... linking ... done.
Loading package primitive-0.5.2.1 ... linking ... done.
Loading package vector-0.10.9.1 ... linking ... done.
Loading package aeson-0.7.0.3 ... linking ... done.
Loading arbitrary code ... running ... done.
[ 1 of 85] Compiling Data.Map.Lens    ( src/Data/Map/Lens.hs, interpreted )
[ 2 of 85] Compiling Control.Lens.Internal.TH ( src/Control/Lens/Internal/TH.hs, interpreted )
[ 3 of 85] Compiling Control.Lens.Internal.TupleIxedTH ( src/Control/Lens/Internal/TupleIxedTH.hs, interpreted )
[ 4 of 85] Compiling Control.Lens.Internal.Setter ( src/Control/Lens/Internal/Setter.hs, interpreted )
[ 5 of 85] Compiling Control.Lens.Internal.Review ( src/Control/Lens/Internal/Review.hs, interpreted )
[ 6 of 85] Compiling Control.Lens.Internal.Reflection ( src/Control/Lens/Internal/Reflection.hs, interpreted )

src/Control/Lens/Internal/Reflection.hs:166:7:
    No instance for (B b60) arising from the ambiguity check for ‘p’
    The type variable ‘b60’ is ambiguous
    When checking that ‘p’
      has the inferred type ‘forall r. StablePtr r’
    Probable cause: the inferred type is ambiguous
    In an equation for ‘reflect’:
        reflect
          = r
          where
              r = unsafePerformIO $ const <$> deRefStablePtr p <* freeStablePtr p
              s = argument r
              p = intPtrToStablePtr
                  $ reflectByte (byte0 s) .|. (reflectByte (byte1 s) `shiftL` 8)
                    .|. (reflectByte (byte2 s) `shiftL` 16)
                    .|. (reflectByte (byte3 s) `shiftL` 24)
                    .|. (reflectByte (byte4 s) `shiftL` 32)
                    .|. (reflectByte (byte5 s) `shiftL` 40)
                    .|. (reflectByte (byte6 s) `shiftL` 48)
                    .|. (reflectByte (byte7 s) `shiftL` 56)
    In the instance declaration for ‘Reifies (Stable w0 w1 a) a’
Failed, modules loaded: Control.Lens.Internal.Review, Control.Lens.Internal.Setter, Control.Lens.Internal.TH, Data.Map.Lens, Control.Lens.Internal.TupleIxedTH.
*Control.Lens.Internal.Review>
```

Not sure why it's only shows up there?
