### PR TITLE
Fix ambiguous uses in doctests.

### DIFF
--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -111,7 +111,7 @@ infixr 9 <.>, <., .>
 --
 -- Mnemonically, the @<@ points to the indexing we want to preserve.
 --
--- >>> let nestedMap = (fmap fromList . fromList) [(1, [(10, "one,ten"), (20, "one,twenty")]), (2, [(30, "two,thirty"), (40,"two,forty")])]
+-- >>> let nestedMap = (fmap Map.fromList . Map.fromList) [(1, [(10, "one,ten"), (20, "one,twenty")]), (2, [(30, "two,thirty"), (40,"two,forty")])]
 -- >>> nestedMap^..(itraversed<.itraversed).withIndex
 -- [(1,"one,ten"),(1,"one,twenty"),(2,"two,thirty"),(2,"two,forty")]
 (<.) :: Indexable i p => (Indexed i s t -> r) -> ((a -> b) -> s -> t) -> p a b -> r
@@ -127,6 +127,7 @@ infixr 9 <.>, <., .>
 -- @f '.' g@ (and @f '.>' g@) gives you the index of @g@ unless @g@ is index-preserving, like a
 -- 'Prism', 'Iso' or 'Equality', in which case it'll pass through the index of @f@.
 --
+-- >>> let nestedMap = (fmap Map.fromList . Map.fromList) [(1, [(10, "one,ten"), (20, "one,twenty")]), (2, [(30, "two,thirty"), (40,"two,forty")])]
 -- >>> nestedMap^..(itraversed.>itraversed).withIndex
 -- [(10,"one,ten"),(20,"one,twenty"),(30,"two,thirty"),(40,"two,forty")]
 (.>) :: (st -> r) -> (kab -> st) -> kab -> r
@@ -142,6 +143,7 @@ reindexed ij f g = f . Indexed $ indexed g . ij
 --
 -- Mnemonically, the @\<@ and @\>@ points to the fact that we want to preserve the indices.
 --
+-- >>> let nestedMap = (fmap Map.fromList . Map.fromList) [(1, [(10, "one,ten"), (20, "one,twenty")]), (2, [(30, "two,thirty"), (40,"two,forty")])]
 -- >>> nestedMap^..(itraversed<.>itraversed).withIndex
 -- [((1,10),"one,ten"),((1,20),"one,twenty"),((2,30),"two,thirty"),((2,40),"two,forty")]
 (<.>) :: Indexable (i, j) p => (Indexed i s t -> r) -> (Indexed j a b -> s -> t) -> p a b -> r

--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -123,7 +123,7 @@ _Unwrapped' = from _Wrapped'
 
 -- | Work under a newtype wrapper.
 --
--- >>> Const "hello" & _Wrapped %~ length & getConst
+-- >>> Const "hello" & _Wrapped %~ Prelude.length & getConst
 -- 5
 --
 -- @
@@ -662,7 +662,7 @@ ala = au . _Unwrapping
 --
 -- As with '_Wrapping', the user supplied function for the newtype is /ignored/.
 --
--- >>> alaf Sum foldMap length ["hello","world"]
+-- >>> alaf Sum foldMap Prelude.length ["hello","world"]
 -- 10
 alaf :: (Profunctor p, Rewrapping s t) => (Unwrapped s -> s) -> (p r t -> e -> s) -> p r (Unwrapped t) -> e -> Unwrapped s
 alaf = auf . _Unwrapping

--- a/src/Data/Aeson/Lens.hs
+++ b/src/Data/Aeson/Lens.hs
@@ -158,7 +158,7 @@ class AsNumber t => AsPrimitive t where
   -- >>> "{\"a\": \"xyz\", \"b\": true}" ^? key "b" . _String
   -- Nothing
   --
-  -- >>> _Object._Wrapped # [("key",_String # "value")]
+  -- >>> _Object._Wrapped # [("key" :: Text, _String # "value")]
   -- "{\"key\":\"value\"}"
   _String :: Prism' t Text
   _String = _Primitive.prism StringPrim (\v -> case v of StringPrim s -> Right s; _ -> Left v)
@@ -252,7 +252,7 @@ class AsPrimitive t => AsValue t where
   -- >>> "{\"a\": {}, \"b\": null}" ^? key "b" . _Object
   -- Nothing
   --
-  -- >>> _Object._Wrapped # [("key",_String # "value")]
+  -- >>> _Object._Wrapped # [("key" :: Text, _String # "value")]
   -- "{\"key\":\"value\"}"
   _Object :: Prism' t (HashMap Text Value)
   _Object = _Value.prism Object (\v -> case v of Object o -> Right o; _ -> Left v)

--- a/src/Data/Text/Lens.hs
+++ b/src/Data/Text/Lens.hs
@@ -86,7 +86,7 @@ unpacked = from packed
 -- '_Text' = 'from' 'packed'
 -- @
 --
--- >>> _Text # "hello" -- :: Text
+-- >>> _Text # "hello" :: Strict.Text
 -- "hello"
 _Text :: IsText t => Iso' t String
 _Text = from packed


### PR DESCRIPTION
Not sure if these are all the best ways to handle these, but I feel like it's important to have passing doctests.

There's one that still fails on 7.6 (?):

```
### Failure in src/Data/Aeson/Lens.hs:255: expression `_Object._Wrapped # [("key" :: Text, _String # "value")]'
expected: "{\"key\":\"value\"}"
 but got: 
          <interactive>:1004:1:
              No instance for (AsValue t0) arising from a use of `_Object'
              The type variable `t0' is ambiguous
              Possible fix: add a type signature that fixes these type variable(s)
              Note: there are several potential instances:
                instance AsValue String -- Defined at src/Data/Aeson/Lens.hs:276:10
                instance AsValue ByteString
                  -- Defined at src/Data/Aeson/Lens.hs:272:10
                instance AsValue Value -- Defined at src/Data/Aeson/Lens.hs:268:10
              In the first argument of `(.)', namely `_Object'
              In the first argument of `(#)', namely `_Object . _Wrapped'
              In the expression:
                _Object . _Wrapped # [("key" :: Text, _String # "value")]### Failure in src/Data/Aeson/Lens.hs:255: expression `_Object._Wrapped # [("key" :: Text, _String # "value")]'
expected: "{\"key\":\"value\"}"
```
