### PR TITLE
Documentation: 'MonadicFold', (^!!), 'acts'.

### DIFF
--- a/src/Control/Lens/Action.hs
+++ b/src/Control/Lens/Action.hs
@@ -94,6 +94,11 @@ a ^! l = getEffect (l (Effect #. return) a)
 --
 -- >>> ["ab","cd","ef"]^!!folded.acts
 -- ["ace","acf","ade","adf","bce","bcf","bde","bdf"]
+--
+-- >>> [1,2]^!!folded.act (\i -> putStr (show i ++ ": ") >> getLine).each.to succ
+-- 1: aa
+-- 2: bb
+-- "bbcc"
 (^!!) :: Monad m => s -> Acting m [a] s a -> m [a]
 a ^!! l = getEffect (l (Effect #. return . return) a)
 {-# INLINE (^!!) #-}
@@ -133,6 +138,10 @@ act sma pafb = cotabulate $ \ws -> effective $ do
 --
 -- >>> (1,"hello")^!_2.acts.to succ
 -- "ifmmp"
+--
+-- >>> (1,getLine)^!!_2.acts.folded.to succ
+-- aa
+-- "bb"
 acts :: IndexPreservingAction m (m a) a
 acts = act id
 {-# INLINE acts #-}

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -510,6 +510,8 @@ type IndexPreservingAction m s a = forall p f r. (Conjoined p, Effective m r f) 
 
 -- | A 'MonadicFold' is a 'Fold' enriched with access to a 'Monad' for side-effects.
 --
+-- A 'MonadicFold' can use side-effects to produce parts of the structure being folded (e.g. reading them from file).
+--
 -- Every 'Fold' can be used as a 'MonadicFold', that simply ignores the access to the 'Monad'.
 --
 -- You can compose a 'MonadicFold' with another 'MonadicFold' using ('Prelude..') from the @Prelude@.


### PR DESCRIPTION
Added a line to the explanation of 'MonadicFold', and IO-based examples for (^!!) and 'acts'.
