### PR TITLE
Add 'deep' and 'deepOf' functions for traversal

### DIFF
--- a/src/Control/Lens/Plated.hs
+++ b/src/Control/Lens/Plated.hs
@@ -271,10 +271,10 @@ l ... m = l . plate . m
 -- do not recurse through matching descendants.
 --
 -- @
--- 'deep' :: 'Plated' s => 'Fold s a' -> 'Fold s a'
--- 'deep' :: 'Plated' s => 'IndexedFold s a' -> 'IndexedFold s a'
--- 'deep' :: 'Plated' s => 'Traversal s s a b' -> 'Traversal s s a b'
--- 'deep' :: 'Plated' s => 'IndexedTraversal s s a b' -> 'IndexedTraversal s s a b'
+-- 'deep' :: 'Plated' s => 'Fold' s a                 -> 'Fold' s a
+-- 'deep' :: 'Plated' s => 'IndexedFold' s a          -> 'IndexedFold' s a
+-- 'deep' :: 'Plated' s => 'Traversal' s s a b        -> 'Traversal' s s a b
+-- 'deep' :: 'Plated' s => 'IndexedTraversal' s s a b -> 'IndexedTraversal' s s a b
 -- @
 deep :: (Conjoined p, Applicative f, Plated s) => Traversing p f s s a b -> Over p f s s a b
 deep = deepOf plate

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -1204,10 +1204,10 @@ infixl 5 `failing`
 -- | Try the second traversal. If it returns no entries, try again with for all entries from the second traversal, recursively.
 --
 -- @
--- 'deepOf' :: 'Fold' s s -> 'Fold' s a -> 'Fold' s a
--- 'deepOf' :: 'Traversal'' s s -> 'Traversal'' s a -> 'Traversal'' s a
--- 'deepOf' :: 'Traversal' s t s t -> 'Traversal' s t a b -> 'Traversal' s t a b
--- 'deepOf' :: 'Fold' s s -> 'IndexedFold' i s a -> 'IndexedFold' i s a
+-- 'deepOf' :: 'Fold' s s          -> 'Fold' s a                   -> 'Fold' s a
+-- 'deepOf' :: 'Traversal'' s s    -> 'Traversal'' s a             -> 'Traversal'' s a
+-- 'deepOf' :: 'Traversal' s t s t -> 'Traversal' s t a b          -> 'Traversal' s t a b
+-- 'deepOf' :: 'Fold' s s          -> 'IndexedFold' i s a          -> 'IndexedFold' i s a
 -- 'deepOf' :: 'Traversal' s t s t -> 'IndexedTraversal' i s t a b -> 'IndexedTraversal' i s t a b
 -- @
 deepOf :: (Conjoined p, Applicative f) => LensLike f s t s t -> Traversing p f s t a b -> Over p f s t a b


### PR DESCRIPTION
I had to implement them in different modules to avoid a circular dependency. Also, I'm not sure if `deep` or `deepOf` breaks any laws? 
