### PR TITLE
Resolution for #439: make Aeson Prisms law-abiding

### DIFF
--- a/AUTHORS.markdown
+++ b/AUTHORS.markdown
@@ -36,6 +36,7 @@ Many people have contributed patches, documentation, wiki pages, bug reports, te
 * [Michael Thompson](mailto:what_is_it_to_do_anything@yahoo.com) [@michaelt](https://github.com/michaelt)
 * [John Wiegley](mailto:johnw@newartisans.com) [@jwiegley](https://github.com/jwiegley)
 * [Jonathan Fischoff](mailto:jfischoff@yahoo.com) [@jfischoff](https://github.com/jfischoff)
+* [Bradford Larsen](mailto:brad.larsen@gmail.com) [@bradlarsen](https://github.com/bradlarsen)
 
 You can watch them carry on the quest for bragging rights in the [contributors graph](https://github.com/ekmett/lens/graphs/contributors).
 

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,7 @@
 ---
 * Added `_Text` isomorphisms to make the proper use with `(#)` more obvious and fit newer convention.
 * Added `Wrapped` instances for `Vector` types
+* Resolved issue #439.  The various `Prism`s for string-like types in `Data.Aeson.Lens` are now law-abiding `Prism`s "up to quotient."
 
 4.1.2
 -----

--- a/lens.cabal
+++ b/lens.cabal
@@ -183,6 +183,7 @@ flag j
 library
   build-depends:
     aeson                     >= 0.7      && < 0.8,
+    attoparsec                >= 0.10     && < 0.12,
     array                     >= 0.3.0.2  && < 0.6,
     base                      >= 4.3      && < 5,
     bifunctors                >= 4        && < 5,


### PR DESCRIPTION
Here's a proposed fix for #439.

I added some doctest tests for the instances that were buggy in #439; these tests are in a named Haddock block at the end of `Data.Aeson.Lens`.
