### PR TITLE
Protect against the huge-exponent DoS attack

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -202,7 +202,7 @@ library
     primitive                 >= 0.4.0.1  && < 0.6,
     profunctors               >= 4        && < 5,
     reflection                >= 1.1.6    && < 2,
-    scientific                >= 0.2      && < 0.4,
+    scientific                >= 0.3.2    && < 0.4,
     semigroupoids             >= 4        && < 5,
     semigroups                >= 0.8.4    && < 1,
     split                     >= 0.2      && < 0.3,

--- a/src/Data/Aeson/Lens.hs
+++ b/src/Data/Aeson/Lens.hs
@@ -38,7 +38,8 @@ import Control.Lens
 import Data.Aeson
 import Data.Aeson.Parser (value)
 import Data.Attoparsec.ByteString.Lazy (maybeResult, parse)
-import Data.Scientific
+import Data.Scientific (Scientific)
+import qualified Data.Scientific as Scientific
 import qualified Data.ByteString as Strict
 import Data.ByteString.Lazy.Char8 as Lazy hiding (putStrLn)
 import Data.Data
@@ -76,7 +77,7 @@ class AsNumber t where
   -- >>> "[10.2]" ^? nth 0 . _Double
   -- Just 10.2
   _Double :: Prism' t Double
-  _Double = _Number.iso realToFrac realToFrac
+  _Double = _Number.iso Scientific.toRealFloat realToFrac
   {-# INLINE _Double #-}
 
   -- |


### PR DESCRIPTION
The `Data.Aeson.Lens._Double prism` converted a `Scientific` to a `Double` using `realToFrac` (`fromRational . toRational`). This however is vulnerable to a DoS attack where an attacker can send a scientific number with a huge exponent like 1e1000000000. `toRational` will convert this to the Rational: `(1 * 10^1000000000) % 1`. The Integer 10^1000000000 will then take up all space and crash your program. The `Scientific.toRealFloat` function guards against huge exponents.
