### PR TITLE
minor documentation tweak in Control.Lens.Fold

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -702,9 +702,9 @@ noneOf l f = not . anyOf l f
 -- @
 -- 'Data.Foldable.product' ≡ 'productOf' 'folded'
 -- @
-
+--
 -- This operation may be more strict than you would expect. If you
--- want a lazier version use @'ala' 'Sum' '.' 'foldMapOf'@
+-- want a lazier version use @'ala' 'Product' '.' 'foldMapOf'@
 --
 -- @
 -- 'productOf' :: 'Num' a => 'Getter' s a     -> s -> a


### PR DESCRIPTION
Fix `Sum` to `Product`, and insert missing comment line which was causing the second half of the comment to be cut off.
