### PR TITLE
Add Foldable, Traversable instances for ((,) a)

### DIFF
--- a/src/Control/Lens/Internal/Indexed.hs
+++ b/src/Control/Lens/Internal/Indexed.hs
@@ -53,6 +53,17 @@ import Data.Profunctor.Unsafe
 import Unsafe.Coerce
 #endif
 
+#if __GLASGOW_HASKELL__ < 708
+import qualified Data.Foldable as F
+ 
+instance Traversable ((,) a) where
+    traverse f (x, y) = (,) x <$> f y
+ 
+instance F.Foldable ((,) a) where
+    foldMap f (_, y) = f y
+    foldr f z (_, y) = f y z
+#endif
+
 ------------------------------------------------------------------------------
 -- Conjoined
 ------------------------------------------------------------------------------


### PR DESCRIPTION
base < 4.7.0.0 (GHC < 7.8) does not include `Foldable` and `Traversable` instances for `((,) a)`. This commits adds those instances if the version of GHC being used is less than 7.8.

This allows compiling lens 4.3 with GHC 7.6.
