### PR TITLE
Bump text upper version bounds

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -204,7 +204,7 @@ library
     split                     >= 0.2      && < 0.3,
     tagged                    >= 0.4.4    && < 1,
     template-haskell          >= 2.4      && < 2.11,
-    text                      >= 0.11     && < 1.2,
+    text                      >= 0.11     && < 1.3,
     transformers              >= 0.2      && < 0.5,
     transformers-compat       >= 0.3      && < 1,
     unordered-containers      >= 0.2      && < 0.3,


### PR DESCRIPTION
Allow `lens` to use `text-1.2.0.0`.
