### PR TITLE
Avoid clash with future `Data.Foldable.null`

### DIFF
--- a/src/Control/Lens/Internal/Deque.hs
+++ b/src/Control/Lens/Internal/Deque.hs
@@ -21,7 +21,7 @@ module Control.Lens.Internal.Deque
   ( Deque(..)
   , size
   , fromList
-  , null
+  , Control.Lens.Internal.Deque.null
   , singleton
   ) where
 
@@ -41,7 +41,6 @@ import Data.Functor.Reverse
 import Data.Traversable as Traversable
 import Data.Semigroup
 import Data.Profunctor.Unsafe
-import Prelude hiding (null)
 
 -- | A Banker's deque based on Chris Okasaki's \"Purely Functional Data Structures\"
 data Deque a = BD !Int [a] !Int [a]


### PR DESCRIPTION
Albeit this approach is a bit ugly (isn't there a way to alias the
current module qualifier to something shorter?), this reduces the
line-count to a minimum and avoids the use of `CPP` :-)
