### PR TITLE
Rewrite the “usage” example for the greater good

### DIFF
--- a/src/Control/Lens.hs
+++ b/src/Control/Lens.hs
@@ -14,20 +14,24 @@
 --
 -- @
 -- import Control.Lens
--- data Foo a = Foo { _fooArgs :: ['String'], _fooValue :: a }
--- 'makeLenses' ''Foo
+-- 
+-- data FooBar a
+--   = Foo { _x :: ['Int'], _y :: a }
+--   | Bar { _x :: ['Int'] }
+-- 'makeLenses' ''FooBar
 -- @
 --
 -- This defines the following lenses:
 --
 -- @
--- fooArgs :: 'Lens'' (Foo a) ['String']
--- fooValue :: 'Lens' (Foo a) (Foo b) a b
+-- x :: 'Lens'' (FooBar a) ['Int']
+-- y :: 'Traversal' (FooBar a) (FooBar b) a b
 -- @
 --
--- You can then access the value with ('^.') and set the value of the field
--- with ('.~') and can use almost any other combinator that is re-exported
--- here on those fields.
+-- You can then access the value of @_x@ with ('^.'), the value of @_y@ –
+-- with ('^?') or ('^?!') (since it can fail), set the values with ('.~'),
+-- modify them with ('%~'), and use almost any other combinator that is
+-- re-exported here on those fields.
 --
 -- The combinators here have unusually specific type signatures, so for
 -- particularly tricky ones, the simpler type signatures you might want to


### PR DESCRIPTION
Since this came up on #haskell today:

```
(03:35:07 PM) danilo2: Hello! I just dioscovered that lenses are PURE
EVIL. I spent hours to track a bug caused by how lenses are stupid. I
would love to ask you If uis there **any way** to fix the following
behaviour. I've got a simple code: http://lpaste.net/112230 After
refactoring I changed some names and everythiong compiled and worked even
if the name was not found in the datatype. Instead of reporting error,
lenses used the monoid to insert empty v

(03:35:31 PM) danilo2: Is there any way, to make lenses throwing error
when field name is not matched instead of just hiding this from me and
using monoid there?
```
