### PR TITLE
Monad, MonadReader and MonadPlus instances for ReifiedMonadicFold

### DIFF
--- a/src/Control/Lens/Reified.hs
+++ b/src/Control/Lens/Reified.hs
@@ -544,6 +544,12 @@ instance Monad (ReifiedMonadicFold m s) where
   ma >>= f = ((ma >>^ f) &&& returnA) >>> app 
   {-# INLINE (>>=) #-}
 
+instance MonadReader s (ReifiedMonadicFold m s) where
+  ask = returnA
+  {-# INLINE ask #-}
+  local f ma = f ^>> ma 
+  {-# INLINE local #-}
+
 instance MonadPlus (ReifiedMonadicFold m s) where
   mzero = empty
   {-# INLINE mzero #-}


### PR DESCRIPTION
Example with the Monad instance:

```
{-# LANGUAGE FlexibleContexts #-}

import Control.Lens
import Control.Monad

widgets :: [(Char,Int,Int)]
widgets = [ ('a',10,100), ('a',77,80), ('b',12,50), ('b',70,120) ]

bsInsideAs :: MonadicFold IO [(Char,Int,Int)] (Char,Int,Int)
bsInsideAs = runMonadicFold $ do
    (c,x1,x2) <- MonadicFold $ folded . act (\x -> print x >> return x)
    guard $ c == 'a'
    r@(c',x1',x2') <- MonadicFold $ folded
    guard $ c' == 'b'
    guard $ x1' >= x1 && x2' <= x2
    return r
```

Executing the fold:

```
*Main> widgets ^!! bsInsideAs
('a',10,100)
('a',77,80)
('b',12,50)
('b',70,120)
[('b',12,50)]
```
