### PR TITLE
Changed some examples to use the Reader monad.

### DIFF
--- a/src/Control/Lens/Action.hs
+++ b/src/Control/Lens/Action.hs
@@ -61,6 +61,7 @@ import Data.Profunctor.Unsafe
 -- $setup
 -- >>> :set -XNoOverloadedStrings
 -- >>> import Control.Lens
+-- >>> import Control.Monad.Reader
 
 infixr 8 ^!, ^!!, ^@!, ^@!!, ^!?, ^@!?
 

--- a/tests/doctests.hsc
+++ b/tests/doctests.hsc
@@ -18,7 +18,6 @@ module Main where
 import Build_doctests (deps)
 import Control.Applicative
 import Control.Monad
-import Control.Monad.Reader
 import Data.List
 import System.Directory
 import System.FilePath


### PR DESCRIPTION
Some examples in Control.Lens.Action were using the "getLine" function and that caused problems with doctest.

They have been modified to use the Reader monad instead.
