### PR TITLE
[WIP] Fix warning from makeLenses when some constructors have no fields

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -332,15 +332,11 @@ test-suite templates
   type: exitcode-stdio-1.0
   main-is: templates.hs
   build-depends: base, lens
-  ghc-options: -Wall -threaded
+  ghc-options: -Wall -Werror -threaded
   hs-source-dirs: tests
 
   if flag(dump-splices)
     ghc-options: -ddump-splices
-
-  if impl(ghc<7.6.1)
-    ghc-options: -Werror
-
 
 -- Verify the properties of lenses with QuickCheck
 test-suite properties

--- a/src/Control/Lens/Internal/FieldTH.hs
+++ b/src/Control/Lens/Internal/FieldTH.hs
@@ -369,11 +369,6 @@ makeFieldClauses opticType cons =
 -- given a constructor name and the number of fields on that
 -- constructor.
 makePureClause :: Name -> Int -> ClauseQ
-
-makePureClause conName 0 =
-  -- clause: _ _ = pure Con
-  clause [wildP, wildP] (normalB (appE (varE pureValName) (conE conName))) []
-
 makePureClause conName fieldCount =
   do xs <- replicateM fieldCount (newName "x")
      -- clause: _ (Con x1..xn) = pure (Con x1..xn)

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -205,5 +205,8 @@ useFold2  = C2 length     ^? r2nub . to ($ [False,True,True])
 useLength :: Int
 useLength = C1 length nub ^. r2length . to ($ [False,True,True])
 
+data PureNoFields = PureNoFieldsA | PureNoFieldsB { _pureNoFields :: Int }
+makeLenses ''PureNoFields
+
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
The test is:

```
data A = A | B { _a :: Int }
makeLenses ''A
```

Which gives a "Warning: Pattern match(es) are overlapped"

It's currently generating a traversal like:

```
a _ _ = pure A
a b c = fmap B (b c)
```

By removing the fieldCount == 0 specialisation of makePureClause, I get:

```
a _ A = pure A
a b c = fmap B (b c)
```

Which gets rid of the warning for this test.

I haven't dug into it too deeply, and I've only tested on GHC 7.6.3, but I can't see an obvious problem with doing it this way.

I also removed the ghc<7.6.1 predicate on -Werror for templates.hs, so it would fail in testing.  I don't get any other warnings in the file, but it must have been there for a reason.
