### PR TITLE
fix docs code block for `makeClassyPrisms`

### DIFF
--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -90,7 +90,8 @@ makePrisms = makePrisms' True
 --
 -- instance AsFooBarBaz (FooBarBaz a) a
 -- @
--- | Generate an "As" class of prisms. Names are selected by prefixing the constructor
+-- 
+-- Generate an "As" class of prisms. Names are selected by prefixing the constructor
 -- name with an underscore.  Constructors with multiple fields will
 -- construct Prisms to tuples of those fields.
 makeClassyPrisms :: Name {- ^ Type constructor name -} -> DecsQ


### PR DESCRIPTION
The second code block in documentation for `makeClassyPrisms` doesn't render correctly. See e.g. [hackage docs](http://hackage.haskell.org/package/lens-4.5/docs/Control-Lens-TH.html#v:makeClassyPrisms).
