### PR TITLE
Restore a surprising corner case to makeFields name parsing.

### DIFF
--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -113,14 +113,22 @@ data Lebowski a = Lebowski
     , _lebowskiMansion  :: String
     , _lebowskiThing    :: Maybe a
     }
+data AbideConfiguration a = AbideConfiguration
+    { _acLocation       :: String
+    , _acDuration       :: Int
+    , _acThing          :: a
+    }
 
 makeFields ''Dude
 makeFields ''Lebowski
+makeFields ''AbideConfiguration
 
 dudeDrink :: String
 dudeDrink      = (Dude 9 "El Duderino" () "white russian")      ^. thing 
 lebowskiCarpet :: Maybe String
 lebowskiCarpet = (Lebowski "Mr. Lebowski" 0 "" (Just "carpet")) ^. thing
+abideAnnoyance :: String
+abideAnnoyance = (AbideConfiguration "the tree" 10 "the wind")  ^. thing
 
 declareLenses [d|
   data Quark1 a = Qualified1   { gaffer1 :: a }


### PR DESCRIPTION
Before lens 4.5, it was the case that this code produced lenses called
foo and bar:

data MyConfig { _mcFoo :: String, _mcBar :: String }
makeFields ''MyConfig

After 4.5, this code no longer worked as the prefix on record fields was
forced to be the type name (suitably capitalized). This change restores the
previous functionality, but only in those cases where all fields within a
given type that are to be lensed begin with the same prefix.

As a pleasant side effect, anyone who had worked around the pre-4.5 behavior with camel cased names by doing something like this:

data MyConfig { _myconfigFoo :: String, _myconfigBar :: String }
makeFields ''MyConfig

will have their code continue working without requiring changes.
