### PR TITLE
Add an abbreviatedFields to get back the legacy behavior of makeFields.

### DIFF
--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -113,14 +113,23 @@ data Lebowski a = Lebowski
     , _lebowskiMansion  :: String
     , _lebowskiThing    :: Maybe a
     }
+data AbideConfiguration a = AbideConfiguration
+    { _acLocation       :: String
+    , _acDuration       :: Int
+    , _acThing          :: a
+    }
+
 
 makeFields ''Dude
 makeFields ''Lebowski
+makeLensesWith abbreviatedFields ''AbideConfiguration
 
 dudeDrink :: String
 dudeDrink      = (Dude 9 "El Duderino" () "white russian")      ^. thing 
 lebowskiCarpet :: Maybe String
 lebowskiCarpet = (Lebowski "Mr. Lebowski" 0 "" (Just "carpet")) ^. thing
+abideAnnoyance :: String
+abideAnnoyance = (AbideConfiguration "the tree" 10 "the wind")  ^. thing
 
 declareLenses [d|
   data Quark1 a = Qualified1   { gaffer1 :: a }


### PR DESCRIPTION
Add an abbreviatedFields to get back the legacy behavior of makeFields.
Also, document the actual pattern makeFields/camelCaseFields requires.
