### PR TITLE
Improve documentation

### DIFF
--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -380,6 +380,11 @@ class Ixed m => At m where
   -- you cannot satisfy the 'Lens' laws.
   at :: Index m -> Lens' m (Maybe (IxValue m))
 
+-- | Delete the value associated with a key in a 'Map'-like container
+--
+-- @
+-- 'sans' k = 'at' k .~ Nothing
+-- @
 sans :: At m => Index m -> m -> m
 sans k m = m & at k .~ Nothing
 {-# INLINE sans #-}

--- a/src/Data/Bits/Lens.hs
+++ b/src/Data/Bits/Lens.hs
@@ -235,8 +235,8 @@ bits f b = Prelude.foldr step 0 <$> traverse g bs where
 -- If you supply this an 'Integer', the result will be an infinite 'Traversal',
 -- which can be productively consumed, but not reassembled.
 --
--- Why is this function called @bytes@ to match 'bits'? Alas, there is already
--- a function by that name in "Data.ByteString.Lens".
+-- Why is'nt this function called @bytes@ to match 'bits'? Alas, there
+-- is already a function by that name in "Data.ByteString.Lens".
 bytewise :: (Integral b, Bits b) => IndexedTraversal' Int b Word8
 bytewise f b = Prelude.foldr step 0 <$> traverse g bs where
   g n = (,) n <$> indexed f n (fromIntegral $ b `shiftR` (n*8))

--- a/src/Data/List/Split/Lens.hs
+++ b/src/Data/List/Split/Lens.hs
@@ -166,12 +166,12 @@ delimiters :: Lens (Splitter a) (Splitter b) [a -> Bool] [b -> Bool]
 delimiters f s@Splitter { delimiter = Delimiter ds } = f ds <&> \ds' -> s { delimiter = Delimiter ds' }
 {-# INLINE delimiters #-}
 
--- | Modify or retrieve the policy for what a 'Splitter' to do with delimiters.
+-- | Modify or retrieve the policy for what a 'Splitter' should do with delimiters.
 delimiting :: Lens' (Splitter a) DelimPolicy
 delimiting f s@Splitter { delimPolicy = p } = f p <&> \p' -> s { delimPolicy = p' }
 {-# INLINE delimiting #-}
 
--- | Modify or retrieve the policy for what a 'Splitter' should about consecutive delimiters.
+-- | Modify or retrieve the policy for what a 'Splitter' should do about consecutive delimiters.
 condensing :: Lens' (Splitter a) CondensePolicy
 condensing f s@Splitter { condensePolicy = p } = f p <&> \p' -> s { condensePolicy = p' }
 {-# INLINE condensing #-}


### PR DESCRIPTION
Modules touched:
- Control.Lens.At: missing docs for `sans`
- Data.Bits.Lens: missing negation
- Data.List.Split.Lens: correct wording for `delimiting` and `condensing` haddock

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
