### PR TITLE
Improve documentation and add examples

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -432,7 +432,13 @@ lined f = fmap (intercalate "\n") . conjoined traverse (indexing traverse) f . l
 -- Fold/Getter combinators
 --------------------------
 
--- | @
+-- | Map each part of a structure viewed through a 'Lens', 'Getter',
+-- 'Fold' or 'Traversal' to a monoid and combine the results.
+--
+-- >>> foldMapOf (folded . both . _Just) Sum [(Just 21, Just 21)]
+-- Sum {getSum = 42}
+--
+-- @
 -- 'Data.Foldable.foldMap' = 'foldMapOf' 'folded'
 -- @
 --
@@ -457,7 +463,13 @@ foldMapOf :: Profunctor p => Accessing p r s a -> p a r -> s -> r
 foldMapOf l f = getConst #. l (Const #. f)
 {-# INLINE foldMapOf #-}
 
--- | @
+-- | Combine the elements of a structure viewed through a 'Lens', 'Getter',
+-- 'Fold' or 'Traversal' using a monoid.
+--
+-- >>> foldOf (folded.folded) [[Sum 1,Sum 4],[Sum 8, Sum 8],[Sum 21]]
+-- Sum {getSum = 42}
+--
+-- @
 -- 'Data.Foldable.fold' = 'foldOf' 'folded'
 -- @
 --

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -1065,7 +1065,7 @@ instance Ord k => TraverseMax k (Map k) where
     Nothing          -> pure m
   {-# INLINE traverseMax #-}
 
--- | Traverse the /nth/ element 'elementOf' a 'Traversal', 'Lens' or
+-- | Traverse the /nth/ 'elementOf' a 'Traversal', 'Lens' or
 -- 'Iso' if it exists.
 --
 -- >>> [[1],[3,4]] & elementOf (traverse.traverse) 1 .~ 5
@@ -1113,7 +1113,7 @@ elementsOf :: Applicative f
 elementsOf l p iafb s = snd $ runIndexing (l (\a -> Indexing (\i -> i `seq` (i + 1, if p i then indexed iafb i a else pure a))) s) 0
 {-# INLINE elementsOf #-}
 
--- | Traverse elements of a 'Traversable' container where their ordinal positions matches a predicate.
+-- | Traverse elements of a 'Traversable' container where their ordinal positions match a predicate.
 --
 -- @
 -- 'elements' ≡ 'elementsOf' 'traverse'
@@ -1203,7 +1203,7 @@ failing l r pafb s = case pins b of
   where b = l sell s
 infixl 5 `failing`
 
--- | Try the second traversal. If it returns no entries, try again with for all entries from the first traversal, recursively.
+-- | Try the second traversal. If it returns no entries, try again with all entries from the first traversal, recursively.
 --
 -- @
 -- 'deepOf' :: 'Fold' s s          -> 'Fold' s a                   -> 'Fold' s a


### PR DESCRIPTION
Again some documentation improvements ;)

Summary:

in `Control.Lens.Traversal`
- typo in haddock for `deepOf`
- fix haddock for `elements`

in `Control.Lens.Fold`
- docs and example for `foldMapOf`
- docs and example for `foldOf`

[![24pullrequests](http://24pullrequests.com/assets/logo-625222452ffc0d57272decb6f851a7fe.png)](http://24pullrequests.com)

Best,
Markus
