### PR TITLE
Make `vector` and `asStream` (more) polymorphic

### DIFF
--- a/src/Data/Vector/Generic/Lens.hs
+++ b/src/Data/Vector/Generic/Lens.hs
@@ -79,18 +79,18 @@ toVectorOf l s = fromList (toListOf l s)
 --
 -- >>> Vector.fromList [0,8,15] ^. from vector
 -- [0,8,15]
-vector :: Vector v a => Iso' [a] (v a)
+vector :: (Vector v a, Vector v b) => Iso [a] [b] (v a) (v b)
 vector = iso fromList V.toList
 {-# INLINE vector #-}
 
 -- | Convert a 'Vector' to a finite 'Stream' (or back.)
-asStream :: Vector v a => Iso' (v a) (Stream a)
+asStream :: (Vector v a, Vector v b) => Iso (v a) (v b) (Stream a) (Stream b)
 asStream = iso stream unstream
 {-# INLINE asStream #-}
 
 -- | Convert a 'Vector' to a finite 'Stream' from right to left (or
 -- back.)
-asStreamR :: Vector v a => Iso' (v a) (Stream a)
+asStreamR :: (Vector v a, Vector v b) => Iso (v a) (v b) (Stream a) (Stream b)
 asStreamR = iso streamR unstreamR
 {-# INLINE asStreamR #-}
 


### PR DESCRIPTION
A different solution to the same underlying problem as #516.

The advantage here is that `boxed.mapped` incurs no performance penalty compared to using `Data.Vector.Unboxed.map` directly! (At least that's what my simple benchmarks made me believe. The vector magic optimizes it all away, unlike when converting to and back from lists, as `each` and my previous solution does.)