### PR TITLE
Control/Lens/Plated.hs: amend for ghc-7.10

### DIFF
--- a/src/Control/Lens/Plated.hs
+++ b/src/Control/Lens/Plated.hs
@@ -8,9 +8,9 @@
 
 #if __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE OverlappingInstances #-}
-#define OVERLAPPING
+#define OVERLAPPING_PRAGMA
 #else
-#define OVERLAPPING {-# OVERLAPPING #-}
+#define OVERLAPPING_PRAGMA {-# OVERLAPPING #-}
 #endif
 
 #ifdef TRUSTWORTHY
@@ -713,7 +713,7 @@ instance (GPlated a f, GPlated a g) => GPlated a (f :*: g) where
   gplate f (x :*: y) = (:*:) <$> gplate f x <*> gplate f y
   {-# INLINE gplate #-}
 
-instance OVERLAPPING GPlated a (K1 i a) where
+instance OVERLAPPING_PRAGMA GPlated a (K1 i a) where
   gplate f (K1 x) = K1 <$> f x
   {-# INLINE gplate #-}
 


### PR DESCRIPTION
Build fails thusly (ghc-7.10.1_rc2/gcc-4.8.4):
    Building lens-4.8...
    Preprocessing library lens-4.8...

    src/Control/Lens/Plated.hs:716:0:
         error: detected recursion whilst expanding macro "OVERLAPPING"
         instance OVERLAPPING GPlated a (K1 i a) where
         ^

The reason is recursive macro definition:
    #define OVERLAPPING {-# OVERLAPPING #-}

Fixed by naming thing on the left differently.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>