### PR TITLE
Unconditionally add Zoom ExceptT instance using mtl-compat

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -196,7 +196,6 @@ library
     kan-extensions            >= 4.2.1    && < 5,
     exceptions                >= 0.1.1    && < 1,
     mtl                       >= 2.0.1    && < 2.3,
-    mtl-compat                == 0.1.*,
     parallel                  >= 3.1.0.1  && < 3.3,
     primitive                 >= 0.4.0.1  && < 0.6,
     profunctors               >= 4        && < 5,
@@ -207,7 +206,7 @@ library
     template-haskell          >= 2.4      && < 2.11,
     text                      >= 0.11     && < 1.3,
     transformers              >= 0.2      && < 0.5,
-    transformers-compat       >= 0.3      && < 1,
+    transformers-compat       >= 0.4      && < 1,
     unordered-containers      >= 0.2      && < 0.3,
     vector                    >= 0.9      && < 0.11,
     void                      >= 0.5      && < 1

--- a/lens.cabal
+++ b/lens.cabal
@@ -196,6 +196,7 @@ library
     kan-extensions            >= 4.2.1    && < 5,
     exceptions                >= 0.1.1    && < 1,
     mtl                       >= 2.0.1    && < 2.3,
+    mtl-compat                == 0.1.*,
     parallel                  >= 3.1.0.1  && < 3.3,
     primitive                 >= 0.4.0.1  && < 0.6,
     profunctors               >= 4        && < 5,

--- a/src/Control/Lens/Zoom.hs
+++ b/src/Control/Lens/Zoom.hs
@@ -41,11 +41,10 @@ import Control.Monad.Trans.Writer.Strict as Strict
 import Control.Monad.Trans.RWS.Lazy as Lazy
 import Control.Monad.Trans.RWS.Strict as Strict
 import Control.Monad.Trans.Error
+import Control.Monad.Trans.Except
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
--- When using mtl-compat we need to import this module to get the MonadState ExceptT instance.
-import Control.Monad.Except
 import Data.Monoid
 import Data.Profunctor.Unsafe
 import Prelude

--- a/src/Control/Lens/Zoom.hs
+++ b/src/Control/Lens/Zoom.hs
@@ -41,12 +41,11 @@ import Control.Monad.Trans.Writer.Strict as Strict
 import Control.Monad.Trans.RWS.Lazy as Lazy
 import Control.Monad.Trans.RWS.Strict as Strict
 import Control.Monad.Trans.Error
-#if MIN_VERSION_mtl(2,2,0)
-import Control.Monad.Trans.Except
-#endif
 import Control.Monad.Trans.List
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
+-- When using mtl-compat we need to import this module to get the MonadState ExceptT instance.
+import Control.Monad.Except
 import Data.Monoid
 import Data.Profunctor.Unsafe
 import Prelude
@@ -150,11 +149,9 @@ instance (Error e, Zoom m n s t) => Zoom (ErrorT e m) (ErrorT e n) s t where
   zoom l = ErrorT . liftM getErr . zoom (\afb -> unfocusingErr #. l (FocusingErr #. afb)) . liftM Err . runErrorT
   {-# INLINE zoom #-}
 
-#if MIN_VERSION_mtl(2,2,0)
 instance Zoom m n s t => Zoom (ExceptT e m) (ExceptT e n) s t where
   zoom l = ExceptT . liftM getErr . zoom (\afb -> unfocusingErr #. l (FocusingErr #. afb)) . liftM Err . runExceptT
   {-# INLINE zoom #-}
-#endif
 
 -- TODO: instance Zoom m m a a => Zoom (ContT r m) (ContT r m) a a where
 


### PR DESCRIPTION
This is needed to allow reverse-dependencies of this package to migrate to `ExceptT` while keeping backwards compatibility for older versions of `mtl`.

Since the `MonadState ExceptT` instance is defined in `Control.Monad.State.Class` in `mtl` and `mtl-compat` can't override this we can import `Control.Monad.Except` instead of `Control.Monad.Trans.Except` to always get the instance.

Also see fpco/stackage#439
