### PR TITLE
fix haddock markup errors

### DIFF
--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -264,7 +264,7 @@ class Foldable f => FoldableWithIndex i f | f -> i where
 
   -- | The 'IndexedFold' of a 'FoldableWithIndex' container.
   --
-  -- 'ifolded'.'asIndex' is a fold over the keys of a 'FoldableWithIndex'.
+  -- @'ifolded' '.' 'asIndex'@ is a fold over the keys of a 'FoldableWithIndex'.
   --
   -- >>> Data.Map.fromList [(2, "hello"), (1, "world")]^..ifolded.asIndex
   -- [1,2]

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -1206,7 +1206,9 @@ overA l p = arr (\s -> let (Context f a) = l sell s in (f, a))
 -- adjust all of the targets of an 'Control.Lens.Traversal.IndexedTraversal' and return a monoidal summary
 -- along with the answer.
 --
--- @l '<%~' f ≡ l '<%@~' 'const' f@
+-- @
+-- l '<%~' f ≡ l '<%@~' 'const' f
+-- @
 --
 -- When you do not need access to the index then ('<%~') is more liberal in what it can accept.
 --
@@ -1237,7 +1239,9 @@ l <<%@~ f = l $ Indexed $ \i a -> second' (f i) (a,a)
 -- adjust all of the targets of an 'Control.Lens.Traversal.IndexedTraversal' and return a monoidal summary
 -- of the supplementary results and the answer.
 --
--- @('%%@~') ≡ 'Control.Lens.Indexed.withIndex'@
+-- @
+-- ('%%@~') ≡ 'Control.Lens.Indexed.withIndex'
+-- @
 --
 -- @
 -- ('%%@~') :: 'Functor' f => 'IndexedLens' i s t a b      -> (i -> a -> f b) -> s -> f t
@@ -1259,7 +1263,9 @@ l <<%@~ f = l $ Indexed $ \i a -> second' (f i) (a,a)
 -- adjust all of the targets of an 'Control.Lens.Traversal.IndexedTraversal' within the current state, and
 -- return a monoidal summary of the supplementary results.
 --
--- @l '%%@=' f ≡ 'state' (l '%%@~' f)@
+-- @
+-- l '%%@=' f ≡ 'state' (l '%%@~' f)
+-- @
 --
 -- @
 -- ('%%@=') :: 'MonadState' s m                 => 'IndexedLens' i s s a b      -> (i -> a -> (r, b)) -> s -> m r


### PR DESCRIPTION
Haddock's markup handling is kinda fishy sometimes. I think it was choking on the lack of spaces before/after `.` in one case and the fact that the @-delimited text contained more @ symbols in the other.