### PR TITLE
Document difference in behaviour for singular and unsafeSingular

### DIFF
--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -630,6 +630,9 @@ holesOf l s = unTagged
 -- >>> [1..10] ^. singular (ix 7)
 -- 8
 --
+-- >>> [] & singular traverse .~ 0
+-- []
+--
 -- @
 -- 'singular' :: 'Traversal' s t a a          -> 'Lens' s t a a
 -- 'singular' :: 'Fold' s a                   -> 'Getter' s a
@@ -653,6 +656,9 @@ singular l = conjoined
 --
 -- The resulting 'Lens' or 'Getter' will be partial if the 'Traversal' targets nothing
 -- or more than one element.
+--
+-- >>> [] & unsafeSingular traverse .~ 0
+-- *** Exception: unsafeSingular: empty traversal
 --
 -- @
 -- 'unsafeSingular' :: 'Traversal' s t a b          -> 'Lens' s t a b


### PR DESCRIPTION
When using singular of an empty traversal as a setter, it does nothing. When using unsafeSingular it fails with an error.