### PR TITLE
PrimMonad is redundant for primitive >0.6 if it's constrained by PrimBase

### DIFF
--- a/src/Control/Monad/Primitive/Lens.hs
+++ b/src/Control/Monad/Primitive/Lens.hs
@@ -29,7 +29,7 @@ import GHC.Prim (State#)
 {-# ANN module "HLint: ignore Unused LANGUAGE pragma" #-}
 
 #if MIN_VERSION_primitive(0,6,0)
-prim :: (PrimMonad m, PrimBase m) => Iso' (m a) (State# (PrimState m) -> (# State# (PrimState m), a #))
+prim :: PrimBase m => Iso' (m a) (State# (PrimState m) -> (# State# (PrimState m), a #))
 #else
 prim :: PrimMonad m => Iso' (m a) (State# (PrimState m) -> (# State# (PrimState m), a #))
 #endif


### PR DESCRIPTION
I was skimming through changes made for GHC 7.10.1/base-4.8.0.0 and i noticed you can leave the PrimMonad out of the signature in `prim`. Just a nitpick, but i'll leave a PR anyway. 

PrimBase is defined like this:
```haskell
class PrimMonad m => PrimBase m where
  -- | Expose the internal structure of the monad
  internal :: ...
```
https://github.com/haskell/primitive/blob/master/Control/Monad/Primitive.hs#L66

btw can someone please say `cabal upload` for lens 4.9?