### PR TITLE
Depend on base-compat for orphan Foldable/Traversable instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,8 @@
 4.9.1
 -----
 * Added `_Wrapped` support for `NonEmpty`.
+* Added dependency on `base-compat`, which contains orphan `Foldable` and `Traversable` instances for `Either`, `Const`, and `(,)`.
+* The `Control.Lens.Internal.Instances` module now reexports the orphan instances from `base-compat`.
 
 4.9
 -------

--- a/lens.cabal
+++ b/lens.cabal
@@ -183,6 +183,7 @@ library
   build-depends:
     array                     >= 0.3.0.2  && < 0.6,
     base                      >= 4.5      && < 5,
+    base-compat               >= 0.4      && < 1,
     bifunctors                >= 4        && < 5,
     bytestring                >= 0.9.1.10 && < 0.11,
     comonad                   >= 4        && < 5,

--- a/src/Control/Lens/Internal/Instances.hs
+++ b/src/Control/Lens/Internal/Instances.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 #ifndef MIN_VERSION_semigroupoids
 #define MIN_VERSION_semigroupoids(x,y,z) 1
 #endif
@@ -18,11 +14,12 @@
 -- Portability :  non-portable
 --
 -- This module includes orphan instances for @(,)@, 'Either' and 'Const' that
--- should be supplied by base. These have moved to @semigroupoids@ as of 4.2.
+-- should be supplied by base. Some of these instances are reexported from
+-- the `base-compat` library.
 ----------------------------------------------------------------------------
 module Control.Lens.Internal.Instances () where
 
-import Data.Traversable.Instances ()
+import Data.Traversable.Compat ()
 
 #if !(MIN_VERSION_semigroupoids(4,2,0))
 
@@ -30,38 +27,9 @@ import Control.Applicative
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
 
-
-#if !(MIN_VERSION_base(4,7,0))
-import Data.Monoid
-import Data.Foldable
-import Data.Traversable
-#endif
-
 -------------------------------------------------------------------------------
 -- Orphan Instances
 -------------------------------------------------------------------------------
-
-#if !(MIN_VERSION_base(4,7,0))
-instance Foldable ((,) b) where
-  foldMap f (_, a) = f a
-
-instance Traversable ((,) b) where
-  traverse f (b, a) = (,) b <$> f a
-
-instance Foldable (Either a) where
-  foldMap _ (Left _) = mempty
-  foldMap f (Right a) = f a
-
-instance Traversable (Either a) where
-  traverse _ (Left b) = pure (Left b)
-  traverse f (Right a) = Right <$> f a
-
-instance Foldable (Const m) where
-  foldMap _ _ = mempty
-
-instance Traversable (Const m) where
-  traverse _ (Const m) = pure $ Const m
-#endif
 
 instance Foldable1 ((,) b) where
   foldMap1 f (_, a) = f a


### PR DESCRIPTION
At the moment, both the `base-compat` and `lens` libraries expose orphan `Foldable` and `Traversable` instances for `Either`, `Const`, and `(,)`, which means they can't be used together. Since `base-compat` was created for the purpose of backporting new features of `base` (including orphan instances), I feel like it makes more sense for them to be defined in `base-compat`. This commit adds a dependency on `base-compat` and reexports the orphan instances from `Control.Lens.Internal.Instances`.

See also [this pull request](https://github.com/ekmett/semigroupoids/pull/27) for `semigroupoids`.