### PR TITLE
Fix docs for generateLazyPatterns

### DIFF
--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -116,14 +116,26 @@ generateUpdateableOptics f r =
   fmap (\x -> r { _allowUpdates = x}) (f (_allowUpdates r))
 
 -- | Generate optics using lazy pattern matches. This can
--- allow fields of an undefined value to be initialized with lenses,
--- and is the default behavior.
+-- allow fields of an undefined value to be initialized with lenses:
 --
+-- @
+-- data Foo = Foo {_x :: Int, _y :: Bool}
+--   deriving Show
+--
+-- 'makeLensesWith' ('lensRules' & 'generateLazyPatterns' .~ True) ''Foo
+-- @
+--
+-- @
+-- >>> undefined & x .~ 8 & y .~ True
+-- Foo {_x = 8, _y = True}
+-- @
+-- 
 -- The downside of this flag is that it can lead to space-leaks and
--- code-size/compile-time increases when generated for large records.
+-- code-size/compile-time increases when generated for large records. By
+-- default this flag is turned off, and strict optics are generated.
 --
 -- When using lazy optics the strict optic can be recovered by composing
--- with '$!'
+-- with '$!':
 --
 -- @
 -- strictOptic = ($!) . lazyOptic


### PR DESCRIPTION
> This can allow fields of an undefined value to be initialized with lenses, and is the default behavior.

Not anymore.

(Also added an example.)