### PR TITLE
Consolidate backported orphans with base-orphans

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -179,6 +179,7 @@ library
   build-depends:
     array                     >= 0.3.0.2  && < 0.6,
     base                      >= 4.5      && < 5,
+    base-orphans              >= 0.3      && < 1,
     bifunctors                >= 5        && < 6,
     bytestring                >= 0.9.1.10 && < 0.11,
     comonad                   >= 4        && < 5,

--- a/src/Control/Lens/Internal/Instances.hs
+++ b/src/Control/Lens/Internal/Instances.hs
@@ -1,10 +1,6 @@
 {-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 #ifndef MIN_VERSION_semigroupoids
 #define MIN_VERSION_semigroupoids(x,y,z) 1
 #endif
@@ -22,6 +18,7 @@
 ----------------------------------------------------------------------------
 module Control.Lens.Internal.Instances () where
 
+import Data.Orphans ()
 import Data.Traversable.Instances ()
 
 #if !(MIN_VERSION_semigroupoids(4,2,0))
@@ -30,38 +27,9 @@ import Control.Applicative
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
 
-
-#if !(MIN_VERSION_base(4,7,0))
-import Data.Monoid
-import Data.Foldable
-import Data.Traversable
-#endif
-
 -------------------------------------------------------------------------------
 -- Orphan Instances
 -------------------------------------------------------------------------------
-
-#if !(MIN_VERSION_base(4,7,0))
-instance Foldable ((,) b) where
-  foldMap f (_, a) = f a
-
-instance Traversable ((,) b) where
-  traverse f (b, a) = (,) b <$> f a
-
-instance Foldable (Either a) where
-  foldMap _ (Left _) = mempty
-  foldMap f (Right a) = f a
-
-instance Traversable (Either a) where
-  traverse _ (Left b) = pure (Left b)
-  traverse f (Right a) = Right <$> f a
-
-instance Foldable (Const m) where
-  foldMap _ _ = mempty
-
-instance Traversable (Const m) where
-  traverse _ (Const m) = pure $ Const m
-#endif
 
 instance Foldable1 ((,) b) where
   foldMap1 f (_, a) = f a


### PR DESCRIPTION
Consolidate some common backported orphan instances from `base` using the `base-orphans` package (similar to [this pull request](https://github.com/ekmett/semigroupoids/pull/28) from `semigroupoids`).