### PR TITLE
Traversal rewrite rules

### DIFF
--- a/benchmarks/folds.hs
+++ b/benchmarks/folds.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE BangPatterns #-}
+
+import qualified Data.ByteString as BS
+import qualified Data.HashMap.Lazy as HM
+import qualified Data.Map as M
+import qualified Data.Sequence as S
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Data.Vector.Generic.Lens
+import Data.ByteString.Lens
+
+import Control.Lens
+import Criterion.Main
+import Criterion.Types
+import Data.Foldable
+
+main :: IO ()
+main = defaultMainWith config
+  [
+    bgroup "vector"
+    [ bgroup "toList"
+      [ bench "native" $ nf V.toList v
+      , bench "each"   $ nf (toListOf each) v
+      ]
+    , bgroup "itoList"
+      [ bench "native"     $ nf (V.toList . V.indexed) v
+      , bench "itraversed" $ nf (itoListOf itraversed) v
+      ]
+    ]
+  , bgroup "unboxed-vector"
+    [ bgroup "toList"
+      [ bench "native" $ nf U.toList u
+      , bench "each"   $ nf (toListOf each) u
+      ]
+    , bgroup "itoList"
+      [ bench "native"     $ nf (U.toList . U.indexed) u
+      , bench "vTraverse" $ nf (itoListOf vectorTraverse) u
+      ]
+    ]
+  , bgroup "sequence"
+    [ bgroup "toList"
+      [ bench "native" $ nf toList s
+      , bench "each"   $ nf (toListOf each) s
+      ]
+    , bgroup "itoList"
+      [ bench "native"     $ nf (toList . S.mapWithIndex (,)) s
+      , bench "itraversed" $ nf (itoListOf itraversed) s
+      ]
+    ]
+  , bgroup "bytestring"
+    [ bgroup "toList"
+      [ bench "native" $ nf BS.unpack b
+      , bench "bytes"  $ nf (toListOf bytes) b
+      , bench "each"   $ nf (toListOf each) b
+      ]
+    , bgroup "itoList"
+      [ bench "native" $ nf (zip [(0::Int)..] . BS.unpack) b
+      , bench "bytes"  $ nf (itoListOf bytes) b
+      ]
+    ]
+  , bgroup "list"
+    [ bgroup "toList"
+      [ bench "native" $ nf toList l
+      , bench "each"   $ nf (toListOf each) l
+      ]
+    , bgroup "itoList"
+      [ bench "native"     $ nf (zip [(0::Int)..]) l
+      , bench "itraversed" $ nf (itoListOf itraversed) l
+      ]
+    ]
+  , bgroup "map"
+    [ bgroup "toList"
+      [ bench "native" $ nf toList m
+      , bench "each"   $ nf itoList m
+      ]
+    , bgroup "itoList"
+      [ bench "native"     $ nf (zip [(0::Int)..] . toList) m
+      , bench "itraversed" $ nf (itoListOf itraversed) m
+      ]
+    ]
+  , bgroup "hash map"
+    [ bgroup "toList"
+      [ bench "native" $ nf HM.keys h
+      , bench "each"   $ nf (toListOf each) h
+      ]
+    , bgroup "itoList"
+      [ bench "native"     $ nf HM.toList h
+      , bench "itoList"    $ nf itoList h
+      , bench "itraversed" $ nf (itoListOf itraversed) h
+      ]
+    , bgroup "sum"
+      [ bench "native" $ nf (sum . id . toList) h
+      , bench "each"   $ nf (sumOf each) h
+      ]
+    ]
+  ]
+  where
+    config = defaultConfig { timeLimit = 1 }
+    l = [0..10000] :: [Int]
+    b = BS.pack $ map fromIntegral l
+    h = HM.fromList $ zip l l
+    m = M.fromList $ zip l l
+    s = S.fromList l
+    u = U.fromList l
+    v = V.fromList l
+

--- a/benchmarks/traversals.hs
+++ b/benchmarks/traversals.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE BangPatterns #-}
+
+import qualified Data.ByteString as BS
+import qualified Data.HashMap.Strict as HM
+import qualified Data.Map as M
+import qualified Data.Sequence as S
+import qualified Data.Vector as V
+import qualified Data.Vector.Unboxed as U
+
+import Data.Vector.Generic.Lens
+import Data.ByteString.Lens
+
+import Control.Lens
+import Criterion.Main
+import Criterion.Types
+
+main :: IO ()
+main = defaultMainWith config
+  [
+    bgroup "vector"
+    [ bgroup "map"
+      [ bench "native"     $ nf (V.map (+100)) v
+      , bench "itraversed" $ nf (over itraversed (+100)) v
+      ]
+    , bgroup "imap"
+      [ bench "native"     $ nf (V.imap           (\i x -> x + i +100)) v
+      , bench "imap"       $ nf (imap             (\i x -> x + i +100)) v
+      , bench "itraversed" $ nf (iover itraversed (\i x -> x + i +100)) v
+      ]
+    ]
+  , bgroup "unboxed-vector"
+    [ bgroup "map"
+      [ bench "native"     $ nf (U.map (+100)) u
+      , bench "itraversed" $ nf (over each (+100)) u
+      ]
+    , bgroup "imap"
+      [ bench "native"     $ nf (U.imap (\i x -> x + i +100)) u
+      , bench "itraversed" $ nf (iover vectorTraverse (\i x -> x + i) :: U.Vector Int -> U.Vector Int) u
+      ]
+    ]
+  , bgroup "sequence"
+    [ bgroup "map"
+      [ bench "native" $ nf (fmap            (+100)) s
+      , bench "each"   $ nf (over each       (+100)) s
+      ]
+    , bgroup "imap"
+      [ bench "native" $ nf (S.mapWithIndex    (\i x -> x + i +100)) s
+      , bench "imap"   $ nf (imap              (\i x -> x + i +100)) s
+      ]
+    ]
+  , bgroup "bytestring"
+    [ bgroup "map"
+      [ bench "native" $ nf (BS.map     (+100)) b
+      , bench "each"   $ nf (over each  (+100)) b
+      ]
+    , bgroup "imap"
+      [
+        bench "bytes" $ nf (iover bytes (\i x -> x + fromIntegral i +100)) b
+      ]
+    ]
+  , bgroup "list"
+    [ bgroup "map"
+      [ bench "native" $ nf (map       (+100)) l
+      , bench "each"   $ nf (over each (+100)) l
+      ]
+    , bgroup "imap"
+      [ bench "imap" $ nf (imap (\i x -> x + i +100)) l
+      ]
+    ]
+  , bgroup "map"
+    [ bgroup "map"
+      [ bench "native"     $ nf (fmap            (+100)) m
+      , bench "each"       $ nf (over each       (+100)) m
+      , bench "itraversed" $ nf (over itraversed (+100)) m
+      ]
+    , bgroup "imap"
+      [ bench "native" $ nf (M.mapWithKey (\i x -> x + i +100)) m
+      , bench "each"   $ nf (imap         (\i x -> x + i +100)) m
+      ]
+    ]
+  , bgroup "hash map"
+    [ bgroup "map"
+      [ bench "native" $ nf (HM.map    (+100)) h
+      , bench "each"   $ nf (over each (+100)) h
+      ]
+    , bgroup "imap"
+      [ bench "native" $ nf (HM.mapWithKey (\i x -> x + i +100)) h
+      , bench "imap"   $ nf (imap          (\i x -> x + i +100)) h
+      ]
+    ]
+  ]
+  where
+    config = defaultConfig { timeLimit = 1 }
+    l  = [0..10000] :: [Int]
+    xl = [0..100000] :: [Int]
+    b  = BS.pack $ map fromIntegral xl
+    h  = HM.fromList $ zip l l
+    m  = M.fromList $ zip l l
+    s  = S.fromList l
+    u  = U.fromList xl
+    v  = V.fromList l

--- a/lens.cabal
+++ b/lens.cabal
@@ -447,6 +447,36 @@ benchmark alongside
     lens,
     transformers
 
+-- Benchmarking folds
+benchmark folds
+  type:           exitcode-stdio-1.0
+  main-is:        folds.hs
+  ghc-options:    -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs: benchmarks
+  build-depends:
+    base,
+    criterion,
+    containers,
+    bytestring,
+    unordered-containers,
+    vector,
+    lens
+
+-- Benchmarking traversals
+benchmark traversals
+  type:           exitcode-stdio-1.0
+  main-is:        traversals.hs
+  ghc-options:    -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs: benchmarks
+  build-depends:
+    base,
+    criterion,
+    containers,
+    bytestring,
+    unordered-containers,
+    vector,
+    lens
+
 -- Benchmarking unsafe implementation strategies
 benchmark unsafe
   type:           exitcode-stdio-1.0
@@ -462,7 +492,6 @@ benchmark unsafe
     generic-deriving,
     lens,
     transformers
-
 
 -- Benchmarking zipper usage
 benchmark zipper

--- a/src/Control/Lens/Each.hs
+++ b/src/Control/Lens/Each.hs
@@ -46,6 +46,7 @@ import Data.Sequence as Seq
 import Data.Text as StrictT
 import Data.Text.Lazy as LazyT
 import Data.Tree as Tree
+import Data.Vector.Generic.Lens (vectorTraverse)
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Primitive as Prim
 import Data.Vector.Primitive (Prim)
@@ -160,21 +161,23 @@ instance Each (Seq a) (Seq b) a b
 instance Each (Tree a) (Tree b) a b
 
 -- | @'each' :: 'Traversal' ('Vector.Vector' a) ('Vector.Vector' b) a b@
-instance Each (Vector.Vector a) (Vector.Vector b) a b
+instance Each (Vector.Vector a) (Vector.Vector b) a b where
+  each = vectorTraverse
+  {-# INLINE each #-}
 
 -- | @'each' :: ('Prim' a, 'Prim' b) => 'Traversal' ('Prim.Vector' a) ('Prim.Vector' b) a b@
 instance (Prim a, Prim b) => Each (Prim.Vector a) (Prim.Vector b) a b where
-  each f v = Prim.fromListN (Prim.length v) <$> traverse f (Prim.toList v)
+  each = vectorTraverse
   {-# INLINE each #-}
 
 -- | @'each' :: ('Storable' a, 'Storable' b) => 'Traversal' ('Storable.Vector' a) ('Storable.Vector' b) a b@
 instance (Storable a, Storable b) => Each (Storable.Vector a) (Storable.Vector b) a b where
-  each f v = Storable.fromListN (Storable.length v) <$> traverse f (Storable.toList v)
+  each = vectorTraverse
   {-# INLINE each #-}
 
 -- | @'each' :: ('Unbox' a, 'Unbox' b) => 'Traversal' ('Unboxed.Vector' a) ('Unboxed.Vector' b) a b@
 instance (Unbox a, Unbox b) => Each (Unboxed.Vector a) (Unboxed.Vector b) a b where
-  each f v = Unboxed.fromListN (Unboxed.length v) <$> traverse f (Unboxed.toList v)
+  each = vectorTraverse
   {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' 'StrictT.Text' 'StrictT.Text' 'Char' 'Char'@

--- a/src/Control/Lens/Each.hs
+++ b/src/Control/Lens/Each.hs
@@ -135,16 +135,24 @@ instance Each (Complex a) (Complex b) a b where
   {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' ('Map' c a) ('Map' c b) a b@
-instance (c ~ d) => Each (Map c a) (Map d b) a b
+instance (c ~ d) => Each (Map c a) (Map d b) a b where
+  each = traversed
+  {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' ('Map' c a) ('Map' c b) a b@
-instance Each (IntMap a) (IntMap b) a b
+instance Each (IntMap a) (IntMap b) a b where
+  each = traversed
+  {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' ('HashMap' c a) ('HashMap' c b) a b@
-instance (c ~ d) => Each (HashMap c a) (HashMap d b) a b
+instance (c ~ d) => Each (HashMap c a) (HashMap d b) a b where
+  each = traversed
+  {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' [a] [b] a b@
-instance Each [a] [b] a b
+instance Each [a] [b] a b where
+  each = traversed
+  {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' (NonEmpty a) (NonEmpty b) a b@
 instance Each (NonEmpty a) (NonEmpty b) a b
@@ -156,7 +164,9 @@ instance Each (Identity a) (Identity b) a b
 instance Each (Maybe a) (Maybe b) a b
 
 -- | @'each' :: 'Traversal' ('Seq' a) ('Seq' b) a b@
-instance Each (Seq a) (Seq b) a b
+instance Each (Seq a) (Seq b) a b where
+  each = traversed
+  {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' ('Tree' a) ('Tree' b) a b@
 instance Each (Tree a) (Tree b) a b

--- a/src/Control/Lens/Each.hs
+++ b/src/Control/Lens/Each.hs
@@ -30,7 +30,6 @@ module Control.Lens.Each
     Each(..)
   ) where
 
-import Control.Lens.Iso
 import Control.Lens.Traversal
 import Control.Lens.Internal.ByteString
 import Data.Array.Unboxed as Unboxed
@@ -44,6 +43,7 @@ import Data.IntMap as IntMap
 import Data.List.NonEmpty
 import Data.Map as Map
 import Data.Sequence as Seq
+import Data.Text.Lens (text)
 import Data.Text as StrictT
 import Data.Text.Lazy as LazyT
 import Data.Tree as Tree
@@ -183,12 +183,12 @@ instance (Unbox a, Unbox b) => Each (Unboxed.Vector a) (Unboxed.Vector b) a b wh
 
 -- | @'each' :: 'Traversal' 'StrictT.Text' 'StrictT.Text' 'Char' 'Char'@
 instance (a ~ Char, b ~ Char) => Each StrictT.Text StrictT.Text a b where
-  each = iso StrictT.unpack StrictT.pack . traversed
+  each = text
   {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' 'LazyT.Text' 'LazyT.Text' 'Char' 'Char'@
 instance (a ~ Char, b ~ Char) => Each LazyT.Text LazyT.Text a b where
-  each = iso LazyT.unpack LazyT.pack . traverse
+  each = text
   {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' 'StrictB.ByteString' 'StrictB.ByteString' 'Word8' 'Word8'@

--- a/src/Control/Lens/Each.hs
+++ b/src/Control/Lens/Each.hs
@@ -32,6 +32,7 @@ module Control.Lens.Each
 
 import Control.Lens.Iso
 import Control.Lens.Traversal
+import Control.Lens.Internal.ByteString
 import Data.Array.Unboxed as Unboxed
 import Data.Array.IArray as IArray
 import Data.ByteString as StrictB
@@ -192,12 +193,12 @@ instance (a ~ Char, b ~ Char) => Each LazyT.Text LazyT.Text a b where
 
 -- | @'each' :: 'Traversal' 'StrictB.ByteString' 'StrictB.ByteString' 'Word8' 'Word8'@
 instance (a ~ Word8, b ~ Word8) => Each StrictB.ByteString StrictB.ByteString a b where
-  each = iso StrictB.unpack StrictB.pack . traverse
+  each = traversedStrictTree
   {-# INLINE each #-}
 
 -- | @'each' :: 'Traversal' 'LazyB.ByteString' 'LazyB.ByteString' 'Word8' 'Word8'@
 instance (a ~ Word8, b ~ Word8) => Each LazyB.ByteString LazyB.ByteString a b where
-  each = iso LazyB.unpack LazyB.pack . traverse
+  each = traversedLazy
   {-# INLINE each #-}
 
 -- | @'each' :: 'Ix' i => 'Traversal' ('Array' i a) ('Array' i b) a b@

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -208,7 +208,7 @@ ifolding sfa f = coerce . traverse_ (coerce . uncurry (indexed f)) . sfa
 -- | Obtain a 'Fold' by lifting 'foldr' like function.
 --
 -- >>> [1,2,3,4]^..foldring foldr
--- [2,3,4]
+-- [1,2,3,4]
 foldring :: (Contravariant f, Applicative f) => ((a -> f a -> f a) -> f a -> s -> f a) -> LensLike f s t a b
 foldring fr f = coerce . fr (\a fa -> f a *> fa) noEffect
 {-# INLINE foldring #-}
@@ -229,20 +229,20 @@ ifoldring ifr f = coerce . ifr (\i a fa -> indexed f i a *> fa) noEffect
 -- >>> [(1,2),(3,4)]^..folded.both
 -- [1,2,3,4]
 folded :: Foldable f => IndexedFold Int (f a) a
-folded = conjoined (foldring foldr) (ifoldring ifoldr)
+folded = conjoined (foldring Foldable.foldr) (ifoldring ifoldr)
 {-# INLINE folded #-}
 
 ifoldr :: Foldable f => (Int -> a -> b -> b) -> b -> f a -> b
-ifoldr f z xs = foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
+ifoldr f z xs = Foldable.foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
 {-# INLINE ifoldr #-}
 
 -- | Obtain a 'Fold' from any 'Foldable' indexed by ordinal position.
 folded64 :: Foldable f => IndexedFold Int64 (f a) a
-folded64 = conjoined (foldring foldr) (ifoldring ifoldr64)
+folded64 = conjoined (foldring Foldable.foldr) (ifoldring ifoldr64)
 {-# INLINE folded64 #-}
 
 ifoldr64 :: Foldable f => (Int64 -> a -> b -> b) -> b -> f a -> b
-ifoldr64 f z xs = foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
+ifoldr64 f z xs = Foldable.foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
 {-# INLINE ifoldr64 #-}
 
 -- | Form a 'Fold1' by repeating the input forever.

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -52,6 +52,7 @@ module Control.Lens.Fold
 
   -- ** Building Folds
   , folding, ifolding
+  , foldring, ifoldring
   , folded
   , folded64
   , unfolded
@@ -204,6 +205,19 @@ ifolding :: (Foldable f, Indexable i p, Contravariant g, Applicative g) => (s ->
 ifolding sfa f = coerce . traverse_ (coerce . uncurry (indexed f)) . sfa
 {-# INLINE ifolding #-}
 
+-- | Obtain a 'Fold' by lifting 'foldr' like function.
+--
+-- >>> [1,2,3,4]^..foldring foldr
+-- [2,3,4]
+foldring :: (Contravariant f, Applicative f) => ((a -> f a -> f a) -> f a -> s -> f a) -> LensLike f s t a b
+foldring fr f = coerce . fr (\a fa -> f a *> fa) noEffect
+{-# INLINE foldring #-}
+
+-- | Obtain 'FoldWithIndex' by lifting 'ifoldr' like function.
+ifoldring :: (Indexable i p, Contravariant f, Applicative f) => ((i -> a -> f a -> f a) -> f a -> s -> f a) -> Over p f s t a b
+ifoldring ifr f = coerce . ifr (\i a fa -> indexed f i a *> fa) noEffect
+{-# INLINE ifoldring #-}
+
 -- | Obtain a 'Fold' from any 'Foldable' indexed by ordinal position.
 --
 -- >>> Just 3^..folded
@@ -215,17 +229,21 @@ ifolding sfa f = coerce . traverse_ (coerce . uncurry (indexed f)) . sfa
 -- >>> [(1,2),(3,4)]^..folded.both
 -- [1,2,3,4]
 folded :: Foldable f => IndexedFold Int (f a) a
-folded = conjoined folded' (indexing folded')
+folded = conjoined (foldring foldr) (ifoldring ifoldr)
 {-# INLINE folded #-}
+
+ifoldr :: Foldable f => (Int -> a -> b -> b) -> b -> f a -> b
+ifoldr f z xs = foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
+{-# INLINE ifoldr #-}
 
 -- | Obtain a 'Fold' from any 'Foldable' indexed by ordinal position.
 folded64 :: Foldable f => IndexedFold Int64 (f a) a
-folded64 = conjoined folded' (indexing64 folded')
+folded64 = conjoined (foldring foldr) (ifoldring ifoldr64)
 {-# INLINE folded64 #-}
 
-folded' :: Foldable f => Fold (f a) a
-folded' f = coerce . getFolding . foldMap (Folding #. f)
-{-# INLINE folded' #-}
+ifoldr64 :: Foldable f => (Int64 -> a -> b -> b) -> b -> f a -> b
+ifoldr64 f z xs = foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
+{-# INLINE ifoldr64 #-}
 
 -- | Form a 'Fold1' by repeating the input forever.
 --

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -107,7 +107,6 @@ import Data.Map as Map
 import Data.Monoid hiding (Product)
 import Data.Profunctor.Unsafe
 import Data.Sequence hiding ((:<), index)
-import Data.Traversable
 import Data.Tree
 import Data.Tuple (swap)
 import Data.Vector (Vector)
@@ -609,8 +608,8 @@ instance TraversableWithIndex k ((,) k) where
 instance FunctorWithIndex Int []
 instance FoldableWithIndex Int []
 instance TraversableWithIndex Int [] where
-  itraverse = itraverseOf traversed
-  {-# INLINE itraverse #-}
+  itraversed = traversed
+  {-# INLINE itraversed #-}
 
 instance FunctorWithIndex Int NonEmpty
 instance FoldableWithIndex Int NonEmpty
@@ -632,8 +631,8 @@ instance TraversableWithIndex () Maybe where
 instance FunctorWithIndex Int Seq
 instance FoldableWithIndex Int Seq
 instance TraversableWithIndex Int Seq where
-  itraverse = itraverseOf traversed
-  {-# INLINE itraverse #-}
+  itraversed = traversed
+  {-# INLINE itraversed #-}
 
 instance FunctorWithIndex Int Vector where
   imap = V.imap
@@ -648,8 +647,8 @@ instance FoldableWithIndex Int Vector where
   ifoldl' = V.ifoldl' . flip
   {-# INLINE ifoldl' #-}
 instance TraversableWithIndex Int Vector where
-  itraverse f = sequenceA . V.imap f
-  {-# INLINE itraverse #-}
+  itraversed = traversed
+  {-# INLINE itraversed #-}
 
 instance FunctorWithIndex Int IntMap
 instance FoldableWithIndex Int IntMap
@@ -659,7 +658,14 @@ instance TraversableWithIndex Int IntMap where
 #else
   itraverse f = sequenceA . IntMap.mapWithKey f
 #endif
-  {-# INLINE itraverse #-}
+  {-# INLINE [0] itraverse #-}
+
+{-# RULES
+"itraversed -> mapIntMap"    itraversed = sets IntMap.map               :: ASetter (IntMap a) (IntMap b) a b;
+"itraversed -> imapIntMap"   itraversed = isets IntMap.mapWithKey       :: AnIndexedSetter Int (IntMap a) (IntMap b) a b;
+"itraversed -> foldrIntMap"  itraversed = foldring IntMap.foldr         :: Getting (Endo r) (IntMap a) a;
+"itraversed -> ifoldrIntMap" itraversed = ifoldring IntMap.foldrWithKey :: IndexedGetting Int (Endo r) (IntMap a) a;
+ #-}
 
 instance FunctorWithIndex k (Map k)
 instance FoldableWithIndex k (Map k)
@@ -669,13 +675,27 @@ instance TraversableWithIndex k (Map k) where
 #else
   itraverse f = sequenceA . Map.mapWithKey f
 #endif
-  {-# INLINE itraverse #-}
+  {-# INLINE [0] itraverse #-}
+
+{-# RULES
+"itraversed -> mapMap"    itraversed = sets Map.map               :: ASetter (Map k a) (Map k b) a b;
+"itraversed -> imapMap"   itraversed = isets Map.mapWithKey       :: AnIndexedSetter k (Map k a) (Map k b) a b;
+"itraversed -> foldrMap"  itraversed = foldring Map.foldr         :: Getting (Endo r) (Map k a) a;
+"itraversed -> ifoldrMap" itraversed = ifoldring Map.foldrWithKey :: IndexedGetting k (Endo r) (Map k a) a;
+ #-}
 
 instance (Eq k, Hashable k) => FunctorWithIndex k (HashMap k)
 instance (Eq k, Hashable k) => FoldableWithIndex k (HashMap k)
 instance (Eq k, Hashable k) => TraversableWithIndex k (HashMap k) where
   itraverse = HashMap.traverseWithKey
-  {-# INLINE itraverse #-}
+  {-# INLINE [0] itraverse #-}
+
+{-# RULES
+"itraversed -> mapHashMap"    itraversed = sets HashMap.map               :: ASetter (HashMap k a) (HashMap k b) a b;
+"itraversed -> imapHashMap"   itraversed = isets HashMap.mapWithKey       :: AnIndexedSetter k (HashMap k a) (HashMap k b) a b;
+"itraversed -> foldrHashMap"  itraversed = foldring HashMap.foldr         :: Getting (Endo r) (HashMap k a) a;
+"itraversed -> ifoldrHashMap" itraversed = ifoldring HashMap.foldrWithKey :: IndexedGetting k (Endo r) (HashMap k a) a;
+ #-}
 
 instance FunctorWithIndex r ((->) r) where
   imap f g x = f x (g x)

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -128,12 +128,11 @@ import Control.Category
 import Control.Comonad
 import Control.Lens.Fold
 import Control.Lens.Getter (Getting, IndexedGetting, coerced)
-import Control.Lens.Setter (isets, sets)
 import Control.Lens.Internal.Bazaar
 import Control.Lens.Internal.Context
 import Control.Lens.Internal.Indexed
 import Control.Lens.Lens
-import Control.Lens.Setter (ASetter, AnIndexedSetter)
+import Control.Lens.Setter (ASetter, AnIndexedSetter, isets, sets)
 import Control.Lens.Type
 import Control.Monad
 import Control.Monad.Trans.State.Lazy

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -137,6 +137,7 @@ import Control.Lens.Type
 import Control.Monad
 import Control.Monad.Trans.State.Lazy
 import Data.Bitraversable
+import Data.Foldable (Foldable)
 import Data.Functor.Compose
 import Data.Functor.Kan.Rift
 import Data.Functor.Yoneda

--- a/src/Data/Text/Lazy/Lens.hs
+++ b/src/Data/Text/Lazy/Lens.hs
@@ -34,6 +34,7 @@ import Data.Text.Lazy.Encoding
 
 -- $setup
 -- >>> :set -XOverloadedStrings
+-- >>> import Control.Lens
 
 -- | This isomorphism can be used to 'pack' (or 'unpack') lazy 'Text'.
 --

--- a/src/Data/Text/Lazy/Lens.hs
+++ b/src/Data/Text/Lazy/Lens.hs
@@ -19,8 +19,15 @@ module Data.Text.Lazy.Lens
   , utf8
   ) where
 
-import Control.Lens
+import Control.Lens.Type
+import Control.Lens.Getter
+import Control.Lens.Fold
+import Control.Lens.Iso
+import Control.Lens.Prism
+import Control.Lens.Setter
+import Control.Lens.Traversal
 import Data.ByteString.Lazy as ByteString
+import Data.Monoid
 import Data.Text.Lazy as Text
 import Data.Text.Lazy.Builder
 import Data.Text.Lazy.Encoding
@@ -102,7 +109,22 @@ builder = iso fromLazyText toLazyText
 -- can be more efficient.
 text :: IndexedTraversal' Int Text Char
 text = unpacked . traversed
-{-# INLINE text #-}
+{-# INLINE [0] text #-}
+
+{-# RULES
+"lazy text -> map"    text = sets Text.map        :: ASetter' Text Char;
+"lazy text -> imap"   text = isets imapLazy       :: AnIndexedSetter' Int Text Char;
+"lazy text -> foldr"  text = foldring Text.foldr  :: Getting (Endo r) Text Char;
+"lazy text -> ifoldr" text = ifoldring ifoldrLazy :: IndexedGetting Int (Endo r) Text Char;
+ #-}
+
+imapLazy :: (Int -> Char -> Char) -> Text -> Text
+imapLazy f = snd . Text.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
+{-# INLINE imapLazy #-}
+
+ifoldrLazy :: (Int -> Char -> a -> a) -> a -> Text -> a
+ifoldrLazy f z xs = Text.foldr (\ x g i -> i `seq` f i x (g (i+1))) (const z) xs 0
+{-# INLINE ifoldrLazy #-}
 
 -- | Encode/Decode a lazy 'Text' to/from lazy 'ByteString', via UTF-8.
 --

--- a/src/Data/Text/Lens.hs
+++ b/src/Data/Text/Lens.hs
@@ -18,7 +18,9 @@ module Data.Text.Lens
   , _Text
   ) where
 
-import           Control.Lens
+import           Control.Lens.Type
+import           Control.Lens.Iso
+import           Control.Lens.Traversal
 import           Data.Text as Strict
 import qualified Data.Text.Strict.Lens as Strict
 import           Data.Text.Lazy as Lazy
@@ -55,7 +57,7 @@ class IsText t where
 instance IsText String where
   packed = id
   {-# INLINE packed #-}
-  text = indexing traverse
+  text = traversed
   {-# INLINE text #-}
   builder = Lazy.packed . builder
   {-# INLINE builder #-}
@@ -104,3 +106,4 @@ instance IsText Lazy.Text where
   {-# INLINE builder #-}
   text = Lazy.text
   {-# INLINE text #-}
+

--- a/src/Data/Text/Lens.hs
+++ b/src/Data/Text/Lens.hs
@@ -27,6 +27,9 @@ import           Data.Text.Lazy as Lazy
 import qualified Data.Text.Lazy.Lens as Lazy
 import           Data.Text.Lazy.Builder
 
+-- $setup
+-- >>> import Control.Lens
+
 -- | Traversals for strict or lazy 'Text'
 class IsText t where
   -- | This isomorphism can be used to 'pack' (or 'unpack') strict or lazy 'Text'.

--- a/src/Data/Text/Strict/Lens.hs
+++ b/src/Data/Text/Strict/Lens.hs
@@ -34,6 +34,7 @@ import Data.Text.Lazy.Builder
 
 -- $setup
 -- >>> :set -XOverloadedStrings
+-- >>> import Control.Lens
 
 -- | This isomorphism can be used to 'pack' (or 'unpack') strict 'Text'.
 --

--- a/src/Data/Vector/Generic/Lens.hs
+++ b/src/Data/Vector/Generic/Lens.hs
@@ -30,10 +30,18 @@ module Data.Vector.Generic.Lens
   -- * Traversal of individual indices
   , ordinals
   , vectorIx
+  , vectorTraverse
   ) where
 
 import Control.Applicative
-import Control.Lens
+import Control.Lens.Type
+import Control.Lens.Lens
+import Control.Lens.Getter
+import Control.Lens.Fold
+import Control.Lens.Iso
+import Control.Lens.Indexed
+import Control.Lens.Setter
+import Control.Lens.Traversal
 import Control.Lens.Internal.List (ordinalNub)
 import Data.Monoid
 import Data.Vector.Generic as V hiding (zip, filter, indexed)
@@ -122,6 +130,18 @@ vectorIx i f v
   | 0 <= i && i < V.length v = f (v V.! i) <&> \a -> v V.// [(i, a)]
   | otherwise                = pure v
 {-# INLINE vectorIx #-}
+
+-- | Indexed vector traversal for a generic vector.
+vectorTraverse :: (V.Vector v a, V.Vector w b) => IndexedTraversal Int (v a) (w b) a b
+vectorTraverse f v = V.fromListN (V.length v) <$> traversed f (V.toList v)
+{-# INLINE [0] vectorTraverse #-}
+
+{-# RULES
+"vectorTraverse -> mapped" vectorTraverse  = sets V.map         :: (V.Vector v a, V.Vector v b) => ASetter (v a) (v b) a b;
+"vectorTraverse -> imapped" vectorTraverse = isets V.imap       :: (V.Vector v a, V.Vector v b) => AnIndexedSetter Int (v a) (v b) a b;
+"vectorTraverse -> foldr"  vectorTraverse  = foldring V.foldr   :: V.Vector v a => Getting (Endo r) (v a) a;
+"vectorTraverse -> ifoldr" vectorTraverse  = ifoldring V.ifoldr :: V.Vector v a => IndexedGetting Int (Endo r) (v a) a;
+ #-}
 
 -- | Different vector implementations are isomorphic to each other.
 converted :: (Vector v a, Vector w a, Vector v b, Vector w b) => Iso (v a) (v b) (w a) (w b)


### PR DESCRIPTION
These rewrite rules specialise a traversal when it's used as a (indexed) setter or getter. This can provide a significant performance boost, especially for indexed variants and functions over unboxed containers.

This is done by rewriting the traversal to use `sets` or `isets` when it's used as `ASetter` or `AnIndexedSetter` or the new `foldring` and `ifoldring` (not great names) with a `Getting` or `IndexedGetting`.

`foldring` and `ifoldring` take a `foldr` like function and turns it into a `Fold`. These are useful for defining rewrite rules. I've also redefined `folded` in terms of these because indexed folds perform better without using `indexing`. In my tests the new `folded` performs at least as well as the old version but there may be some issue's I haven't thought of.

Because the rewrite rules only depend on the context the traversal is used, not their arguments/what they're applied to, they have a good fire rate. Rules still fire when they're composed / defined as part of another function.

I've also added benchmarks for common traversals and folds.