### PR TITLE
Fix lens to compile against 'bytestring < 0.10.4'

### DIFF
--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -45,9 +45,7 @@ import Control.Lens.Fold
 import Control.Lens.Indexed
 import Control.Lens.Setter
 import qualified Data.ByteString               as B
-#if MIN_VERSION_bytestring(0,10,4)
 import qualified Data.ByteString.Char8         as B8
-#endif
 import qualified Data.ByteString.Lazy          as BL
 import qualified Data.ByteString.Lazy.Char8    as BL8
 import qualified Data.ByteString.Internal      as BI


### PR DESCRIPTION
There was an `#ifdef` around the import of `Data.ByteString.Char8` in the
`Control.Lens.Internal.ByteString` module that got rid of the import for
`bytestring` versions less than `0.10.4`, however other functions within the
module still require this import because they are not guarded by an `#ifdef`.