### PR TITLE
Moving arguments to the right in Control.Lens.At

### DIFF
--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -130,17 +130,17 @@ class Contains m where
   contains :: Index m -> Lens' m Bool
 
 instance Contains IntSet where
-  contains k f s = f (IntSet.member k s) <&> \b ->
+  contains k = \f s -> f (IntSet.member k s) <&> \b ->
     if b then IntSet.insert k s else IntSet.delete k s
   {-# INLINE contains #-}
 
 instance Ord a => Contains (Set a) where
-  contains k f s = f (Set.member k s) <&> \b ->
+  contains k = \f s -> f (Set.member k s) <&> \b ->
     if b then Set.insert k s else Set.delete k s
   {-# INLINE contains #-}
 
 instance (Eq a, Hashable a) => Contains (HashSet a) where
-  contains k f s = f (HashSet.member k s) <&> \b ->
+  contains k = \f s -> f (HashSet.member k s) <&> \b ->
     if b then HashSet.insert k s else HashSet.delete k s
   {-# INLINE contains #-}
 

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -391,49 +391,55 @@ sans k m = m & at k .~ Nothing
 {-# INLINE sans #-}
 
 instance At (Maybe a) where
-  at () f = f
+  at () = \f -> f
   {-# INLINE at #-}
 
 instance At (IntMap a) where
-  at k f m = f mv <&> \r -> case r of
+  at k = \f m ->
+    let mv = IntMap.lookup k m
+    in f mv <&> \r -> case r of
     Nothing -> maybe m (const (IntMap.delete k m)) mv
     Just v' -> IntMap.insert k v' m
-    where mv = IntMap.lookup k m
   {-# INLINE at #-}
 
 instance Ord k => At (Map k a) where
-  at k f m = f mv <&> \r -> case r of
+  at k = \f m ->
+    let mv = Map.lookup k m
+    in f mv <&> \r -> case r of
     Nothing -> maybe m (const (Map.delete k m)) mv
     Just v' -> Map.insert k v' m
-    where mv = Map.lookup k m
   {-# INLINE at #-}
 
 instance (Eq k, Hashable k) => At (HashMap k a) where
-  at k f m = f mv <&> \r -> case r of
+  at k = \f m ->
+    let mv = HashMap.lookup k m
+    in f mv <&> \r -> case r of
     Nothing -> maybe m (const (HashMap.delete k m)) mv
     Just v' -> HashMap.insert k v' m
-    where mv = HashMap.lookup k m
   {-# INLINE at #-}
 
 instance At IntSet where
-  at k f m = f mv <&> \r -> case r of
+  at k = \f m ->
+    let mv = if IntSet.member k m then Just () else Nothing
+    in f mv <&> \r -> case r of
     Nothing -> maybe m (const (IntSet.delete k m)) mv
     Just () -> IntSet.insert k m
-    where mv = if IntSet.member k m then Just () else Nothing
   {-# INLINE at #-}
 
 instance Ord k => At (Set k) where
-  at k f m = f mv <&> \r -> case r of
+  at k = \f m ->
+    let mv = if Set.member k m then Just () else Nothing
+    in f mv <&> \r -> case r of
     Nothing -> maybe m (const (Set.delete k m)) mv
     Just () -> Set.insert k m
-    where mv = if Set.member k m then Just () else Nothing
   {-# INLINE at #-}
 
 instance (Eq k, Hashable k) => At (HashSet k) where
-  at k f m = f mv <&> \r -> case r of
+  at k = \f m ->
+    let mv = if HashSet.member k m then Just () else Nothing
+    in f mv <&> \r -> case r of
     Nothing -> maybe m (const (HashSet.delete k m)) mv
     Just () -> HashSet.insert k m
-    where mv = if HashSet.member k m then Just () else Nothing
   {-# INLINE at #-}
 
 

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -404,7 +404,7 @@ sans k m = m & at k .~ Nothing
 {-# INLINE sans #-}
 
 instance At (Maybe a) where
-  at () = \f -> f
+  at () = id
   {-# INLINE at #-}
 
 instance At (IntMap a) where


### PR DESCRIPTION
I've tried applying #183 to the instances in Control.Lens.At. One thing I'm unsure about is the translation from guards to if-then-else in cases where the lambda-ized arguments are part of the guard expression.