### PR TITLE
Move type synonyms to their assumed location

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -168,7 +168,6 @@ import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
-import Data.Reflection
 import Data.Traversable
 import Prelude hiding (foldr)
 

--- a/src/Control/Lens/Review.hs
+++ b/src/Control/Lens/Review.hs
@@ -40,7 +40,6 @@ import Control.Monad.Reader as Reader
 import Control.Monad.State as State
 import Control.Lens.Getter
 import Control.Lens.Internal.Review
-import Control.Lens.Internal.Setter
 import Control.Lens.Type
 import Data.Bifunctor
 import Data.Functor.Identity
@@ -61,18 +60,6 @@ infixr 8 #
 ------------------------------------------------------------------------------
 -- Review
 ------------------------------------------------------------------------------
-
--- | This is a limited form of a 'Prism' that can only be used for 're' operations.
---
--- Like with a 'Getter', there are no laws to state for a 'Review'.
---
--- You can generate a 'Review' by using 'unto'. You can also use any 'Prism' or 'Iso'
--- directly as a 'Review'.
-type Review t b = forall p f. (Choice p, Bifunctor p, Settable f) => Optic' p f t b
-
--- | If you see this in a signature for a function, the function is expecting a 'Review'
--- (in practice, this usually means a 'Prism').
-type AReview t b = Optic' Tagged Identity t b
 
 -- | An analogue of 'to' for 'review'.
 --

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -28,6 +28,7 @@ module Control.Lens.Type
     Equality, Equality', As
   , Iso, Iso'
   , Prism , Prism'
+  , Review , AReview
   -- * Lenses, Folds and Traversals
   , Lens, Lens'
   , Traversal, Traversal'
@@ -61,9 +62,12 @@ module Control.Lens.Type
 import Control.Applicative
 import Control.Lens.Internal.Setter
 import Control.Lens.Internal.Indexed
+import Data.Bifunctor
+import Data.Functor.Identity
 import Data.Functor.Contravariant
 import Data.Functor.Apply
 import Data.Profunctor
+import Data.Tagged
 import Prelude ()
 
 -- $setup
@@ -328,6 +332,22 @@ type Iso s t a b = forall p f. (Profunctor p, Functor f) => p a (f b) -> p s (f 
 -- type 'Iso'' = 'Control.Lens.Type.Simple' 'Iso'
 -- @
 type Iso' s a = Iso s s a a
+
+------------------------------------------------------------------------------
+-- Review Internals
+------------------------------------------------------------------------------
+
+-- | This is a limited form of a 'Prism' that can only be used for 're' operations.
+--
+-- Like with a 'Getter', there are no laws to state for a 'Review'.
+--
+-- You can generate a 'Review' by using 'unto'. You can also use any 'Prism' or 'Iso'
+-- directly as a 'Review'.
+type Review t b = forall p f. (Choice p, Bifunctor p, Settable f) => Optic' p f t b
+
+-- | If you see this in a signature for a function, the function is expecting a 'Review'
+-- (in practice, this usually means a 'Prism').
+type AReview t b = Optic' Tagged Identity t b
 
 ------------------------------------------------------------------------------
 -- Prism Internals


### PR DESCRIPTION
Lens has a bug where the TH code [assumes](https://github.com/ekmett/lens/blob/master/src/Control/Lens/Internal/TH.hs#L162) that Review is in `Control.Lens.Type`, but it isn't.

This program is a minimal example reproducing the bug:
```
{-# LANGUAGE TemplateHaskell #-}
{-# LANGUAGE GADTs #-}
import Control.Lens
data A where A :: a -> A
makePrisms ''A
```

The error generated by GHC is:
```
lensbug.hs:5:1-14: Can't find interface-file declaration for type constructor or class Control.Lens.Type.Review …
      Probable cause: bug in .hi-boot file, or inconsistent .hi file
      Use -ddump-if-trace to get an idea of which file caused the error
    In the type signature for ‘_A’:
      _A :: forall a_a7aq. Control.Lens.Type.Review A a_a7aq
Compilation failed.
```

This PR is about moving the `Review` and `AReview` type synonyms to where they are expected to be, similarly to other synonyms. It also removes an unused import.