### PR TITLE
Use sequence numbers in generated symbol names

### DIFF
--- a/src/Control/Lens/Internal/FieldTH.hs
+++ b/src/Control/Lens/Internal/FieldTH.hs
@@ -397,7 +397,7 @@ makeFieldClauses rules opticType cons =
 -- constructor.
 makePureClause :: Name -> Int -> ClauseQ
 makePureClause conName fieldCount =
-  do xs <- replicateM fieldCount (newName "x")
+  do xs <- mapM (newName . ("x" ++) . show) [1..fieldCount]
      -- clause: _ (Con x1..xn) = pure (Con x1..xn)
      clause [wildP, conP conName (map varP xs)]
             (normalB (appE (varE pureValName) (appsE (conE conName : map varE xs))))
@@ -410,7 +410,7 @@ makeGetterClause :: Name -> Int -> [Int] -> ClauseQ
 makeGetterClause conName fieldCount []     = makePureClause conName fieldCount
 makeGetterClause conName fieldCount fields =
   do f  <- newName "f"
-     xs <- replicateM (length fields) (newName "x")
+     xs <- mapM (newName . ("x" ++) . show) [1..(length fields)]
 
      let pats (i:is) (y:ys)
            | i `elem` fields = varP y : pats is ys
@@ -435,8 +435,8 @@ makeFieldOpticClause conName fieldCount [] _ =
   makePureClause conName fieldCount
 makeFieldOpticClause conName fieldCount (field:fields) irref =
   do f  <- newName "f"
-     xs <- replicateM fieldCount          (newName "x")
-     ys <- replicateM (1 + length fields) (newName "y")
+     xs <- mapM (newName . ("x" ++) . show) [1..fieldCount]
+     ys <- mapM (newName . ("y" ++) . show) [1..(1 + length fields)]
 
      let xs' = foldr (\(i,x) -> set (ix i) x) xs (zip (field:fields) ys)
 

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -306,7 +306,7 @@ makeConReviewExp con = appE (varE untoValName) reviewer
 -- (\(x,y,z) -> Con x y z) :: b -> t
 makeReviewer :: Name -> Int -> ExpQ
 makeReviewer conName fields =
-  do xs <- replicateM fields (newName "x")
+  do xs <- mapM (newName . ("x" ++) . show) [1..fields]
      lam1E (toTupleP (map varP xs))
            (conE conName `appsE1` map varE xs)
 
@@ -321,7 +321,7 @@ makeReviewer conName fields =
 makeSimpleRemitter :: Name -> Int -> ExpQ
 makeSimpleRemitter conName fields =
   do x  <- newName "x"
-     xs <- replicateM fields (newName "y")
+     xs <- mapM (newName . ("y" ++) . show) [1..fields]
      let matches =
            [ match (conP conName (map varP xs))
                    (normalB (appE (conE rightDataName) (toTupleE (map varE xs))))
@@ -343,7 +343,7 @@ makeFullRemitter cons target =
      lam1E (varP x) (caseE (varE x) (map mkMatch cons))
   where
   mkMatch (NCon conName _ n) =
-    do xs <- replicateM (length n) (newName "y")
+    do xs <- mapM (newName . ("y" ++) . show) [1..(length n)]
        match (conP conName (map varP xs))
              (normalB
                (if conName == target
@@ -357,7 +357,7 @@ makeFullRemitter cons target =
 -- (\(Con x y z) -> (x,y,z)) :: s -> a
 makeIsoRemitter :: Name -> Int -> ExpQ
 makeIsoRemitter conName fields =
-  do xs <- replicateM fields (newName "x")
+  do xs <- mapM (newName . ("y" ++) . show) [1..fields]
      lam1E (conP conName (map varP xs))
            (toTupleE (map varE xs))
 


### PR DESCRIPTION
I find myself needing to take the output of template haskell and turn it into a source file.  This is because running template haskell under ghcjs is extremely slow (like, seconds turn into hours) and consumes a lot of memory (more than I have.)  I also strip off the module qualifiers and the suffixes added by newName.  The first is because the module qualifiers are often for private unexported modules, and also because in the template haskell output the qualifiers appear in places where they are illegal.  I strip off the newName suffixes because I want the code to be human readable, and I want it to be reproducible to help detect any unexpected changes.

For these reasons, I have made the changes included here, which replace uses of

    replicateM count (newName "x")

with

    mapM (newName . ("x" ++) . show) [1..count]