### PR TITLE
Make Equality poly-kinded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ wip
 cabal.sandbox.config
 .stack-work/
 codex.tags
+.stack-work/

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ wip
 cabal.sandbox.config
 .stack-work/
 codex.tags
-.stack-work/

--- a/src/Control/Lens/Equality.hs
+++ b/src/Control/Lens/Equality.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TypeFamilies #-}
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
 -----------------------------------------------------------------------------
@@ -32,11 +32,7 @@ module Control.Lens.Equality
   ) where
 
 import Control.Lens.Type
-#if __GLASGOW_HASKELL__ >= 708
 import Data.Proxy (Proxy)
-#else
-import Data.Functor.Identity (Identity)
-#endif
 
 #ifdef HLINT
 {-# ANN module "HLint: ignore Use id" #-}
@@ -50,17 +46,16 @@ import Data.Functor.Identity (Identity)
 -- Equality
 -----------------------------------------------------------------------------
 
--- Compatibility shim
-#if __GLASGOW_HASKELL__ < 708
-type Proxy = Identity
-#endif
-
 -- | Provides witness that @(s ~ a, b ~ t)@ holds.
 data Identical a b s t where
   Identical :: Identical a b a b
 
 -- | When you see this as an argument to a function, it expects an 'Equality'.
+#if __GLASGOW_HASKELL__ >= 706
+type AnEquality (s :: k1) (t :: k2) (a :: k1) (b :: k2) = Identical a (Proxy b) a (Proxy b) -> Identical a (Proxy b) s (Proxy t)
+#else
 type AnEquality s t a b = Identical a (Proxy b) a (Proxy b) -> Identical a (Proxy b) s (Proxy t)
+#endif
 
 -- | A 'Simple' 'AnEquality'.
 type AnEquality' s a = AnEquality s s a a
@@ -77,7 +72,7 @@ substEq l = case runEq l of
 {-# INLINE substEq #-}
 
 -- | We can use 'Equality' to do substitution into anything.
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 706
 mapEq :: forall (s :: k1) (t :: k2) (a :: k1) (b :: k2) (f :: k1 -> *) . AnEquality s t a b -> f s -> f a
 #else
 mapEq :: AnEquality s t a b -> f s -> f a

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE KindSignatures #-}
-#if __GLASGOW_HASKELL__ >= 708
+#if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
 -------------------------------------------------------------------------------
@@ -445,6 +445,8 @@ type Prism' s a = Prism s s a a
 -- Note: Composition with an 'Equality' is index-preserving.
 #if __GLASGOW_HASKELL__ >= 708
 type Equality (s :: k1) (t :: k2) (a :: k1) (b :: k2) = forall (p :: k1 -> k3 -> *) (f :: k2 -> k3) . p a (f b) -> p s (f t)
+#elif __GLASGOW_HASKELL__ >= 706
+type Equality (s :: k1) (t :: k2) (a :: k1) (b :: k2) = forall (p :: k1 -> * -> *) (f :: k2 -> *) . p a (f b) -> p s (f t)
 #else
 type Equality s t a b = forall p (f :: * -> *) . p a (f b) -> p s (f t)
 #endif

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE KindSignatures #-}
-#if __GLASGOW_HASKELL__ >= 706
+#if __GLASGOW_HASKELL__ >= 708
 {-# LANGUAGE PolyKinds #-}
 #endif
 -------------------------------------------------------------------------------
@@ -443,7 +443,11 @@ type Prism' s a = Prism s s a a
 -- | A witness that @(a ~ s, b ~ t)@.
 --
 -- Note: Composition with an 'Equality' is index-preserving.
-type Equality s t a b = forall p (f :: * -> *). p a (f b) -> p s (f t)
+#if __GLASGOW_HASKELL__ >= 708
+type Equality (s :: k1) (t :: k2) (a :: k1) (b :: k2) = forall (p :: k1 -> k3 -> *) (f :: k2 -> k3) . p a (f b) -> p s (f t)
+#else
+type Equality s t a b = forall p (f :: * -> *) . p a (f b) -> p s (f t)
+#endif
 
 -- | A 'Simple' 'Equality'.
 type Equality' s a = Equality s s a a


### PR DESCRIPTION
Allow `Equality s t a b` to prove `s ~ a` and `t ~ b` whenever
`s` and `a` have the same kind and `t` and `b` have the same kind.
Fixes  #605 

Specifically, change the definition of `Equality` to

```haskell
type Equality (s :: k1) (t :: k2) (a :: k1) (b :: k2) =
    forall (p :: k1 -> k3 -> *) (f :: k2 -> k3) . p a (f b) -> p s (f t)
```
for `GHC >= 7.8` and to
```haskell
type Equality (s :: k1) (t :: k2) (a :: k1) (b :: k2) =
    forall (p :: k1 -> * -> *) (f :: k2 -> *) . p a (f b) -> p s (f t)
```
for `GHC==7.6`,

and the definition of `AnEquality` to

```haskell
type AnEquality s t a b =
    Identical a (Proxy b) a (Proxy b) -> Identical a (Proxy b) s (Proxy t)
```

for all versions (with appropriate kind signatures for 7.6+).