### PR TITLE
Add .stack-work to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ wip
 *#
 .cabal-sandbox/
 cabal.sandbox.config
+.stack-work/
 codex.tags


### PR DESCRIPTION
When using stack, .stack-work is full of junk that should never
ever be tracked by git. Let's make sure it never is.