### PR TITLE
Control.Lens.TH: more documentation and exports

### DIFF
--- a/src/Control/Lens/Internal/FieldTH.hs
+++ b/src/Control/Lens/Internal/FieldTH.hs
@@ -541,7 +541,7 @@ applyTypeSubst sub = rewrite aux
 -- Field generation parameters
 ------------------------------------------------------------------------
 
-
+-- | Rules to construct lenses for data fields.
 data LensRules = LensRules
   { _simpleLenses    :: Bool
   , _generateSigs    :: Bool

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -170,8 +170,8 @@ lensField f r = fmap (\x -> r { _fieldToDef = x}) (f (_fieldToDef r))
 
 -- | The rule to create function names of lenses for data fields.
 --
--- Most of the time you won't need the first two arguments. It's up to
--- you to use those arguments to define some smart 'LensRules'.
+-- Although it's sometimes useful, you won't need the first two
+-- arguments most of the time.
 type FieldNamer = Name -- ^ Name of the data type that lenses are being generated for.
                   -> [Name] -- ^ Names of all fields (including the field being named) in the data type.
                   -> Name -- ^ Name of the field being named.

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -70,6 +70,7 @@ module Control.Lens.TH
   , generateLazyPatterns
   -- ** FieldNamers
   , underscoreNoPrefixNamer
+  , lookingupNamer
   , camelCaseNamer
   , underscoreNamer
   , abbreviatedNamer
@@ -222,10 +223,11 @@ underscoreNoPrefixNamer _ _ n =
 lensRulesFor ::
   [(String, String)] {- ^ [(Field Name, Definition Name)] -} ->
   LensRules
-lensRulesFor fields = lensRules & lensField .~ mkNameLookup fields
+lensRulesFor fields = lensRules & lensField .~ lookingupNamer fields
 
-mkNameLookup :: [(String,String)] -> FieldNamer
-mkNameLookup kvs _ _ field =
+-- | Create a 'FieldNamer' from explicit pairings of @(fieldName, lensName)@.
+lookingupNamer :: [(String,String)] -> FieldNamer
+lookingupNamer kvs _ _ field =
   [ TopName (mkName v) | (k,v) <- kvs, k == nameBase field]
 
 -- | Rules for making lenses and traversals that precompose another 'Lens'.
@@ -253,7 +255,7 @@ classyRulesFor
   LensRules
 classyRulesFor classFun fields = classyRules
   & lensClass .~ (over (mapped . both) mkName . classFun . nameBase)
-  & lensField .~ mkNameLookup fields
+  & lensField .~ lookingupNamer fields
 
 -- | A 'LensRules' used by 'makeClassy_'.
 classyRules_ :: LensRules

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -71,6 +71,7 @@ module Control.Lens.TH
   -- ** FieldNamers
   , underscoreNoPrefixNamer
   , lookingupNamer
+  , mappingNamer
   , camelCaseNamer
   , underscoreNamer
   , abbreviatedNamer
@@ -229,6 +230,12 @@ lensRulesFor fields = lensRules & lensField .~ lookingupNamer fields
 lookingupNamer :: [(String,String)] -> FieldNamer
 lookingupNamer kvs _ _ field =
   [ TopName (mkName v) | (k,v) <- kvs, k == nameBase field]
+
+-- | Create a 'FieldNamer' from a mapping function. If the function
+-- returns @[]@, it creates no lens for the field.
+mappingNamer :: (String -> [String]) -- ^ A function that maps a @fieldName@ to @lensName@s.
+             -> FieldNamer
+mappingNamer mapper _ _ = fmap (TopName . mkName) . mapper . nameBase
 
 -- | Rules for making lenses and traversals that precompose another 'Lens'.
 classyRules :: LensRules

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -43,19 +43,23 @@ module Control.Lens.TH
   -- ** Wrapped
   , declareWrapped
   -- * Configuring Lenses
+  -- ** Running LensRules
   , makeLensesWith
   , declareLensesWith
-  , defaultFieldRules
-  , camelCaseFields
-  , underscoreFields
-  , abbreviatedFields
+  -- ** LensRules type
   , LensRules
-  , DefName(..)
+  -- ** Predefined LensRules
   , lensRules
   , lensRulesFor
   , classyRules
   , classyRules_
+  , defaultFieldRules
+  , camelCaseFields
+  , underscoreFields
+  , abbreviatedFields
+  -- ** LensRules configuration accessors
   , lensField
+  , DefName(..)
   , lensClass
   , simpleLenses
   , createClass
@@ -239,6 +243,7 @@ classyRulesFor classFun fields = classyRules
   & lensClass .~ (over (mapped . both) mkName . classFun . nameBase)
   & lensField .~ mkNameLookup fields
 
+-- | A 'LensRules' used by 'makeClassy_'.
 classyRules_ :: LensRules
 classyRules_
   = classyRules & lensField .~ \_ _ n -> [TopName (mkName ('_':nameBase n))]

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -24,18 +24,24 @@
 module Control.Lens.TH
   (
   -- * Constructing Lenses Automatically
+  -- ** Lenses for data fields
     makeLenses, makeLensesFor
   , makeClassy, makeClassyFor, makeClassy_
+  , makeFields
+  -- ** Prisms
   , makePrisms
   , makeClassyPrisms
+  -- ** Wrapped
   , makeWrapped
-  , makeFields
   -- * Constructing Lenses Given a Declaration Quote
+  -- ** Lenses for data fields
   , declareLenses, declareLensesFor
   , declareClassy, declareClassyFor
-  , declarePrisms
-  , declareWrapped
   , declareFields
+  -- ** Prisms
+  , declarePrisms
+  -- ** Wrapped
+  , declareWrapped
   -- * Configuring Lenses
   , makeLensesWith
   , declareLensesWith

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -68,6 +68,10 @@ module Control.Lens.TH
   , generateSignatures
   , generateUpdateableOptics
   , generateLazyPatterns
+  -- ** FieldNamers
+  , camelCaseNamer
+  , underscoreNamer
+  , abbreviatedNamer
   ) where
 
 #if !MIN_VERSION_base(4,8,0)
@@ -616,6 +620,7 @@ overHead f (x:xs) = f x : xs
 underscoreFields :: LensRules
 underscoreFields = defaultFieldRules & lensField .~ underscoreNamer
 
+-- | A 'FieldNamer' for 'underscoreFields'.
 underscoreNamer :: FieldNamer
 underscoreNamer _ _ field = maybeToList $ do
   _      <- prefix field'
@@ -639,6 +644,7 @@ underscoreNamer _ _ field = maybeToList $ do
 camelCaseFields :: LensRules
 camelCaseFields = defaultFieldRules
 
+-- | A 'FieldNamer' for 'camelCaseFields'.
 camelCaseNamer :: FieldNamer
 camelCaseNamer tyName fields field = maybeToList $ do
 
@@ -667,6 +673,7 @@ camelCaseNamer tyName fields field = maybeToList $ do
 abbreviatedFields :: LensRules
 abbreviatedFields = defaultFieldRules { _fieldToDef = abbreviatedNamer }
 
+-- | A 'FieldNamer' for 'abbreviatedFields'.
 abbreviatedNamer :: FieldNamer
 abbreviatedNamer _ fields field = maybeToList $ do
 

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -369,5 +369,47 @@ makeLenses ''PureNoFields
 data ReviewTest where ReviewTest :: a -> ReviewTest
 makePrisms ''ReviewTest
 
+
+-- test FieldNamers
+
+data CheckUnderscoreNoPrefixNamer = CheckUnderscoreNoPrefixNamer
+                                    { _fieldUnderscoreNoPrefix :: Int }
+makeLensesWith (lensRules & lensField .~ underscoreNoPrefixNamer ) ''CheckUnderscoreNoPrefixNamer
+checkUnderscoreNoPrefixNamer :: Lens' CheckUnderscoreNoPrefixNamer Int
+checkUnderscoreNoPrefixNamer = fieldUnderscoreNoPrefix
+
+-- how can we test NOT generating a lens for some fields?
+
+data CheckMappingNamer = CheckMappingNamer
+                         { fieldMappingNamer :: String }
+makeLensesWith (lensRules & lensField .~ (mappingNamer (return . ("hogehoge_" ++)))) ''CheckMappingNamer
+checkMappingNamer :: Lens' CheckMappingNamer String
+checkMappingNamer = hogehoge_fieldMappingNamer
+
+data CheckLookingupNamer = CheckLookingupNamer
+                           { fieldLookingupNamer :: Int }
+makeLensesWith (lensRules & lensField .~ (lookingupNamer [("fieldLookingupNamer", "foobarFieldLookingupNamer")])) ''CheckLookingupNamer
+checkLookingupNamer :: Lens' CheckLookingupNamer Int
+checkLookingupNamer = foobarFieldLookingupNamer
+
+data CheckUnderscoreNamer = CheckUnderscoreNamer
+                            { _hogeprefix_fieldCheckUnderscoreNamer :: Int }
+makeLensesWith (defaultFieldRules & lensField .~ underscoreNamer) ''CheckUnderscoreNamer
+checkUnderscoreNamer :: Lens' CheckUnderscoreNamer Int
+checkUnderscoreNamer = fieldCheckUnderscoreNamer
+
+data CheckCamelCaseNamer = CheckCamelCaseNamer
+                           { _checkCamelCaseNamerFieldCamelCaseNamer :: Int }
+makeLensesWith (defaultFieldRules & lensField .~ camelCaseNamer) ''CheckCamelCaseNamer
+checkCamelCaseNamer :: Lens' CheckCamelCaseNamer Int
+checkCamelCaseNamer = fieldCamelCaseNamer
+
+data CheckAbbreviatedNamer = CheckAbbreviatedNamer
+                             { _hogeprefixFieldAbbreviatedNamer :: Int }
+makeLensesWith (defaultFieldRules & lensField .~ abbreviatedNamer ) ''CheckAbbreviatedNamer
+checkAbbreviatedNamer :: Lens' CheckAbbreviatedNamer Int
+checkAbbreviatedNamer = fieldAbbreviatedNamer
+
+
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
This patch is mainly for `Control.Lens.TH`.

- Introduce subsections to the document.
- Add and export type-synonyms `FieldNamer` and `ClassyNamer`.
- Export the namers that were hidden.
- Add and export `mappingNamer`.

I just wanted `mappingNamer` to configure `LensRules` easily (See also: http://stackoverflow.com/questions/17132514/generating-lenses-for-a-lens-library-with-a-custom-name-processor-instead-of-t ) However, I think exporting namers helps users understand how LensRules work.
