### PR TITLE
Free Zoom

### DIFF
--- a/src/Control/Lens/Internal/Zoom.hs
+++ b/src/Control/Lens/Internal/Zoom.hs
@@ -232,6 +232,20 @@ instance Applicative (k (Err e s)) => Applicative (FocusingErr e k s) where
 -- 'Control.Monad.Trans.FreeT'
 newtype FocusingFree f m k s a = FocusingFree { unfocusingFree :: k (FreeF f s (FreeT f m s)) a }
 
+instance Functor (k (FreeF f s (FreeT f m s))) => Functor (FocusingFree f m k s) where
+  fmap f (FocusingFree as) = FocusingFree (fmap f as)
+  {-# INLINE fmap #-}
+
+instance Apply (k (FreeF f s (FreeT f m s))) => Apply (FocusingFree f m k s) where
+  FocusingFree kf <.> FocusingFree ka = FocusingFree (kf <.> ka)
+  {-# INLINE (<.>) #-}
+
+instance Applicative (k (FreeF f s (FreeT f m s))) => Applicative (FocusingFree f m k s) where
+  pure = FocusingFree . pure
+  {-# INLINE pure #-}
+  FocusingFree kf <*> FocusingFree ka = FocusingFree (kf <*> ka)
+  {-# INLINE (<*>) #-}
+
 -----------------------------------------------------------------------------
 --- Effect
 -------------------------------------------------------------------------------

--- a/src/Control/Lens/Internal/Zoom.hs
+++ b/src/Control/Lens/Internal/Zoom.hs
@@ -24,6 +24,7 @@ module Control.Lens.Internal.Zoom
   , FocusingOn(..)
   , FocusingMay(..), May(..)
   , FocusingErr(..), Err(..)
+  , FocusingFree(..)
   -- * Magnify
   , Effect(..)
   , EffectRWS(..)
@@ -33,6 +34,7 @@ import Control.Applicative
 import Control.Category
 import Control.Comonad
 import Control.Monad.Reader as Reader
+import Control.Monad.Trans.Free
 import Data.Functor.Bind
 import Data.Functor.Contravariant
 import Data.Semigroup
@@ -221,6 +223,14 @@ instance Applicative (k (Err e s)) => Applicative (FocusingErr e k s) where
   {-# INLINE pure #-}
   FocusingErr kf <*> FocusingErr ka = FocusingErr (kf <*> ka)
   {-# INLINE (<*>) #-}
+
+------------------------------------------------------------------------------
+-- FocusingFree
+------------------------------------------------------------------------------
+
+-- | Used by 'Control.Lens.Zoom.Zoom' to 'Control.Lens.Zoom.zoom' into
+-- 'Control.Monad.Trans.FreeT'
+newtype FocusingFree f m k s a = FocusingFree { unfocusingFree :: k (FreeF f s (FreeT f m s)) a }
 
 -----------------------------------------------------------------------------
 --- Effect


### PR DESCRIPTION
This adds an instance of Zoom for the free monad transformer. There are a few things of note:

This removes the `Zoomed m ~ Zoomed n` constraint. It is a nice thing to have in theory, but for a recursive instance like this, it can't be satisfied, or at least can't be satisfied without some gymnastics I haven't worked out.

The behaviour could get kind of unintuitive when applied to multiple layers of free monad. A single value of type `FreeT f m a` can have many different `m (...)` values in it, and these will each get zoomed separately. While this is totally find with a `Lens`, it could cause weirdness for a `Traversal` if you expect it to coalesce all the values into one.

I haven't really thought about the behaviour of the `Traversal` here and/or whether it makes sense, I've just defined the obvious instance. It's quite possible that it doesn't make sense and that there is no sensible way to implement it, or perhaps there is a sensible way to implement it and this boring one wasn't it. If this is an issue, it's easy enough to remove the `Apply` and `Applicative` instances so that you can only zoom on it with a proper `Lens`.

I haven't touched Magnify, primarily because I have yaks of my own to shave.