### PR TITLE
Add Prisms for URec data family instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 4.15
 ----
 * Remove `Generics.Deriving.Lens` module.
+* Incorporate `URec`, which was introduced in `GHC.Generics` in `base-4.9`. For compatibility with older versions of `base`, `lens` now conditionally depends on `generic-deriving`
 
 4.14
 ----
@@ -281,7 +282,7 @@
 * Many performance optimizations.
 * Switched to `exceptions` from `MonadCatchIO-transformers`
 * Added types for working with `RelevantFold` and `RelevantTraversal`. These are a `Fold` or `Traversal` that always has at least one target. Since `Apply` isn't a superclass of `Applicative`, you occasionally need to convert between them, but it lets you more readily work with less unsafety.
-* Changed `unwrapping` and `wrapping` to have the same constructor-oriented order as a `Prism` and renamed them t `_Wrapping` and `_Unwrapping` respectively. 
+* Changed `unwrapping` and `wrapping` to have the same constructor-oriented order as a `Prism` and renamed them t `_Wrapping` and `_Unwrapping` respectively.
 * Drastically changed the way `_Wrapping` and `_Unwrapping` are built to get much better inference.
 * There are about 15,000 lines of patches over the last year, so I'm sure we missed a few big changes.
 

--- a/lens.cabal
+++ b/lens.cabal
@@ -211,6 +211,9 @@ library
     vector                    >= 0.9      && < 0.12,
     void                      >= 0.5      && < 1
 
+  if impl(ghc < 8.0)
+    build-depends: generic-deriving >= 1.10 && < 2
+
   exposed-modules:
     Control.Exception.Lens
     Control.Lens

--- a/src/GHC/Generics/Lens.hs
+++ b/src/GHC/Generics/Lens.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -37,10 +38,21 @@ module GHC.Generics.Lens
   , _M1
   , _L1
   , _R1
+  , _UAddr
+  , _UChar
+  , _UDouble
+  , _UFloat
+  , _UInt
+  , _UWord
   ) where
 
 import Control.Lens
+import GHC.Exts (Char(..), Double(..), Float(..), Int(..), Ptr(..), Word(..))
 import GHC.Generics
+
+#ifdef MIN_VERSION_generic_deriving
+import Generics.Deriving.Base
+#endif
 
 _V1 :: Over p f (V1 s) (V1 t) a b
 _V1 _ = absurd where
@@ -84,3 +96,45 @@ _R1 = prism remitter reviewer
   reviewer (R1 l) = Right l
   reviewer x = Left x
 {-# INLINE _R1 #-}
+
+_UAddr :: Iso (UAddr p) (UAddr q) (Ptr c) (Ptr d)
+_UAddr = iso remitter reviewer
+  where
+  remitter (UAddr a) = Ptr a
+  reviewer (Ptr a) = UAddr a
+{-# INLINE _UAddr #-}
+
+_UChar :: Iso (UChar p) (UChar q) Char Char
+_UChar = iso remitter reviewer
+  where
+  remitter (UChar c) = C# c
+  reviewer (C# c) = UChar c
+{-# INLINE _UChar #-}
+
+_UDouble :: Iso (UDouble p) (UDouble q) Double Double
+_UDouble = iso remitter reviewer
+  where
+  remitter (UDouble d) = D# d
+  reviewer (D# d) = UDouble d
+{-# INLINE _UDouble #-}
+
+_UFloat :: Iso (UFloat p) (UFloat q) Float Float
+_UFloat = iso remitter reviewer
+  where
+  remitter (UFloat f) = F# f
+  reviewer (F# f) = UFloat f
+{-# INLINE _UFloat #-}
+
+_UInt :: Iso (UInt p) (UInt q) Int Int
+_UInt = iso remitter reviewer
+  where
+  remitter (UInt i) = I# i
+  reviewer (I# i) = UInt i
+{-# INLINE _UInt #-}
+
+_UWord :: Iso (UWord p) (UWord q) Word Word
+_UWord = iso remitter reviewer
+  where
+  remitter (UWord w) = W# w
+  reviewer (W# w) = UWord w
+{-# INLINE _UWord #-}


### PR DESCRIPTION
These were introduced to `GHC.Generics` in 8.0. Note that for backwards compatibility purposes, this requires incurring a dependency on `generic-deriving` (which `GHC.Generics.Lens` claims to depend on anyway).

Fixes one part of #657.