### PR TITLE
Fix doctests on Windows

### DIFF
--- a/src/System/FilePath/Lens.hs
+++ b/src/System/FilePath/Lens.hs
@@ -39,6 +39,23 @@ import Control.Lens hiding ((<.>))
 -- $setup
 -- >>> :set -XNoOverloadedStrings
 
+{- NB: Be very careful if you are planning to modify the doctest output in
+this module! Path separators are OS-dependent (\\ with Windows, / with Posix),
+so we take great care to avoid using separators in doctest output so that they
+will be valid on all operating systems.
+
+If you find yourself wanting to test a function that uses path separators in
+the output, it would be wise to:
+
+1. Compare the tested expression and the expected results explicitly using (==).
+2. Always use the </> function (and derived combinators) to construct path
+   separators instead of typing them manually. That is, don't type out
+   "foo/bar", but rather "foo" </> "bar".
+
+This way we can avoid leaking path separators into the output. See the doctest
+example for (</>~) for an example of how to do this.
+-}
+
 infixr 4 </>~, <</>~, <<</>~, <.>~, <<.>~, <<<.>~
 infix 4 </>=, <</>=, <<</>=, <.>=, <<.>=, <<<.>=
 

--- a/src/System/FilePath/Lens.hs
+++ b/src/System/FilePath/Lens.hs
@@ -44,8 +44,8 @@ infix 4 </>=, <</>=, <<</>=, <.>=, <<.>=, <<<.>=
 
 -- | Modify the path by adding another path.
 --
--- >>> both </>~ "bin" $ ("hello","world")
--- ("hello/bin","world/bin")
+-- >>> (both </>~ "bin" $ ("hello","world")) == ("hello" </> "bin", "world" </> "bin")
+-- True
 --
 -- @
 -- ('</>~') :: 'Setter' s a 'FilePath' 'FilePath' -> 'FilePath' -> s -> a
@@ -60,8 +60,8 @@ l </>~ n = over l (</> n)
 
 -- | Modify the target(s) of a 'Lens'', 'Iso'', 'Setter'' or 'Traversal'' by adding a path.
 --
--- >>> execState (both </>= "bin") ("hello","world")
--- ("hello/bin","world/bin")
+-- >>> execState (both </>= "bin") ("hello","world") == ("hello" </> "bin", "world" </> "bin")
+-- True
 --
 -- @
 -- ('</>=') :: 'MonadState' s m => 'Setter'' s 'FilePath' -> 'FilePath' -> m ()
@@ -172,8 +172,8 @@ l <<<.>= b = l %%= \a -> (a, a <.> b)
 -- and filename component and the generated basenames are not null and contain no directory
 -- separators.
 --
--- >>> basename .~ "filename" $ "path/name.png"
--- "path/filename.png"
+-- >>> (basename .~ "filename" $ "path" </> "name.png") == "path" </> "filename.png"
+-- True
 basename :: Lens' FilePath FilePath
 basename f p = (<.> takeExtension p) . (takeDirectory p </>) <$> f (takeBaseName p)
 {-# INLINE basename #-}
@@ -184,8 +184,8 @@ basename f p = (<.> takeExtension p) . (takeDirectory p </>) <$> f (takeBaseName
 -- Note: this is /not/ a legal 'Lens' unless the outer 'FilePath' already has a directory component,
 -- and generated directories are not null.
 --
--- >>> "long/path/name.txt" ^. directory
--- "long/path"
+-- >>> (("long" </> "path" </> "name.txt") ^. directory) == "long" </> "path"
+-- True
 directory :: Lens' FilePath FilePath
 directory f p = (</> takeFileName p) <$> f (takeDirectory p)
 {-# INLINE directory #-}
@@ -197,8 +197,8 @@ directory f p = (</> takeFileName p) <$> f (takeDirectory p)
 -- extension 'FilePath' components are either null or start with 'System.FilePath.extSeparator'
 -- and do not contain any internal 'System.FilePath.extSeparator's.
 --
--- >>> extension .~ ".png" $ "path/name.txt"
--- "path/name.png"
+-- >>> (extension .~ ".png" $ "path" </> "name.txt") == "path" </> "name.png"
+-- True
 extension :: Lens' FilePath FilePath
 extension f p = (n <.>) <$> f e
  where
@@ -212,8 +212,8 @@ extension f p = (n <.>) <$> f e
 -- filename 'FilePath' components are not null and do not contain any
 -- elements of 'System.FilePath.pathSeparators's.
 --
--- >>> filename .~ "name.txt" $ "path/name.png"
--- "path/name.txt"
+-- >>> (filename .~ "name.txt" $ "path" </> "name.png") == "path" </> "name.txt"
+-- True
 filename :: Lens' FilePath FilePath
 filename f p = (takeDirectory p </>) <$> f (takeFileName p)
 {-# INLINE filename #-}


### PR DESCRIPTION
Since many of the functions in `System.FilePath.Lens` are defined in terms of `(</>)`, their doctest output varies depending on whether `lens` is compiled on a Unix-like OS or not. As a result, the doctests fail on Windows:

```
### Failure in src\System\FilePath\Lens.hs:47: expression `both </>~ "bin" $ ("hello","world")'
expected: ("hello/bin","world/bin")
 but got: ("hello\\bin","world\\bin")
### Failure in src\System\FilePath\Lens.hs:63: expression `execState (both </>= "bin") ("hello","world")'
expected: ("hello/bin","world/bin")
 but got: ("hello\\bin","world\\bin")
### Failure in src\System\FilePath\Lens.hs:175: expression `basename .~ "filename" $ "path/name.png"'
expected: "path/filename.png"
 but got: "path\\filename.png"
### Failure in src\System\FilePath\Lens.hs:215: expression `filename .~ "name.txt" $ "path/name.png"'
expected: "path/name.txt"
 but got: "path\\name.txt"
Examples: 837  Tried: 837  Errors: 0  Failures: 4
Test suite doctests: FAIL
```

This is an attempt to fix the problem by having the doctests output the result of whether two filepaths are equal, which should avoid any OS-dependent output.