### PR TITLE
Use more efficient functions from containers-0.5.8.1 whenever possible

### DIFF
--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -21,6 +21,10 @@
 #ifndef MIN_VERSION_base
 #define MIN_VERSION_base(x,y,z) 1
 #endif
+
+#ifndef MIN_VERSION_containers
+#define MIN_VERSION_containers(x,y,z) 1
+#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.At
@@ -454,17 +458,25 @@ instance At (Maybe a) where
   {-# INLINE at #-}
 
 instance At (IntMap a) where
+#if MIN_VERSION_containers(0,5,8)
+  at k f m = IntMap.alterF f k m
+#else
   at k f m = f mv <&> \r -> case r of
     Nothing -> maybe m (const (IntMap.delete k m)) mv
     Just v' -> IntMap.insert k v' m
     where mv = IntMap.lookup k m
+#endif
   {-# INLINE at #-}
 
 instance Ord k => At (Map k a) where
+#if MIN_VERSION_containers(0,5,8)
+  at k f m = Map.alterF f k m
+#else
   at k f m = f mv <&> \r -> case r of
     Nothing -> maybe m (const (Map.delete k m)) mv
     Just v' -> Map.insert k v' m
     where mv = Map.lookup k m
+#endif
   {-# INLINE at #-}
 
 instance (Eq k, Hashable k) => At (HashMap k a) where

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -459,7 +459,7 @@ instance At (Maybe a) where
 
 instance At (IntMap a) where
 #if MIN_VERSION_containers(0,5,8)
-  at k f m = IntMap.alterF f k m
+  at k f = IntMap.alterF f k
 #else
   at k f m = f mv <&> \r -> case r of
     Nothing -> maybe m (const (IntMap.delete k m)) mv
@@ -470,7 +470,7 @@ instance At (IntMap a) where
 
 instance Ord k => At (Map k a) where
 #if MIN_VERSION_containers(0,5,8)
-  at k f m = Map.alterF f k m
+  at k f = Map.alterF f k
 #else
   at k f m = f mv <&> \r -> case r of
     Nothing -> maybe m (const (Map.delete k m)) mv

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -653,7 +653,11 @@ instance TraversableWithIndex () Maybe where
 instance FunctorWithIndex Int Seq where
   imap = mapWithIndex
 instance FoldableWithIndex Int Seq where
+#if MIN_VERSION_containers(0,5,8)
+  ifoldMap = foldMapWithIndex
+#else
   ifoldMap f = Data.Foldable.fold . mapWithIndex f
+#endif
   ifoldr = foldrWithIndex
   ifoldl f = foldlWithIndex (flip f)
   {-# INLINE ifoldl #-}

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -658,9 +658,11 @@ instance FoldableWithIndex Int Seq where
   ifoldl f = foldlWithIndex (flip f)
   {-# INLINE ifoldl #-}
 instance TraversableWithIndex Int Seq where
--- The next version of containers will probably offer traverseWithIndex;
--- when that comes out, it should be used for this.
+#if MIN_VERSION_containers(0,5,8)
+  itraverse = traverseWithIndex
+#else
   itraverse f = sequenceA . mapWithIndex f
+#endif
 
 instance FunctorWithIndex Int Vector where
   imap = V.imap

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -99,11 +99,11 @@ import Control.Lens.Type () -- haddocks
 import Data.Char (toLower, isUpper)
 import Data.Foldable hiding (concat, any)
 import Data.List as List
-import qualified Data.Map as Map hiding (toList,map,filter)
+import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Maybe (maybeToList)
 import Data.Monoid
-import qualified Data.Set as Set hiding (toList,map,filter)
+import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Set.Lens
 import Data.Traversable hiding (mapM)

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -99,10 +99,12 @@ import Control.Lens.Type () -- haddocks
 import Data.Char (toLower, isUpper)
 import Data.Foldable hiding (concat, any)
 import Data.List as List
-import Data.Map as Map hiding (toList,map,filter)
+import qualified Data.Map as Map hiding (toList,map,filter)
+import Data.Map (Map)
 import Data.Maybe (maybeToList)
 import Data.Monoid
-import Data.Set as Set hiding (toList,map,filter)
+import qualified Data.Set as Set hiding (toList,map,filter)
+import Data.Set (Set)
 import Data.Set.Lens
 import Data.Traversable hiding (mapM)
 import Language.Haskell.TH

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -152,7 +152,8 @@ import Data.Functor.Day.Curried
 import Data.Functor.Yoneda
 import Data.Int
 import Data.IntMap as IntMap
-import Data.Map as Map
+import qualified Data.Map as Map
+import Data.Map (Map)
 import Data.Sequence (Seq, mapWithIndex)
 import Data.Vector as Vector (Vector, imap)
 import Data.Monoid


### PR DESCRIPTION
With `containers-0.5.8.1` or later, we can use the more efficient `traverseWithIndex` function for the `TraversableWithIndex` instance for `Seq`.

cc'ing @treeowl in case there are other optimizations of this ilk I overlooked.

Fixes #629.