### PR TITLE
Add {Functor,Foldable,Traversable}WithIndex instances recently added to keys

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -3,6 +3,7 @@
 * Remove `Generics.Deriving.Lens` module.
 * Incorporate `URec`, which was introduced in `GHC.Generics` in `base-4.9`. For compatibility with older versions of `base`, `lens` now conditionally depends on `generic-deriving`
 * Add `Rewrapped` instance for `ExceptT`
+* Add `FunctorWithIndex`, `FoldableWithIndex`, and `TraversableWithIndex` instances for `Sum`, `Proxy`, `Tagged` and data types in `GHC.Generics`
 
 4.14
 ----


### PR DESCRIPTION
A bunch of instances have been added to `keys` as of late, so this commit adds their counterparts in `lens`. This provides `FunctorWithIndex`, `FoldableWithIndex`, and `TraversableWithIndex` instances for `Sum`, `Proxy`, `Tagged` and data types in `GHC.Generics`.