### PR TITLE
Add a Generic default implementation for Wrapped

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next
+----
+* Add a `Generic` default implementation for `Wrapped`
+
 4.15.1
 ----
 * Restore the `generic` and `generic1` functions in `GHC.Generics.Lens`

--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -80,7 +80,6 @@ module Control.Lens.Wrapped
 #endif
   -- * Generics
   , _GWrapped'
-  , GWrapped
   ) where
 
 #include "HsBaseConfig.h"
@@ -191,30 +190,22 @@ class Wrapped s where
   -- If your type has a 'Generic' instance, '_Wrapped'' will default to '_GWrapped'',
   -- and you can choose to not override it with your own definition.
   _Wrapped' :: Iso' s (Unwrapped s)
-  default _Wrapped' :: (Generic s, GWrapped (Rep s), Unwrapped s ~ GUnwrapped (Rep s))
+  default _Wrapped' :: (Generic s, D1 d (C1 c (S1 s' (Rec0 a))) ~ Rep s, Unwrapped s ~ GUnwrapped (Rep s))
                     => Iso' s (Unwrapped s)
   _Wrapped' = _GWrapped'
   {-# INLINE _Wrapped' #-}
 
 -- | Implement the '_Wrapped' operation for a type using its 'Generic' instance.
-_GWrapped' :: (Generic s, GWrapped (Rep s), Unwrapped s ~ GUnwrapped (Rep s))
+_GWrapped' :: (Generic s, D1 d (C1 c (S1 s' (Rec0 a))) ~ Rep s, Unwrapped s ~ GUnwrapped (Rep s))
            => Iso' s (Unwrapped s)
-_GWrapped' = iso Generic.from Generic.to . _GWrapped''
+_GWrapped' = iso Generic.from Generic.to . iso remitter reviewer
+  where
+    remitter (M1 (M1 (M1 (K1 x)))) = x
+    reviewer x = M1 (M1 (M1 (K1 x)))
 {-# INLINE _GWrapped' #-}
 
-class GWrapped f where
-  type GUnwrapped f :: *
-  _GWrapped'' :: Iso' (f s) (GUnwrapped f)
-
--- We only need one instance, as all newtypes (and data type with exactly one
--- constructor with exactly one field) have the same shape to their Reps.
-instance GWrapped (D1 d (C1 c (S1 s (Rec0 a)))) where
-  type GUnwrapped (D1 d (C1 c (S1 s (Rec0 a)))) = a
-  _GWrapped'' = iso remitter reviewer
-    where
-      remitter (M1 (M1 (M1 (K1 x)))) = x
-      reviewer x = M1 (M1 (M1 (K1 x)))
-  {-# INLINE _GWrapped'' #-}
+type family GUnwrapped (rep :: * -> *) :: *
+type instance GUnwrapped (D1 d (C1 c (S1 s (Rec0 a)))) = a
 
 #if __GLASGOW_HASKELL__ >= 710
 


### PR DESCRIPTION
Inspired by the [`newtype-generics`](http://hackage.haskell.org/package/newtype-generics) library, we can quite easily define a `Generic`-based default implementation for `Wrapped` that simply wraps and unwraps the generic representation of a newtype (or datatype with one constructor and field).

Open question: should we use this to eliminate some of the boilerplate in `Control.Lens.Wrapped` for its `Wrapped` instances? The generics code here uses exclusively `newtype`s, so it's extremely easy to optimize away and thus the performance should be the same. In fact, I tried compiling `main = print $ ala Sum foldMap [1,2,3,4]` before and after these changes, and in both cases they produced the same Core.
