### PR TITLE
Add more Wrapped instances

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,9 @@
 4.15.1
 ----
 * Restore the `generic` and `generic1` functions in `GHC.Generics.Lens`
+* Add more `Rewrapped` and `Wrapped` instances for data types from the `base`,
+  `bifunctors`, `exceptions`, `free`, `profunctors`, and `semigroupoids`
+  libraries
 
 4.15
 ----

--- a/lens.cabal
+++ b/lens.cabal
@@ -184,7 +184,7 @@ library
     array                     >= 0.3.0.2  && < 0.6,
     base                      >= 4.5      && < 5,
     base-orphans              >= 0.3      && < 1,
-    bifunctors                >= 5        && < 6,
+    bifunctors                >= 5.1      && < 6,
     bytestring                >= 0.9.1.10 && < 0.11,
     comonad                   >= 4        && < 6,
     contravariant             >= 1.3      && < 2,

--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -135,7 +135,6 @@ import           Data.HashSet as HashSet
 import           Data.HashMap.Lazy as HashMap
 import           Data.List.NonEmpty
 import           Data.Map as Map
-import qualified Data.Monoid as Monoid
 import           Data.Monoid
 import qualified Data.Profunctor as Profunctor
 import           Data.Profunctor hiding (WrappedArrow(..))
@@ -161,6 +160,10 @@ import           System.Posix.Types
 import           Data.Ord (Down(Down))
 #else
 import           GHC.Exts (Down(Down))
+#endif
+
+#if MIN_VERSION_base(4,8,0)
+import qualified Data.Monoid as Monoid
 #endif
 
 #ifdef HLINT

--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -119,7 +119,6 @@ import           Data.Bifunctor.Join
 import           Data.Bifunctor.Joker
 import           Data.Bifunctor.Tannen
 import           Data.Bifunctor.Wrapped
-import           Data.Fixed
 import           Data.Foldable as Foldable
 import           Data.Functor.Bind
 import           Data.Functor.Compose
@@ -320,12 +319,6 @@ instance t ~ Down a => Rewrapped (Down a) t
 instance Wrapped (Down a) where
   type Unwrapped (Down a) = a
   _Wrapped' = iso (\(Down a) -> a) Down
-  {-# INLINE _Wrapped' #-}
-
-instance t ~ Fixed b => Rewrapped (Fixed a) t
-instance Wrapped (Fixed a) where
-  type Unwrapped (Fixed a) = Integer
-  _Wrapped' = iso (\(MkFixed a) -> a) MkFixed
   {-# INLINE _Wrapped' #-}
 
 instance Rewrapped Errno t


### PR DESCRIPTION
`Control.Lens.Wrapped` is missing quite a few `Wrapped`/`Rewrapped` instances for its dependencies, so I added lots of instances for datatypes from the following libraries:

* `base`
* `bifunctors`
* `exceptions`
* `free`
* `profunctors`
* `semigroupoids`