### PR TITLE
Fix `makePrisms` to work with GADTs

### DIFF
--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -366,9 +366,12 @@ checkR2nub = r2nub
 data PureNoFields = PureNoFieldsA | PureNoFieldsB { _pureNoFields :: Int }
 makeLenses ''PureNoFields
 
-data ReviewTest where ReviewTest :: a -> ReviewTest
+data ReviewTest a b where
+  MkReviewTest :: a -> a -> ReviewTest a Bool
 makePrisms ''ReviewTest
 
+data PrismTest a b = L a | R b
+makeClassyPrisms ''PrismTest
 
 -- test FieldNamers
 


### PR DESCRIPTION
It looks like GADTs used to specify the return type via the context.

```haskell
data Foo a where
  Foo :: Foo Bool
```

would desugar to something like

```haskell
data Foo a where
  Foo :: (a ~ Bool) => Foo a
```

Apparently, this representation has changed and the `GadtC` constructor now
embeds the return type directly.

This commit uses the new source of information and thus partially address #684. Partially, because this commit does not fix the generation of classy GADT prisms.