### PR TITLE
INLINE coerced

### DIFF
--- a/src/Control/Lens/Iso.hs
+++ b/src/Control/Lens/Iso.hs
@@ -611,3 +611,4 @@ coerced l = case sym Coercion :: Coercion a s of
               Coercion -> rmap (fmap coerce') l .# coerce
 #endif
 #endif
+{-# INLINE coerced #-}


### PR DESCRIPTION
Is there any reason not to ? All the other Isos in this file are inlined, so this looks like an accidental omission.