### PR TITLE
Cleaner `deepOf` implementation

### DIFF
--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -1256,11 +1256,7 @@ infixl 5 `failing`
 -- 'deepOf' :: 'Traversal' s t s t -> 'IndexedTraversal' i s t a b -> 'IndexedTraversal' i s t a b
 -- @
 deepOf :: (Conjoined p, Applicative f) => LensLike f s t s t -> Traversing p f s t a b -> Over p f s t a b
-deepOf r l pafb = go
-  where go s = case pins b of
-          [] -> r go s
-          xs -> unsafeOuts b <$> traverse (cosieve pafb) xs
-          where b = l sell s
+deepOf r l = failing l (r . deepOf r l)
 
 -- | "Fuse" a 'Traversal' by reassociating all of the '\<*\>' operations to the
 -- left and fusing all of the 'fmap' calls into one. This is particularly


### PR DESCRIPTION
This leverages `failing` to provide a cleaner implementation.

**Note:** `deepOf id other` will enter an infinite loop if `other` fails, but that is true for the current implementation as well (so Don't-do-That™).

I can see this being rejected if Traversal laws are a concern when involving `failure`, as mentioned in [this Stackoverflow post](http://stackoverflow.com/questions/27138856/why-does-failing-from-lens-produce-invalid-traversals).