### PR TITLE
Errata for PR #706

### DIFF
--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -698,12 +698,13 @@ camelCaseNamer tyName fields field = maybeToList $ do
 -- @classUnderscoreNoPrefixFields@ the field names are not expected to
 -- be prefixed with the type name. This might be the desired behaviour
 -- when the @DuplicateRecordFields@ extension is enabled.
+classUnderscoreNoPrefixFields :: LensRules
 classUnderscoreNoPrefixFields =
   defaultFieldRules & lensField .~ classUnderscoreNoPrefixNamer
 
 -- | A 'FieldNamer' for 'classUnderscoreNoPrefixFields'.
 classUnderscoreNoPrefixNamer :: FieldNamer
-classUnderscoreNoPrefixNamer tyName fields field = maybeToList $ do
+classUnderscoreNoPrefixNamer _ _ field = maybeToList $ do
   fieldUnprefixed <- stripPrefix "_" (nameBase field)
   let className  = "Has" ++ overHead toUpper fieldUnprefixed
       methodName = fieldUnprefixed


### PR DESCRIPTION
Sorry for the noise. My previous PR #706 has introduced some stylistic issues, which I'd like to fix.

Added type signature for ```classUnderscoreNoPrefixFields``` and removed unused arguments from ```classUnderscoreNoPrefixNamer```.