### PR TITLE
Compatibility with GHC 8.2

### DIFF
--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -505,7 +505,7 @@ class (FunctorWithIndex i t, FoldableWithIndex i t, Traversable t) => Traversabl
   -- @
   itraverse :: Applicative f => (i -> a -> f b) -> t a -> f (t b)
 #ifndef HLINT
-  default itraverse :: Applicative f => (Int -> a -> f b) -> t a -> f (t b)
+  default itraverse :: (i ~ Int) => Applicative f => (i -> a -> f b) -> t a -> f (t b)
   itraverse = traversed .# Indexed
   {-# INLINE itraverse #-}
 #endif

--- a/src/Data/Dynamic/Lens.hs
+++ b/src/Data/Dynamic/Lens.hs
@@ -19,7 +19,7 @@
 module Data.Dynamic.Lens
   ( AsDynamic(..)
 #if __GLASGOW_HASKELL__ >= 710
-  , pattern Dynamic
+  , pattern Data.Dynamic.Lens.Dynamic
 #endif
   ) where
 


### PR DESCRIPTION
Data.Dynamic now exposes its constructor due to type-indexed Typeable,
so it is necessary to qualify the export of the Dyanmic pattern in
Data.Dynamic.Lens.

Also, the default signature of itraverse did not match its class'
definition, triggering GHC's new default method compatibility check.