### PR TITLE
Fix broken link in haddock

### DIFF
--- a/src/Control/Lens/Internal/Context.hs
+++ b/src/Control/Lens/Internal/Context.hs
@@ -133,7 +133,7 @@ class Corepresentable p => Sellable p w | w -> p where
 ------------------------------------------------------------------------------
 
 -- | The indexed store can be used to characterize a 'Control.Lens.Lens.Lens'
--- and is used by 'Control.Lens.Lens.clone'.
+-- and is used by 'Control.Lens.Lens.cloneLens'.
 --
 -- @'Context' a b t@ is isomorphic to
 -- @newtype 'Context' a b t = 'Context' { runContext :: forall f. 'Functor' f => (a -> f b) -> f t }@,


### PR DESCRIPTION
Also `cloneLens` and alike don't really use `Context` (anymore?) but `Pretext (->)`, so maybe this should be changed anyway?