### PR TITLE
Enable hlint 2.0.1

### DIFF
--- a/HLint.hs
+++ b/HLint.hs
@@ -4,6 +4,7 @@ ignore "Reduce duplication"
 ignore "Redundant lambda"
 ignore "Use >=>"
 ignore "Use const"
+ignore "Use module export list"
 
 -- Used hlint --find src/ in the lens repo to generate this:
 infixl 9 :>

--- a/lens.cabal
+++ b/lens.cabal
@@ -433,8 +433,8 @@ test-suite hlint
   else
     build-depends:
       base,
-      -- Upper version bound is in place due to https://github.com/ekmett/lens/issues/723
-      hlint >= 1.9.27 && < 2
+      -- Bounds are in place due to https://github.com/ekmett/lens/issues/723
+      hlint >= 1.9.27 && < 2 || >= 2.0.1
 
     -- Workaround for https://github.com/malcolmwallace/cpphs/issues/9
     if impl(ghc < 7.6)


### PR DESCRIPTION
Following the fix of https://github.com/ndmitchell/hlint/issues/320 we can turn back on the latest version of HLint. HLint 2 also introduces a new warning, which you may wish to fix rather than ignore, but I've ignored it for now.