### PR TITLE
Add type families for concrete optics

### DIFF
--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE TypeFamilies #-}
 #if __GLASGOW_HASKELL__ >= 706
 {-# LANGUAGE PolyKinds #-}
 #endif
@@ -60,6 +61,7 @@ module Control.Lens.Type
   , IndexedLensLike, IndexedLensLike'
   , Optical, Optical'
   , Optic, Optic'
+  , GetConcreteFunctor, GetConcreteProfunctor
   ) where
 
 import Control.Applicative
@@ -622,3 +624,21 @@ type Over p f s t a b = p a (f b) -> s -> f t
 -- type 'Over'' p f = 'Simple' ('Over' p f)
 -- @
 type Over' p f s a = Over p f s s a a
+
+-- | Extract the concrete 'Functor' from a concrete 'ALens', 'AnIso', etc.
+--
+-- @
+-- GetConcreteFunctor (ALens s t a b) = Pretext (->) a b
+-- GetConcreteFunctor (AnIso s t a b) = Identity
+-- @
+type family GetConcreteFunctor (x :: *) :: * -> *
+type instance GetConcreteFunctor (p a (f b) -> p s (f t)) = f
+
+-- | Extract the concrete 'Profunctor' from a concrete 'ALens', 'AnIso', etc.
+--
+-- @
+-- GetConcreteProfunctor (ALens s t a b) = (->)
+-- GetConcreteProfunctor (AnIso s t a b) = Exchange a b
+-- @
+type family GetConcreteProfunctor (x :: *) :: * -> * -> *
+type instance GetConcreteProfunctor (p a (f b) -> p s (f t)) = p


### PR DESCRIPTION
It's occasionally useful to get one's hands on the concrete `Functor` or
`Profunctor` of an `ALens`, `APrism`, etc., to use in constraints. Currently,
the only built-in option is to import the relevant `.Internal` module and use
the right one. But since these types are all concrete and transparent, it's
actually possible to write type families to extract the relevant types.
So let's do that, purely for convenience.

Note: I believe it must be possible to use `TypeInType` to make the kinds
of the results depend on the arguments. So we should be able to ask for
something like `GetConcreteFunctor (AnEquality 'Bool 'Int 'Bool 'Int)`.
But I don't yet know enough about `TypeInType` to be able to do that myself.