### PR TITLE
Fix #643 by threading through more state

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+4.15.4
+----
+* `declareFields` now avoids creating duplicate field classes that are shared
+  among multiple datatypes within the same invocation.
+
 4.15.3
 ----
 * Generalized types of `transformMOf`, `transformOf`, `transformMOnOf`,

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -86,8 +86,9 @@ import Control.Applicative
 #if !(MIN_VERSION_template_haskell(2,7,0))
 import Control.Monad (ap)
 #endif
-import Control.Monad.State
-import Control.Monad.Writer
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.State
+import Control.Monad.Trans.Writer
 import Control.Lens.Fold
 import Control.Lens.Getter
 import Control.Lens.Lens
@@ -105,6 +106,7 @@ import Data.List as List
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Maybe (maybeToList)
+import Data.Monoid
 import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Set.Lens

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -58,7 +58,7 @@ checkA1 :: Lens' (Hadron a b) a
 checkA1 = a1
 
 checkA2 :: Lens' (Hadron a b) a
-checkA2 = a2 
+checkA2 = a2
 
 checkC :: Lens (Hadron a b) (Hadron a b') b b'
 checkC = c
@@ -237,7 +237,7 @@ checkThing3 :: Lens' (AbideConfiguration a) a
 checkThing3 = thing
 
 dudeDrink :: String
-dudeDrink      = (Dude 9 "El Duderino" () "white russian")      ^. thing 
+dudeDrink      = (Dude 9 "El Duderino" () "white russian")      ^. thing
 lebowskiCarpet :: Maybe String
 lebowskiCarpet = (Lebowski "Mr. Lebowski" 0 "" (Just "carpet")) ^. thing
 abideAnnoyance :: String
@@ -348,6 +348,17 @@ checkB0' = b0
 checkC0' :: Traversal' (DeclaredFields f a) String
 checkC0' = c0
 #endif
+
+declareFields [d|
+    data Aardvark = Aardvark { aardvarkAlbatross :: Int }
+    data Baboon   = Baboon   { baboonAlbatross   :: Int }
+  |]
+
+checkAardvark :: Lens' Aardvark Int
+checkAardvark = albatross
+
+checkBaboon :: Lens' Baboon Int
+checkBaboon = albatross
 
 data Rank2Tests
   = C1 { _r2length :: forall a. [a] -> Int


### PR DESCRIPTION
#643 happens because we aren't keeping track of which field classes we've created during an invocation of `declareFields`. This accomplishes that by adding more `State`. In particular, I keep track of a `Set` of field class `Names` which are consulted before creating a new field class, and propagate this information where necessary.