### PR TITLE
Use travis_wait as a workaround for long test times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ install:
 script:
  - cabal configure --enable-tests --enable-benchmarks -v2  # -v2 provides useful information for debugging
  - cabal build   # this builds all libraries and executables (including tests)
- - cabal test
+ - travis_wait cabal test
  - cabal sdist   # tests that a source-distribution can be generated
 
 # Check that the resulting source distribution can be built & installed.


### PR DESCRIPTION
Until https://github.com/sol/doctest/pull/165 is released, it'd be nice to have `travis_wait` in place to avoid Travis timing out on `cabal test`, which tends to take slightly over 10 minutes.