### PR TITLE
Add #ifdef guards around ANN pragmas

### DIFF
--- a/experimental/Control/Lens/Internal/Jacket.hs
+++ b/experimental/Control/Lens/Internal/Jacket.hs
@@ -56,7 +56,9 @@ import Control.Lens.Type
 import Data.Foldable
 import Data.Monoid
 
+#ifdef HLINT
 {-# ANN module "HLint: ignore Use foldl" #-}
+#endif
 
 -- $setup
 -- >>> import Control.Lens

--- a/experimental/Control/Lens/Internal/Zip.hs
+++ b/experimental/Control/Lens/Internal/Zip.hs
@@ -50,7 +50,9 @@ import Data.Maybe
 --import Data.Monoid
 --import Data.Profunctor.Unsafe
 
+#ifdef HLINT
 {-# ANN module "HLint: ignore Use foldl" #-}
+#endif
 
 -----------------------------------------------------------------------------
 -- * Zippers

--- a/src/Control/Lens/Cons.hs
+++ b/src/Control/Lens/Cons.hs
@@ -68,7 +68,9 @@ import qualified Data.Vector.Unboxed as Unbox
 import           Data.Word
 import           Prelude
 
+#ifdef HLINT
 {-# ANN module "HLint: ignore Eta reduce" #-}
+#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings

--- a/src/Control/Lens/Internal/List.hs
+++ b/src/Control/Lens/Internal/List.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Internal.List
@@ -17,7 +18,9 @@ module Control.Lens.Internal.List
 import Data.IntSet (IntSet)
 import qualified Data.IntSet as IntSet
 
+#ifdef HLINT
 {-# ANN module "HLint: ignore Redundant bracket" #-}
+#endif HLINT
 
 -- | Return the the subset of given ordinals within a given bound
 -- and in order of the first occurrence seen.

--- a/src/Control/Lens/Prism.hs
+++ b/src/Control/Lens/Prism.hs
@@ -70,7 +70,9 @@ import Unsafe.Coerce
 #endif
 import Prelude
 
+#ifdef HLINT
 {-# ANN module "HLint: ignore Use camelCase" #-}
+#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings
@@ -333,15 +335,15 @@ only a = prism' (\() -> a) $ guard . (a ==)
 {-# INLINE only #-}
 
 
--- | This 'Prism' compares for approximate equality with a given value and a predicate for testing, 
+-- | This 'Prism' compares for approximate equality with a given value and a predicate for testing,
 -- an example where the value is the empty list and the predicate checks that a list is empty (same
 -- as 'Control.Lens.Empty._Empty' with the 'Control.Lens.Empty.AsEmpty' list instance):
--- 
+--
 -- >>> nearly [] null # ()
 -- []
 -- >>> [1,2,3,4] ^? nearly [] null
 -- Nothing
--- 
+--
 -- @'nearly' [] 'Prelude.null' :: 'Prism'' [a] ()@
 --
 -- To comply with the 'Prism' laws the arguments you supply to @nearly a p@ are somewhat constrained.
@@ -349,7 +351,7 @@ only a = prism' (\() -> a) $ guard . (a ==)
 -- We assume @p x@ holds iff @x ≡ a@. Under that assumption then this is a valid 'Prism'.
 --
 -- This is useful when working with a type where you can test equality for only a subset of its
--- values, and the prism selects such a value. 
+-- values, and the prism selects such a value.
 
 nearly :: a -> (a -> Bool) -> Prism' a ()
 nearly a p = prism' (\() -> a) $ guard . p


### PR DESCRIPTION
My editor also removed some end-of-line whitespace, which I assume is fine.