### PR TITLE
Fix: redirect missing submodule link.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "doctest"]
 	path = doctest
-	url = https://github.com/RyanGlScott/doctest
+	url = https://github.com/sol/doctest


### PR DESCRIPTION
the old link doesn't work any more.  not sure about the new one, but i'll open this anyway to shout out there is a problem.  does anybody know if this should work?

thanks!