### PR TITLE
Fix `Setter'`'s unintended document code

### DIFF
--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -301,7 +301,7 @@ type Setter s t a b = forall f. Settable f => (a -> f b) -> s -> f t
 -- @
 --
 -- @
--- type 'Setter'' = 'Setter''
+-- type 'Setter'' = 'Simple' 'Setter'
 -- @
 type Setter' s a = Setter s s a a
 


### PR DESCRIPTION
The document of `Setter'` says `type Setter' = Setter'`,  
but I think it is wrong of `type Setter' = Simple Setter`.

Is this right ? 🤔 