### PR TITLE
Make dumped splices of PrismTH compilable

### DIFF
--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -322,7 +322,7 @@ makeReviewer conName fields =
 -- ) :: s -> Either s a
 makeSimpleRemitter :: Name -> Int -> ExpQ
 makeSimpleRemitter conName fields =
-  do x  <- newName "x"
+  do x  <- newName "xb"
      xs <- newNames "y" fields
      let matches =
            [ match (conP conName (map varP xs))
@@ -341,7 +341,7 @@ makeSimpleRemitter conName fields =
 -- ) :: s -> Either t a
 makeFullRemitter :: [NCon] -> Name -> ExpQ
 makeFullRemitter cons target =
-  do x <- newName "x"
+  do x <- newName "xc"
      lam1E (varP x) (caseE (varE x) (map mkMatch cons))
   where
   mkMatch (NCon conName _ _ n) =


### PR DESCRIPTION
I'm still dumping splices from ghc so that ghcjs compiles don't take forever.  This patch prevents compile errors when doing that.  See also issue #696 and #602.