### PR TITLE
Add traversalUnion to Control.Lens.Unsound

### DIFF
--- a/src/Control/Lens/Unsound.hs
+++ b/src/Control/Lens/Unsound.hs
@@ -95,7 +95,7 @@ prismSum k =
 
 -- | A generalization of `mappend`ing folds: A union of disjoint traversals.
 --
--- Traversing the same entry twice is discouraged.
+-- Traversing the same entry twice is illegal.
 --
 -- Are you looking for 'Control.Lens.Traversal.failing'?
 --

--- a/src/Control/Lens/Unsound.hs
+++ b/src/Control/Lens/Unsound.hs
@@ -34,6 +34,7 @@ module Control.Lens.Unsound
   ( 
     lensProduct
   , prismSum
+  , traversalMappend
   ) where
 
 import Control.Applicative
@@ -91,3 +92,13 @@ prismSum k =
   where
     f a@(Right _) _ = a
     f (Left _)    b = b 
+
+-- | A generalization of `mappend`ing folds: A union of disjoint traversals.
+--
+-- Traversing the same entry twice is discouraged.
+--
+-- Are you looking for 'Control.Lens.Traversal.failing'?
+--
+traversalUnion :: ATraversal' s a -> ATraversal' s a -> Traversal' s a
+traversalUnion t1 t2 =
+    lensProduct (partsOf t1) (partsOf t2) . both . each

--- a/src/Control/Lens/Unsound.hs
+++ b/src/Control/Lens/Unsound.hs
@@ -34,7 +34,7 @@ module Control.Lens.Unsound
   ( 
     lensProduct
   , prismSum
-  , traversalMappend
+  , traversalUnion
   ) where
 
 import Control.Applicative
@@ -99,6 +99,6 @@ prismSum k =
 --
 -- Are you looking for 'Control.Lens.Traversal.failing'?
 --
-traversalUnion :: ATraversal' s a -> ATraversal' s a -> Traversal' s a
+traversalUnion :: Traversal' s a -> Traversal' s a -> Traversal' s a
 traversalUnion t1 t2 =
     lensProduct (partsOf t1) (partsOf t2) . both . each


### PR DESCRIPTION
From my position, "Traversing the same entry twice is not lawful." is hearsay: Ctrl-F `no duplicates` on https://artyom.me/lens-over-tea-2

This implementation looks to me like an inefficient proof of concept.