### PR TITLE
Add Cons / Snoc for Control.Applicative.ZipList

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -33,6 +33,8 @@
 
 * Add `Semigroup` and `Monoid` instances for `Indexing`.
 
+* Added `Cons` and `Snoc` instances for `Control.Applicative.ZipList`
+
 4.15.4
 ----
 * `makeFields` and `declareFields` are now smarter with respect to type

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+next
+----
+* Added `Cons` and `Snoc` instances for `Control.Applicative.ZipList`
+
 4.16 [2018.01.28]
 -----------------
 * The `Semigroup` instances for `Traversed` and `Sequenced` are now more
@@ -32,8 +36,6 @@
   with GHC 8.4).
 
 * Add `Semigroup` and `Monoid` instances for `Indexing`.
-
-* Added `Cons` and `Snoc` instances for `Control.Applicative.ZipList`
 
 4.15.4
 ----

--- a/src/Control/Lens/Cons.hs
+++ b/src/Control/Lens/Cons.hs
@@ -68,7 +68,7 @@ import qualified Data.Vector.Primitive as Prim
 import           Data.Vector.Unboxed (Unbox)
 import qualified Data.Vector.Unboxed as Unbox
 import           Data.Word
-#if __GLASGOW_HASKELL__ >= 800
+#if __GLASGOW_HASKELL__ >= 708
 import           Data.Coerce
 #endif
 import           Control.Applicative (ZipList(..))

--- a/src/Control/Lens/Cons.hs
+++ b/src/Control/Lens/Cons.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE InstanceSigs #-}
 #ifdef TRUSTWORTHY
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -129,14 +128,12 @@ instance Cons [a] [b] a b where
 
 instance Cons (ZipList a) (ZipList b) a b where
 #if __GLASGOW_HASKELL__ >= 708
-  _Cons :: Prism (ZipList a) (ZipList b) (a, ZipList a) (b, ZipList b)
   _Cons = withPrism listCons $ \listReview listPreview -> 
     prism (coerce listReview) (coerce listPreview) where
 
     listCons :: Prism [a] [b] (a, [a]) (b, [b])
     listCons = _Cons
 #else
-  _Cons :: Prism (ZipList a) (ZipList b) (a, ZipList a) (b, ZipList b)
   _Cons = prism to from where
 
     to :: (b, ZipList b) -> ZipList b
@@ -376,14 +373,12 @@ instance Snoc [a] [b] a b where
 
 instance Snoc (ZipList a) (ZipList b) a b where
 #if __GLASGOW_HASKELL__ >= 708
-  _Snoc :: Prism (ZipList a) (ZipList b) (ZipList a, a) (ZipList b, b)
   _Snoc = withPrism listSnoc $ \listReview listPreview -> 
     prism (coerce listReview) (coerce listPreview) where
 
     listSnoc :: Prism [a] [b] ([a], a) ([b], b)
     listSnoc = _Snoc
 #else
-  _Snoc :: Prism (ZipList a) (ZipList b) (ZipList a, a) (ZipList b, b)
   _Snoc = prism to from where
 
     to :: (ZipList b, b) -> ZipList b

--- a/src/Control/Lens/Cons.hs
+++ b/src/Control/Lens/Cons.hs
@@ -51,6 +51,7 @@ import Control.Lens.Prism
 import Control.Lens.Review
 import Control.Lens.Tuple
 import Control.Lens.Type
+import Control.Lens.Internal.Coerce
 import qualified Data.ByteString      as StrictB
 import qualified Data.ByteString.Lazy as LazyB
 import           Data.Monoid
@@ -67,9 +68,6 @@ import qualified Data.Vector.Primitive as Prim
 import           Data.Vector.Unboxed (Unbox)
 import qualified Data.Vector.Unboxed as Unbox
 import           Data.Word
-#if __GLASGOW_HASKELL__ >= 708
-import           Data.Coerce
-#endif
 import           Control.Applicative (ZipList(..))
 import           Prelude
 
@@ -127,22 +125,11 @@ instance Cons [a] [b] a b where
   {-# INLINE _Cons #-}
 
 instance Cons (ZipList a) (ZipList b) a b where
-#if __GLASGOW_HASKELL__ >= 708
   _Cons = withPrism listCons $ \listReview listPreview -> 
-    prism (coerce listReview) (coerce listPreview) where
+    prism (coerce' listReview) (coerce' listPreview) where
 
     listCons :: Prism [a] [b] (a, [a]) (b, [b])
     listCons = _Cons
-#else
-  _Cons = prism to from where
-
-    to :: (b, ZipList b) -> ZipList b
-    to (b, ZipList bs) = ZipList (b:bs)
-
-    from :: ZipList a -> Either (ZipList b) (a, ZipList a)
-    from (ZipList [])     = Left (ZipList [])
-    from (ZipList (a:as)) = Right (a, ZipList as)
-#endif
 
   {-# INLINE _Cons #-}
 
@@ -372,23 +359,11 @@ instance Snoc [a] [b] a b where
   {-# INLINE _Snoc #-}
 
 instance Snoc (ZipList a) (ZipList b) a b where
-#if __GLASGOW_HASKELL__ >= 708
   _Snoc = withPrism listSnoc $ \listReview listPreview -> 
-    prism (coerce listReview) (coerce listPreview) where
+    prism (coerce' listReview) (coerce' listPreview) where
 
     listSnoc :: Prism [a] [b] ([a], a) ([b], b)
     listSnoc = _Snoc
-#else
-  _Snoc = prism to from where
-
-    to :: (ZipList b, b) -> ZipList b
-    to (ZipList as, a) = ZipList (as Prelude.++ [a])
-
-    from :: ZipList a -> Either (ZipList b) (ZipList a, a)
-    from (ZipList aas) = if Prelude.null aas
-      then Left  (ZipList [])
-      else Right (ZipList (Prelude.init aas), Prelude.last aas)
-#endif
 
   {-# INLINE _Snoc #-}
 

--- a/src/Control/Lens/Cons.hs
+++ b/src/Control/Lens/Cons.hs
@@ -128,7 +128,7 @@ instance Cons [a] [b] a b where
   {-# INLINE _Cons #-}
 
 instance Cons (ZipList a) (ZipList b) a b where
-#if __GLASGOW_HASKELL__ >= 800
+#if __GLASGOW_HASKELL__ >= 708
   _Cons :: Prism (ZipList a) (ZipList b) (a, ZipList a) (b, ZipList b)
   _Cons = withPrism listCons $ \listReview listPreview -> 
     prism (coerce listReview) (coerce listPreview) where
@@ -375,7 +375,7 @@ instance Snoc [a] [b] a b where
   {-# INLINE _Snoc #-}
 
 instance Snoc (ZipList a) (ZipList b) a b where
-#if __GLASGOW_HASKELL__ >= 800
+#if __GLASGOW_HASKELL__ >= 708
   _Snoc :: Prism (ZipList a) (ZipList b) (ZipList a, a) (ZipList b, b)
   _Snoc = withPrism listSnoc $ \listReview listPreview -> 
     prism (coerce listReview) (coerce listPreview) where


### PR DESCRIPTION
Added `Cons (ZipList a) (ZipList b) a b` and `Snoc (ZipList a) (ZipList b) a b` per #783 

I `coerce`d the list instances

```haskell
_Cons :: Prism (ZipList a) (ZipList b) (a, ZipList a) (b, ZipList b)
_Cons = withPrism listCons $ \listReview listPreview -> 
  prism (coerce listReview) (coerce listPreview) where

  listCons :: Prism [a] [b] (a, [a]) (b, [b])
  listCons = _Cons
```

but for older versions (< 7.8?) that don't support `Data.Coerce`:

```haskell
_Cons :: Prism (ZipList a) (ZipList b) (a, ZipList a) (b, ZipList b)
_Cons = prism to from where

  to :: (b, ZipList b) -> ZipList b
  to (b, ZipList bs) = ZipList (b:bs)

  from :: ZipList a -> Either (ZipList b) (a, ZipList a)
  from (ZipList [])     = Left (ZipList [])
  from (ZipList (a:as)) = Right (a, ZipList as)
```