### PR TITLE
Add class Rixed ... where rix :: Index m => Lens' m (IxValue m)

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -184,6 +184,7 @@ flag j
 
 library
   build-depends:
+    adjunctions               >= 4.2      && < 5,
     array                     >= 0.3.0.2  && < 0.6,
     base                      >= 4.5      && < 5,
     base-orphans              >= 0.5.2    && < 1,


### PR DESCRIPTION
This is being asked once in a while

- Also https://hackage.haskell.org/package/total-map can be an instance of `Rixed`
- `adjunctions` is in dependency closure already (`lens` depends on `kan-extensions`)
- between `riix` and `irix` I chose former.

Why `rix`? Because it's short and *most* instances are `Representable` functors.