### PR TITLE
Fix #799 by distinguishing data/type families in makeFields

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,6 +2,8 @@ next
 ----
 * Re-export `(<&>)` from `Data.Functor` on `base-4.11` and later.
 * Added `Cons` and `Snoc` instances for `Control.Applicative.ZipList`
+* Fix a bug in which `makeFields` would generate equality constraints for
+  field types involving data families, which are unnecessary.
 
 4.16 [2018.01.28]
 -----------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -342,6 +342,7 @@ library
 test-suite templates
   type: exitcode-stdio-1.0
   main-is: templates.hs
+  other-modules: T799
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
 

--- a/tests/T799.hs
+++ b/tests/T799.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+-- | Test 'makeFields' on a field whose type has a data family. Unlike for
+-- type families, for data families we do not generate type equality
+-- constraints, as they are not needed to avoid the issue in #754.
+--
+-- This tests that the fix for #799 is valid by putting this in a module in
+-- which UndecidableInstances is not enabled.
+module T799 where
+
+import Control.Lens
+
+data family DF a
+newtype instance DF Int = FooInt Int
+
+data Bar = Bar { _barFoo :: DF Int }
+makeFields ''Bar
+
+checkBarFoo :: Lens' Bar (DF Int)
+checkBarFoo = foo

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -26,6 +26,7 @@ module Main where
 
 import Control.Lens
 -- import Test.QuickCheck (quickCheck)
+import T799 ()
 
 data Bar a b c = Bar { _baz :: (a, b) }
 makeLenses ''Bar


### PR DESCRIPTION
Previously, the Template Haskell machinery powering `makeFields` would treat data families and type families alike, causing #799.