### PR TITLE
Only incur semigroups and void dependencies on old GHCs.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,7 @@
+Next
+----
+* Only incur `semigroups` and `void` dependencies on old GHCs.
+
 4.17 [2018.07.03]
 -----------------
 * Allow building with GHC 8.6.

--- a/lens.cabal
+++ b/lens.cabal
@@ -213,7 +213,6 @@ library
     profunctors               >= 5.2.1    && < 6,
     reflection                >= 2.1      && < 3,
     semigroupoids             >= 5        && < 6,
-    semigroups                >= 0.8.4    && < 1,
     tagged                    >= 0.4.4    && < 1,
     template-haskell          >= 2.4      && < 2.15,
     th-abstraction            >= 0.2.1    && < 0.3,
@@ -221,14 +220,17 @@ library
     transformers              >= 0.2      && < 0.6,
     transformers-compat       >= 0.4      && < 1,
     unordered-containers      >= 0.2.4    && < 0.3,
-    vector                    >= 0.9      && < 0.13,
-    void                      >= 0.5      && < 1
+    vector                    >= 0.9      && < 0.13
 
   if impl(ghc < 8.0)
-    build-depends: generic-deriving >= 1.10 && < 2
+    build-depends:
+      generic-deriving >= 1.10  && < 2,
+      semigroups       >= 0.8.4 && < 1
 
   if impl(ghc < 7.9)
-    build-depends: nats >= 0.1 && < 1.2
+    build-depends:
+      nats >= 0.1 && < 1.2,
+      void >= 0.5 && < 1
 
   exposed-modules:
     Control.Exception.Lens


### PR DESCRIPTION
With other recent changes in dependencies, now it should be possible
to depend on `lens` without incurring a dependency on either of those!