### PR TITLE
Use infinite streams in the lens-pong example

### DIFF
--- a/examples/lens-examples.cabal
+++ b/examples/lens-examples.cabal
@@ -57,7 +57,8 @@ executable lens-pong
     gloss      >= 1.12  && < 1.13,
     lens,
     mtl        >= 2.0.1 && < 2.3,
-    random     >= 1.0   && < 1.2
+    random     >= 1.0   && < 1.2,
+    streams    >= 3.3   && < 4
   main-is: Pong.hs
   default-language: Haskell2010
   ghc-options: -Wall


### PR DESCRIPTION
Currently, we use a list of `Vector`s, which requires partial pattern matches in various parts of the code. Unfortunately, this breaks when `MonadFailDesugaring` is enabled (as will be the case starting with GHC 8.6), as there is no `MonadFail` instance for `Identity`.

To sidestep this issue, I replace the list of `Vector`s with an infinite `Stream` of these. This localizes the partiality to one function in `Pong.hs` (`listToStream`).

Addresses one bullet point of #815.