### PR TITLE
Add .png files to extra-doc-files

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -1,24 +1,17 @@
 \begin{code}
 {-# LANGUAGE CPP #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -Wall #-}
 module Main (main) where
 
 #ifndef MIN_VERSION_cabal_doctest
 #define MIN_VERSION_cabal_doctest(x,y,z) 0
 #endif
 
--- haddock stuff
-import Distribution.Package ( Package (..), packageName )
-import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
-import Distribution.Simple.Setup (Flag (..), HaddockFlags, haddockDistPref)
-import Distribution.Simple.Utils (copyFiles)
-import Distribution.Verbosity (normal)
-import Distribution.Text ( display )
-import System.FilePath ( (</>) )
-
 #if MIN_VERSION_cabal_doctest(1,0,0)
 
-import Distribution.Extra.Doctest ( doctestsUserHooks )
+import Distribution.Extra.Doctest ( defaultMainWithDoctests )
+main :: IO ()
+main = defaultMainWithDoctests "doctests"
 
 #else
 
@@ -31,25 +24,11 @@ import Distribution.Extra.Doctest ( doctestsUserHooks )
 import Warning ()
 #endif
 
-doctestsUserHooks :: String -> UserHooks
-doctestsUserHooks _ = simpleUserHooks
-
-#endif
-
-haddockOutputDir :: Package p => HaddockFlags -> p -> FilePath
-haddockOutputDir flags pkg = destDir where
-  baseDir = case haddockDistPref flags of
-    NoFlag -> "."
-    Flag x -> x
-  destDir = baseDir </> "doc" </> "html" </> display (packageName pkg)
+import Distribution.Simple
 
 main :: IO ()
-main = defaultMainWithHooks duh
-  { postHaddock = \args flags pkg lbi -> do
-     copyFiles normal (haddockOutputDir flags pkg) [("images","Hierarchy.png")]
-     postHaddock duh args flags pkg lbi
-  }
-  where
-    duh = doctestsUserHooks "doctests"
+main = defaultMain
+
+#endif
 
 \end{code}

--- a/lens.cabal
+++ b/lens.cabal
@@ -2,7 +2,7 @@ name:          lens
 category:      Data, Lenses, Generics
 version:       4.17
 license:       BSD2
-cabal-version: >= 1.8
+cabal-version: 1.18
 license-file:  LICENSE
 author:        Edward A. Kmett
 maintainer:    Edward A. Kmett <ekmett@gmail.com>
@@ -103,7 +103,6 @@ extra-source-files:
   examples/lens-examples.cabal
   examples/*.hs
   examples/*.lhs
-  images/*.png
   lens-properties/CHANGELOG.markdown
   lens-properties/LICENSE
   lens-properties/Setup.hs
@@ -116,6 +115,8 @@ extra-source-files:
   CHANGELOG.markdown
   README.markdown
   SUPPORT.markdown
+extra-doc-files:
+  images/*.png
 
 source-repository head
   type: git
@@ -348,6 +349,8 @@ library
 
   hs-source-dirs: src
 
+  default-language: Haskell2010
+
 -- Verify that Template Haskell expansion works
 test-suite templates
   type: exitcode-stdio-1.0
@@ -355,6 +358,7 @@ test-suite templates
   other-modules: T799
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
+  default-language: Haskell2010
 
   if flag(dump-splices)
     ghc-options: -ddump-splices
@@ -374,6 +378,7 @@ test-suite properties
   hs-source-dirs:
     tests
     lens-properties/src
+  default-language: Haskell2010
   if !flag(test-properties)
     buildable: False
   else
@@ -391,6 +396,7 @@ test-suite hunit
   main-is: hunit.hs
   ghc-options: -w -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: tests
+  default-language: Haskell2010
 
   if !flag(test-hunit)
     buildable: False
@@ -411,6 +417,7 @@ test-suite doctests
   main-is:           doctests.hs
   ghc-options:       -Wall -threaded
   hs-source-dirs:    tests
+  default-language:  Haskell2010
   x-doctest-options: --fast
 
   if flag(trustworthy) && impl(ghc>=7.2)
@@ -441,10 +448,11 @@ test-suite doctests
 
 -- Basic benchmarks for the uniplate-style combinators
 benchmark plated
-  type:           exitcode-stdio-1.0
-  main-is:        plated.hs
-  ghc-options:    -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
-  hs-source-dirs: benchmarks
+  type:             exitcode-stdio-1.0
+  main-is:          plated.hs
+  ghc-options:      -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  default-language: Haskell2010
   build-depends:
     base,
     comonad,
@@ -460,10 +468,11 @@ benchmark plated
 
 -- Benchmarking alongside variants
 benchmark alongside
-  type:           exitcode-stdio-1.0
-  main-is:        alongside.hs
-  ghc-options:    -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
-  hs-source-dirs: benchmarks
+  type:             exitcode-stdio-1.0
+  main-is:          alongside.hs
+  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  default-language: Haskell2010
   build-depends:
     base,
     comonad >= 4,
@@ -474,10 +483,11 @@ benchmark alongside
 
 -- Benchmarking folds
 benchmark folds
-  type:           exitcode-stdio-1.0
-  main-is:        folds.hs
-  ghc-options:    -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
-  hs-source-dirs: benchmarks
+  type:             exitcode-stdio-1.0
+  main-is:          folds.hs
+  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  default-language: Haskell2010
   build-depends:
     base,
     criterion,
@@ -489,10 +499,11 @@ benchmark folds
 
 -- Benchmarking traversals
 benchmark traversals
-  type:           exitcode-stdio-1.0
-  main-is:        traversals.hs
-  ghc-options:    -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
-  hs-source-dirs: benchmarks
+  type:             exitcode-stdio-1.0
+  main-is:          traversals.hs
+  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  default-language: Haskell2010
   build-depends:
     base,
     criterion,
@@ -505,10 +516,11 @@ benchmark traversals
 
 -- Benchmarking unsafe implementation strategies
 benchmark unsafe
-  type:           exitcode-stdio-1.0
-  main-is:        unsafe.hs
-  ghc-options:    -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
-  hs-source-dirs: benchmarks
+  type:             exitcode-stdio-1.0
+  main-is:          unsafe.hs
+  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  default-language: Haskell2010
   build-depends:
     base,
     comonad >= 4,


### PR DESCRIPTION
This allows us to drastically simplify Setup.hs, as we no longer need to manually copy over these PNG files during the Haddock phase.

This feature requires `Cabal-1.18` or later, so I needed to sprinkle in uses of `default-language: Haskell2010` in order to please `cabal check`.

cc @phadej—can you think of anything bad that could happen with this approach?