### PR TITLE
Add an indexOn function to convert folds into indexed folds

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -135,6 +135,7 @@ module Control.Lens.Fold
   , ifiltered
   , itakingWhile
   , idroppingWhile
+  , indexOn
 
   -- * Internal types
   , Leftmost
@@ -2683,6 +2684,16 @@ idroppingWhile p l f = (flip evalState True .# getCompose) `rmap` l g where
       b' = b && p i a
     in (if b' then pure a else indexed f i a, b')
 {-# INLINE idroppingWhile #-}
+
+-- | Obtain an 'IndexedFold' from a regular 'Fold' using an indexing
+-- function. If @fld@ iterates over the @ai@, then @fld `'indexOn'` ix@ iterates
+-- over the @f ai@, each with index @ix ai@.
+--
+-- >>> itoListOf (traversed `indexOn` fst) [(1, True), (7, True), (4, False), (3, True)]
+-- [(1,(1,True)),(7,(7,True)),(4,(4,False)),(3,(3,True))]
+indexOn :: Fold s a -> (a -> i) -> IndexedFold i s a
+indexOn fld ix = \ p ->
+  fld (\a -> indexed p (ix a) a)
 
 ------------------------------------------------------------------------------
 -- Misc.


### PR DESCRIPTION
I've needed this function in particular to use `toMapOf` on a regular traversal (in the example, in the commit, I use a list of pairs, which sounds like a reasonably common use-case, but my actual use case was more a set-as-a-map datastructure, like unique sets in GHC).

As I've needed something like this before, I thought it might be of general interest. So here it is.