### PR TITLE
Add match-match Prism law

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,7 @@ Next
 * Only incur `semigroups` and `void` dependencies on old GHCs.
 * Add `holes1Of`
 * Add `locally` https://github.com/ekmett/lens/pull/829
+* Add third `Prism` law.
 
 4.17 [2018.07.03]
 -----------------

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -375,7 +375,7 @@ type AReview t b = Optic' Tagged Identity t b
 -- around with 'Control.Lens.Review.re' to obtain a 'Getter' in the
 -- opposite direction.
 --
--- There are two laws that a 'Prism' should satisfy:
+-- There are three laws that a 'Prism' should satisfy:
 --
 -- First, if I 'Control.Lens.Review.re' or 'Control.Lens.Review.review' a value with a 'Prism' and then 'Control.Lens.Fold.preview' or use ('Control.Lens.Fold.^?'), I will get it back:
 --
@@ -385,9 +385,17 @@ type AReview t b = Optic' Tagged Identity t b
 --
 -- Second, if you can extract a value @a@ using a 'Prism' @l@ from a value @s@, then the value @s@ is completely described by @l@ and @a@:
 --
--- If @'Control.Lens.Fold.preview' l s ≡ 'Just' a@ then @'Control.Lens.Review.review' l a ≡ s@
+-- @
+-- 'Control.Lens.Fold.preview' l s ≡ 'Just' a ⟹ 'Control.Lens.Review.review' l a ≡ s
+-- @
 --
--- These two laws imply that the 'Traversal' laws hold for every 'Prism' and that we 'Data.Traversable.traverse' at most 1 element:
+-- Third, if you get non-match @t@, you can convert it result back to @s@:
+--
+-- @
+-- 'Control.Lens.Combinators.matching' l s ≡ 'Left' t ⟹ 'Control.Lens.Combinators.matching' l t ≡ 'Left' s
+-- @
+--
+-- The first two laws imply that the 'Traversal' laws hold for every 'Prism' and that we 'Data.Traversable.traverse' at most 1 element:
 --
 -- @
 -- 'Control.Lens.Fold.lengthOf' l x '<=' 1


### PR DESCRIPTION
- I found it in http://oleg.fi/gists/posts/2018-12-12-find-correct-laws.html#s:8
- Russell specifies it in lens-family: https://hub.darcs.net/roconnor/lens-family/browse/src/Lens/Family2/Unchecked.hs#155

Two independent inventions make a discovery?

---

![screenshot from 2018-12-13 10-15-02](https://user-images.githubusercontent.com/51087/49924868-007a6f80-fec0-11e8-8839-e64fc8d479fa.png)


I used long right arrow unicode, which chrome seems to render ok. (one have be careful in editors though, VIM renders that character in a funny way).