### PR TITLE
New docs for the ways to get the head of a fold

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -1252,9 +1252,8 @@ lengthOf l = foldlOf' l (\a _ -> a + 1) 0
 -- >>> "world" ^? ix 20
 -- Nothing
 --
--- Note that there is also a prefix version of this operator, 'preview'.
--- As it is a prefix function, it can operate in any 'Control.Monad.Reader.MonadReader'
--- 
+-- This operator works as an infix version of 'preview'. 
+--
 -- @
 -- ('^?') ≡ 'flip' 'preview'
 -- @
@@ -1967,16 +1966,24 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 -- 'Data.Maybe.listToMaybe' '.' 'toList' ≡ 'preview' 'folded'
 -- @
 --
--- Unlike '^?', this function uses a 
--- 'Control.Monad.Reader.MonadReader' to read the value to be focused in on.
--- This allows one to pass the value as the last argument by using the 
--- 'Control.Monad.Reader.MonadReader' instance for @(->) s@:
---
 -- @
 -- 'preview' = 'view' '.' 'pre'
 -- @
+-- 
 --
--- In this case, it can be helpful to think of 'preview' as having one of these
+-- Unlike '^?', this function uses a 
+-- 'Control.Monad.Reader.MonadReader' to read the value to be focused in on.
+-- This allows one to pass the value as the last argument by using the 
+-- 'Control.Monad.Reader.MonadReader' instance for @(->) s@
+-- However, it may also be used as part of some deeply nested transformer stack.
+--
+-- 'preview' uses a monoidal value to obtain the result.
+-- This means that it generally has good performance, but can occasionally cause space leaks
+-- or even stack overflows on some data types.
+-- There is another function, 'firstOf', which avoids these issues at the cost of
+-- a slight constant performance cost and a little less flexibility.
+--
+-- It may be helpful to think of 'preview' as having one of the following
 -- more specialized types:
 -- 
 -- @
@@ -1987,8 +1994,6 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 -- 'preview' :: 'Traversal'' s a -> s -> 'Maybe' a
 -- @
 --
--- However, it may also be used as part of some deeply nested transformer stack,
--- like so:
 --
 -- @
 -- 'preview' :: 'MonadReader' s m => 'Getter' s a     -> m ('Maybe' a)
@@ -1996,12 +2001,6 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 -- 'preview' :: 'MonadReader' s m => 'Lens'' s a      -> m ('Maybe' a)
 -- 'preview' :: 'MonadReader' s m => 'Iso'' s a       -> m ('Maybe' a)
 -- 'preview' :: 'MonadReader' s m => 'Traversal'' s a -> m ('Maybe' a)
---
--- 'firstOf' is also not generalized to work with any 'MonadReader', like '^?'.
--- Unlike '^?' and 'preview', however, it uses a slightly different means of getting
--- the first value. This method has slightly worse performance, but won't ever 
--- cause a stack overflow. If you get stack overflows from using 'preview',
--- refactor to use 'firstOf' instead.
 -- 
 -- @
 preview :: MonadReader s m => Getting (First a) s a -> m (Maybe a)

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -1254,10 +1254,14 @@ lengthOf l = foldlOf' l (\a _ -> a + 1) 0
 --
 -- Note that there is also a prefix version of this operator, 'preview'.
 -- As it is a prefix function, it can operate in any 'Control.Monad.Reader.MonadReader'
+-- 
 -- @
 -- ('^?') ≡ 'flip' 'preview'
 -- @
 --
+-- It may be helpful to think of '?^' as having one of the following
+-- more specialized types:
+-- 
 -- @
 -- ('^?') :: s -> 'Getter' s a     -> 'Maybe' a
 -- ('^?') :: s -> 'Fold' s a       -> 'Maybe' a
@@ -1956,7 +1960,8 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 ------------------------------------------------------------------------------
 
 -- | Retrieve the first value targeted by a 'Fold' or 'Traversal' (or 'Just' the result
--- from a 'Getter' or 'Lens'). See also '^?'
+-- from a 'Getter' or 'Lens'). See also 'firstOf' and '?^', which are similar with
+-- some subtle differences (explained below).
 --
 -- @
 -- 'Data.Maybe.listToMaybe' '.' 'toList' ≡ 'preview' 'folded'
@@ -1971,6 +1976,9 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 -- 'preview' = 'view' '.' 'pre'
 -- @
 --
+-- In this case, it can be helpful to think of 'preview' as having one of these
+-- more specialized types:
+-- 
 -- @
 -- 'preview' :: 'Getter' s a     -> s -> 'Maybe' a
 -- 'preview' :: 'Fold' s a       -> s -> 'Maybe' a
@@ -1988,6 +1996,13 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 -- 'preview' :: 'MonadReader' s m => 'Lens'' s a      -> m ('Maybe' a)
 -- 'preview' :: 'MonadReader' s m => 'Iso'' s a       -> m ('Maybe' a)
 -- 'preview' :: 'MonadReader' s m => 'Traversal'' s a -> m ('Maybe' a)
+--
+-- 'firstOf' is also not generalized to work with any 'MonadReader', like '^?'.
+-- Unlike '^?' and 'preview', however, it uses a slightly different means of getting
+-- the first value. This method has slightly worse performance, but won't ever 
+-- cause a stack overflow. If you get stack overflows from using 'preview',
+-- refactor to use 'firstOf' instead.
+-- 
 -- @
 preview :: MonadReader s m => Getting (First a) s a -> m (Maybe a)
 preview l = asks (getFirst #. foldMapOf l (First #. Just))

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -1237,7 +1237,7 @@ lengthOf l = foldlOf' l (\a _ -> a + 1) 0
 -- way to extract the optional value.
 --
 -- Note: if you get stack overflows due to this, you may want to use 'firstOf' instead, which can deal
--- more gracefully with heavily left-biased trees. This is because '?^' works by using the 
+-- more gracefully with heavily left-biased trees. This is because '^?' works by using the 
 -- 'Data.Monoid.First' monoid, which can occasionally cause space leaks.
 --
 -- >>> Left 4 ^?_Left
@@ -1259,7 +1259,7 @@ lengthOf l = foldlOf' l (\a _ -> a + 1) 0
 -- ('^?') ≡ 'flip' 'preview'
 -- @
 --
--- It may be helpful to think of '?^' as having one of the following
+-- It may be helpful to think of '^?' as having one of the following
 -- more specialized types:
 -- 
 -- @
@@ -1295,7 +1295,7 @@ s ^?! l = foldrOf l const (error "(^?!): empty Fold") s
 -- | Retrieve the 'First' entry of a 'Fold' or 'Traversal' or retrieve 'Just' the result
 -- from a 'Getter' or 'Lens'.
 --
--- The answer is computed in a manner that leaks space less than @'preview'@ or @'?^'@
+-- The answer is computed in a manner that leaks space less than @'preview'@ or @^?'@
 -- and gives you back access to the outermost 'Just' constructor more quickly, but does so
 -- in a way that builds an intermediate structure, and thus may have worse
 -- constant factors. This also means that it can not be used in any 'Control.Monad.Reader.MonadReader',
@@ -1960,7 +1960,7 @@ ipre l = dimap (getFirst . getConst #. l (Indexed $ \i a -> Const (First (Just (
 ------------------------------------------------------------------------------
 
 -- | Retrieve the first value targeted by a 'Fold' or 'Traversal' (or 'Just' the result
--- from a 'Getter' or 'Lens'). See also 'firstOf' and '?^', which are similar with
+-- from a 'Getter' or 'Lens'). See also 'firstOf' and '^?', which are similar with
 -- some subtle differences (explained below).
 --
 -- @


### PR DESCRIPTION
This fixes #729 by providing end users with a bit more information on the differences between '^?', 'preview', and 'firstOf'. 