### PR TITLE
Add Wrapped/Rewrapped instances for Data.Monoid.Ap, new in base-4.12.0.0

### DIFF
--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -337,6 +337,14 @@ instance Wrapped (Monoid.Alt f a) where
   {-# INLINE _Wrapped' #-}
 #endif
 
+#if MIN_VERSION_base(4,12,0)
+instance (t ~ Monoid.Ap g b) => Rewrapped (Monoid.Ap f a) t
+instance Wrapped (Monoid.Ap f a) where
+  type Unwrapped (Monoid.Ap f a) = f a
+  _Wrapped' = iso Monoid.getAp Monoid.Ap
+  {-# INLINE _Wrapped' #-}
+#endif
+
 instance t ~ ArrowMonad m' a' => Rewrapped (ArrowMonad m a) t
 instance Wrapped (ArrowMonad m a) where
   type Unwrapped (ArrowMonad m a) = m () a


### PR DESCRIPTION
```
*Control.Exception.Lens Control.Lens Data.Monoid Data.Foldable> ala Ap foldMap [Just "hello", Just " ", Just "world"]
Just "hello world"
*Control.Exception.Lens Control.Lens Data.Monoid Data.Foldable> ala Ap foldMap [Just "hello", Just " ", Just "world", Nothing]
Nothing
```

There probably are other newtypes new in base 4.12, but this is the one I've wanted on several occasions, so it's the one I'm aware of.