### PR TITLE
Adapt to template-haskell-2.15.0.0

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
-next [????.??.??]
+4.18 [????.??.??]
 -----------------
+* Support building with GHC 8.8.
 * Add additional bifunctor instances for `Swapped`.
 * New lenses `head1` and `last1`, to access the first/last elements of
   a `Traversable1` container.

--- a/lens.cabal
+++ b/lens.cabal
@@ -1,6 +1,6 @@
 name:          lens
 category:      Data, Lenses, Generics
-version:       4.17.1
+version:       4.18
 license:       BSD2
 cabal-version: 1.18
 license-file:  LICENSE
@@ -126,7 +126,7 @@ source-repository head
 
 custom-setup
   setup-depends:
-    Cabal >= 1.10 && <2.5,
+    Cabal >= 1.10 && <3.1,
     base  >= 4.5 && <5,
     cabal-doctest >= 1 && <1.1,
     filepath
@@ -217,7 +217,7 @@ library
     reflection                >= 2.1      && < 3,
     semigroupoids             >= 5        && < 6,
     tagged                    >= 0.4.4    && < 1,
-    template-haskell          >= 2.4      && < 2.15,
+    template-haskell          >= 2.4      && < 2.16,
     th-abstraction            >= 0.2.1    && < 0.4,
     text                      >= 0.11     && < 1.3,
     transformers              >= 0.2      && < 0.6,

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -146,9 +146,6 @@ import Control.Monad
 import Control.Monad.Trans.State.Lazy
 import Data.Bitraversable
 import Data.CallStack
-#if __GLASGOW_HASKELL__ < 710
-import Data.Foldable (Foldable)
-#endif
 import Data.Functor.Apply
 import Data.Functor.Compose
 import Data.Functor.Day.Curried
@@ -160,19 +157,27 @@ import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Sequence (Seq, mapWithIndex)
 import Data.Vector as Vector (Vector, imap)
-import Data.Monoid (Monoid (..), Any (..), Endo (..))
+import Data.Monoid (Any (..), Endo (..))
 import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
 import Data.Reflection
-import Data.Semigroup (Semigroup (..))
 import Data.Semigroup.Traversable
 import Data.Semigroup.Bitraversable
 import Data.Traversable
 import Data.Tuple (swap)
 import GHC.Magic (inline)
 import Prelude hiding ((.),id)
+
+#if !(MIN_VERSION_base(4,8,0))
+import Data.Foldable (Foldable)
+import Data.Monoid (Monoid (..))
+#endif
+
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Semigroup (Semigroup (..))
+#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings -XFlexibleContexts

--- a/src/Control/Monad/Error/Lens.hs
+++ b/src/Control/Monad/Error/Lens.hs
@@ -35,8 +35,10 @@ import Control.Monad
 import Control.Monad.Error.Class
 import Data.Functor.Plus
 import qualified Data.Monoid as M
+
+#if !(MIN_VERSION_base(4,11,0))
 import Data.Semigroup (Semigroup(..))
-import Prelude
+#endif
 
 #ifdef HLINT
 {-# ANN module "HLint: ignore Use fmap" #-}


### PR DESCRIPTION
My main motivation for submitting this PR is so that we can have `lens` `master` successfully build with GHC 8.8.1-alpha1. That being said, it's unclear whether we'll want to have the next release of `lens` include `Language.Haskell.TH.Lens` at all—see #844. If we do end up splitting off `Language.Haskell.TH.Lens` into its own package, it will need to include these changes anyway in order to build with 8.8, so it would be good to merge them either way.

Regardless of what decision is made on #844, the changes required will necessitate a major version bump, so this PR does so now.