### PR TITLE
Correct ByteString imports CPP

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -199,7 +199,7 @@ library
     base                      >= 4.5      && < 5,
     base-orphans              >= 0.5.2    && < 1,
     bifunctors                >= 5.1      && < 6,
-    bytestring                >= 0.9.1.10 && < 0.11,
+    bytestring                >= 0.9.2.1  && < 0.11,
     call-stack                >= 0.1      && < 0.2,
     comonad                   >= 4        && < 6,
     contravariant             >= 1.3      && < 2,

--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -59,13 +59,11 @@ import Foreign.Ptr
 import Foreign.Storable
 #if MIN_VERSION_base(4,8,0)
 import Foreign.ForeignPtr
-#elif MIN_VERSION_base(4,4,0)
+#else
 import Foreign.ForeignPtr.Safe
+#endif
 #if !MIN_VERSION_bytestring(0,10,4)
 import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
-#endif
-#else
-import Foreign.ForeignPtr
 #endif
 import GHC.Base (unsafeChr)
 import GHC.ForeignPtr (mallocPlainForeignPtrBytes)


### PR DESCRIPTION
- Those were exposed if you downgrade bytestring,
  that's silly thing to do; but automatic tools do find silly examples.
- Also bump bytestring lowerbound to what's bundled with GHC-7.4