### PR TITLE
Spread Iso ideas around

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -31,6 +31,11 @@
 * Make `magnify` offer its getter argument the `Contravariant` and `Functor`
   instances it will require. This allows `magnify` to be used without
   knowing the concrete monad being magnified.
+* Add `equality`, `equality'`, `withEquality`, `underEquality`, `overEquality`,
+  `fromLeibniz`, `fromLeibniz'` and `cloneEquality` to `Control.Lens.Equality`.
+* Add `withLens` to `Control.Lens.Lens`.
+* Make `substEq` and `simply` in `Control.Lens.Equality`
+  and `withIso` in `Control.Lens.Iso` levity polymorphic.
 
 4.17.1 [2019.04.26]
 -------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -257,6 +257,7 @@ library
     Control.Lens.Internal.Context
     Control.Lens.Internal.CTypes
     Control.Lens.Internal.Deque
+    Control.Lens.Internal.Equality
     Control.Lens.Internal.Exception
     Control.Lens.Internal.FieldTH
     Control.Lens.Internal.PrismTH

--- a/src/Control/Lens/Internal/Equality.hs
+++ b/src/Control/Lens/Internal/Equality.hs
@@ -1,0 +1,87 @@
+{-# language CPP #-}
+{-# language GADTs #-}
+{-# language RankNTypes #-}
+{-# language StandaloneDeriving #-}
+{-# language TypeOperators #-}
+#if __GLASGOW_HASKELL__ >= 706
+-- PolyKinds is known to be especially flaky in 7.4. It didn't get *really*
+-- solid until 8.0 or, but it's somewhat usable from 7.6 to 7.10.
+{-# language PolyKinds #-}
+#endif
+module Control.Lens.Internal.Equality (
+    (:~:)(..)
+  , sym
+  , trans
+  , castWith
+  , gcastWith
+  , eqT
+
+{-
+We can't define 'apply' or 'outer' for 7.4, since they won't kind-check without
+PolyKinds. We're not currently using them anyway.
+
+'inner' won't typecheck with 7.4 or 7.6, apparently due to GHC bugs.  There
+may be a workaround available if we need it:
+
+  https://github.com/ekmett/lens/pull/862#discussion_r307945760
+-}
+  ) where
+#if MIN_VERSION_base (4,7,0)
+import Data.Type.Equality
+import Data.Typeable (eqT)
+
+#else
+
+import Control.Category
+import Data.Typeable (Typeable, gcast)
+import Prelude hiding (id, (.))
+
+infix 4 :~:
+
+-- | Propositional equality. If @a :~: b@ is inhabited by some terminating
+-- value, then the type @a@ is the same as the type @b@. To use this equality
+-- in practice, pattern-match on the @a :~: b@ to get out the @Refl@ constructor;
+-- in the body of the pattern-match, the compiler knows that @a ~ b@.
+data a :~: b where
+  Refl :: a :~: a
+
+instance Category (:~:) where
+  id = Refl
+  Refl . Refl = Refl
+
+-- | Symmetry of equality
+sym :: (a :~: b) -> (b :~: a)
+sym Refl = Refl
+
+-- | Transitivity of equality
+trans :: (a :~: b) -> (b :~: c) -> (a :~: c)
+trans Refl Refl = Refl
+
+-- | Type-safe cast, using propositional equality
+castWith :: (a :~: b) -> a -> b
+castWith Refl x = x
+
+-- | Generalized form of type-safe cast using propositional equality
+gcastWith :: (a :~: b) -> ((a ~ b) => r) -> r
+gcastWith Refl x = x
+
+deriving instance Eq   (a :~: b)
+deriving instance Ord  (a :~: b)
+deriving instance Show (a :~: b)
+deriving instance a ~ b => Read (a :~: b)
+
+-- This can't be derived until 7.8, when we don't need it anymore.
+instance a ~ b => Bounded (a :~: b) where
+  minBound = Refl
+  maxBound = Refl
+
+instance a ~ b => Enum (a :~: b) where
+  toEnum 0 = Refl
+  toEnum _ = error "Control.Lens.Internal.Equality toEnum: bad argument"
+
+  fromEnum Refl = 0
+
+-- | Extract a witness of equality of two types
+eqT :: (Typeable a, Typeable b) => Maybe (a :~: b)
+eqT = gcast Refl
+#endif

--- a/src/Control/Lens/Iso.hs
+++ b/src/Control/Lens/Iso.hs
@@ -10,6 +10,10 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+{-# LANGUAGE TypeInType #-}
+#endif
+
 #ifndef MIN_VERSION_bytestring
 #define MIN_VERSION_bytestring(x,y,z) 1
 #endif
@@ -140,6 +144,10 @@ import Data.Type.Coercion
 import qualified GHC.Exts as Exts
 #endif
 
+#if __GLASGOW_HASKELL__ >= 800
+import GHC.Exts (TYPE)
+#endif
+
 #ifdef HLINT
 {-# ANN module "HLint: ignore Use on" #-}
 #endif
@@ -189,7 +197,12 @@ from l = withIso l $ flip iso
 
 -- | Extract the two functions, one from @s -> a@ and
 -- one from @b -> t@ that characterize an 'Iso'.
+#if __GLASGOW_HASKELL__ >= 800
+withIso :: forall s t a b rep (r :: TYPE rep).
+             AnIso s t a b -> ((s -> a) -> (b -> t) -> r) -> r
+#else
 withIso :: AnIso s t a b -> ((s -> a) -> (b -> t) -> r) -> r
+#endif
 withIso ai k = case ai (Exchange id Identity) of
   Exchange sa bt -> k sa (runIdentity #. bt)
 {-# INLINE withIso #-}


### PR DESCRIPTION
* Add several functions to `Control.Lens.Equality` mimicking
  similar ones in `Control.Lens.Iso`.

* Add `withLens` mimicking `withIso`.

* Make several CPS-style functions levity-polymorphic, because we
  can.

Closes #861
Closes #860