### PR TITLE
Fix #866

### DIFF
--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -320,10 +320,11 @@ makeReviewer conName fields =
 --          Con x y z -> Right (x,y,z)
 --          _         -> Left x
 -- ) :: s -> Either s a
-makeSimpleRemitter :: Name -- The name of the constructor on which this prism focuses
-                   -> Int  -- The number of constructors the parent data type has
-                   -> Int  -- The number of fields the constructor has
-                   -> ExpQ
+makeSimpleRemitter ::
+  Name {- The name of the constructor on which this prism focuses -} ->
+  Int  {- The number of constructors the parent data type has     -} ->
+  Int  {- The number of fields the constructor has                -} ->
+  ExpQ
 makeSimpleRemitter conName numCons fields =
   do x  <- newName "x"
      xs <- newNames "y" fields

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -441,6 +441,9 @@ makeLensesWith (defaultFieldRules & lensField .~ abbreviatedNamer ) ''CheckAbbre
 checkAbbreviatedNamer :: Lens' CheckAbbreviatedNamer Int
 checkAbbreviatedNamer = fieldAbbreviatedNamer
 
+-- Ensure that `makeClassyPrisms` doesn't generate a redundant catch-all case (#866)
+data T866 = MkT866
+$(makeClassyPrisms ''T866)
 
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
When generating a prism for a data type with only one constructor, avoid generating a catch-all case, as it is never necessary.