### PR TITLE
Disambiguate TH-generated classy prisms for punned data type names

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -7,6 +7,11 @@
 * Weaken `holeInOne`'s `Category p` constraint to `Comonad (Corep p)`.
 * Generalize the type of `GHC.Generics.Lens.generic1` from
   `Iso' (f a) (Rep1 f a)` to `Iso (f a) (f b) (Rep1 f a) (Rep1 f b)`.
+* `makeClassyPrisms` now supports generating prisms for data types that share
+  a name with one of its constructors. In such a scenario, the name of the
+  classy prism for the data type will be prefixed with an extra `_` (for
+  prefix names) or `.` (for infix names) to disambiguate it from the prism
+  for the constructor.
 * Add additional bifunctor instances for `Swapped`.
 * New lenses `head1` and `last1`, to access the first/last elements of
   a `Traversable1` container.

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -514,18 +514,24 @@ normalizeCon info = NCon (D.constructorName info)
 prismName :: Name -> Name
 prismName = prismName' False
 
-prismName' :: Bool -- ^ This is 'True' in the event that:
-                   --
-                   -- 1. We are generating the name of a classy prism for a
-                   --    data type, and
-                   -- 2. The data type shares a name with one of its
-                   --    constructors (e.g., @data A = A@).
-                   --
-                   -- In such a scenario, we take care not to generate the same
-                   -- prism name that the constructor receives (e.g., @_A@).
-                   -- For prefix names, we accomplish this by adding an extra
-                   -- underscore; for infix names, an extra dot.
-           -> Name -> Name
+-- | Compute a prism's name with a special case for when the type
+-- constructor matches one of the value constructors.
+--
+-- The overlapping flag wil be 'True' in the event that:
+--
+-- 1. We are generating the name of a classy prism for a
+--    data type, and
+-- 2. The data type shares a name with one of its
+--    constructors (e.g., @data A = A@).
+--
+-- In such a scenario, we take care not to generate the same
+-- prism name that the constructor receives (e.g., @_A@).
+-- For prefix names, we accomplish this by adding an extra
+-- underscore; for infix names, an extra dot.
+prismName' ::
+  Bool {- ^ overlapping constructor -} ->
+  Name {- ^ type constructor        -} ->
+  Name {- ^ prism name              -}
 prismName' sameNameAsCon n =
   case nameBase n of
     [] -> error "prismName: empty name base?"

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -445,5 +445,12 @@ checkAbbreviatedNamer = fieldAbbreviatedNamer
 data T866 = MkT866
 $(makeClassyPrisms ''T866)
 
+-- Ensure that `makeClassyPrisms` doesn't generate duplicate prism names for
+-- data types that share a name with one of its constructors (#865)
+data T865 = T865 | T865a | T865b T866
+$(makeClassyPrisms ''T865)
+instance AsT866 T865 where
+  _T866 = __T865 . _T866
+
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
Consider a scenario in which one uses Template Haskell to generate classy prisms for a data type that shares a name with one of its constructors, as in the following example from #865:

```hs
newtype SDLException = SDLException String deriving Show
makeClassyPrisms ''SDLException
```

We clearly can't use the name `_SDLException` to refer to both the prism for the data type and the prism for the constructor, so we need to disambiguate them somehow. This patch adopts the convention that in such a scenario, the name of the prism for the data type will be prefixed with an extra `_` (i.e., `__SDLException`) to distinguish it from the constructor prism, `_SDLException`.

Fixes #865.