### PR TITLE
Fuse liftMs in Zoom for FreeT

### DIFF
--- a/src/Control/Lens/Zoom.hs
+++ b/src/Control/Lens/Zoom.hs
@@ -197,7 +197,7 @@ instance Zoom m n s t => Zoom (ExceptT e m) (ExceptT e n) s t where
   {-# INLINE zoom #-}
 
 instance (Functor f, Zoom m n s t) => Zoom (FreeT f m) (FreeT f n) s t where
-  zoom l = FreeT . liftM (fmap $ zoom l) . liftM getFreed . zoom (\afb -> unfocusingFree #.. l (FocusingFree #.. afb)) . liftM Freed . runFreeT
+  zoom l = FreeT . liftM (fmap (zoom l) . getFreed) . zoom (\afb -> unfocusingFree #.. l (FocusingFree #.. afb)) . liftM Freed . runFreeT
 
 ------------------------------------------------------------------------------
 -- Magnify


### PR DESCRIPTION
According to the second Functor law, we can always fuse consecutive applications of `liftM`. We don't know if the monadic bind is cheap, so we certainly should do so.