### PR TITLE
Remove -traditional flag from cpp

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -326,8 +326,6 @@ library
   other-modules:
     Paths_lens
 
-  cpp-options: -traditional
-
   if flag(safe)
     cpp-options: -DSAFE=1
 


### PR DESCRIPTION
This seems to have been breaking profiling builds on GHC 8.8.