### PR TITLE
Re-enable -Wunused-matches

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -345,9 +345,8 @@ library
   if impl(ghc<7.4)
     ghc-options: -fno-spec-constr-count
 
-  -- hack around the buggy unused matches check for class associated types in ghc 8 rc1
   if impl(ghc >= 8)
-    ghc-options: -Wno-missing-pattern-synonym-signatures -Wno-unused-matches
+    ghc-options: -Wno-missing-pattern-synonym-signatures
 
   if flag(j) && impl(ghc>=7.8)
     ghc-options: -j4

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -613,7 +613,7 @@ instance TraversableWithIndex () Identity where
   {-# INLINE itraverse #-}
 
 instance FunctorWithIndex Void (Const e) where
-  imap f (Const a) = Const a
+  imap _ (Const a) = Const a
   {-# INLINE imap #-}
 
 instance FoldableWithIndex Void (Const e) where
@@ -621,11 +621,11 @@ instance FoldableWithIndex Void (Const e) where
   {-# INLINE ifoldMap #-}
 
 instance TraversableWithIndex Void (Const e) where
-  itraverse f (Const a) = pure (Const a)
+  itraverse _ (Const a) = pure (Const a)
   {-# INLINE itraverse #-}
 
 instance FunctorWithIndex Void (Constant e) where
-  imap f (Constant a) = Constant a
+  imap _ (Constant a) = Constant a
   {-# INLINE imap #-}
 
 instance FoldableWithIndex Void (Constant e) where
@@ -633,7 +633,7 @@ instance FoldableWithIndex Void (Constant e) where
   {-# INLINE ifoldMap #-}
 
 instance TraversableWithIndex Void (Constant e) where
-  itraverse f (Constant a) = pure (Constant a)
+  itraverse _ (Constant a) = pure (Constant a)
   {-# INLINE itraverse #-}
 
 instance FunctorWithIndex k ((,) k) where


### PR DESCRIPTION
Commit b2e0efe6842f25c545291579baecf8790ee24636 added `-Wno-unused-matches` to `lens.cabal` in an effort to work around [GHC#11451](https://gitlab.haskell.org/ghc/ghc/issues/11451), which affected GHC 8.0.1-rc1 (the newest compiler at the time). However, #11451 has since been fixed, and as far as I can tell, it does not affect the latest point release of GHC 8.0 (8.0.2). In light of this, it seems a bit silly to me to specifically disable this warning when it no longer provides any tangible benefit. Let's reenable it.