### PR TITLE
Require semigroup in <>~

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,7 +1,9 @@
-next [????.??.??]
+4.19 [????.??.??]
 -----------------
 * Add `{Functor,Foldable,Traversable}WithIndex` instances for
   `Control.Applicative.Const` and `Data.Functor.Constant.Constant`.
+* Make `<>~` and `<>=` and their `<op` and `<<op` state variants require only
+  `Semigroup`, not `Monoid`
 
 4.18.1 [2019.09.13]
 -------------------

--- a/benchmarks/plated.hs
+++ b/benchmarks/plated.hs
@@ -7,9 +7,8 @@
 #define MIN_VERSION_base(x,y,z) 1
 #endif
 
-#if !(MIN_VERSION_base(4,8,0))
-import           Control.Applicative
-#endif
+import Prelude ()
+import Prelude.Compat
 
 import           Control.Lens
 import           Control.DeepSeq

--- a/lens.cabal
+++ b/lens.cabal
@@ -1,6 +1,6 @@
 name:          lens
 category:      Data, Lenses, Generics
-version:       4.18.1
+version:       4.19
 license:       BSD2
 cabal-version: 1.18
 license-file:  LICENSE

--- a/lens.cabal
+++ b/lens.cabal
@@ -327,6 +327,7 @@ library
     Numeric.Natural.Lens
 
   other-modules:
+    Control.Lens.Internal.Prelude
     Paths_lens
 
   if flag(safe)
@@ -464,6 +465,7 @@ benchmark plated
   default-language: Haskell2010
   build-depends:
     base,
+    base-compat >=0.11.0 && <0.12,
     comonad,
     criterion,
     deepseq,

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -150,7 +150,9 @@ module Control.Lens.Fold
   , foldMapByOf
   ) where
 
-import Control.Applicative as Applicative
+import Prelude ()
+
+import Control.Applicative (Alternative (..))
 import Control.Applicative.Backwards
 import Control.Comonad
 import Control.Lens.Getter
@@ -158,19 +160,18 @@ import Control.Lens.Internal.Fold
 import Control.Lens.Internal.Getter
 import Control.Lens.Internal.Indexed
 import Control.Lens.Internal.Magma
+import Control.Lens.Internal.Prelude
 import Control.Lens.Type
 import Control.Monad as Monad
 import Control.Monad.Reader
 import Control.Monad.State
 import Data.CallStack
-import Data.Foldable
 import Data.Functor.Apply hiding ((<.))
-import Data.Functor.Compose
 import Data.Functor.Contravariant
 import Data.Int (Int64)
 import Data.List (intercalate)
-import Data.Maybe
-import Data.Monoid
+import Data.Maybe (fromMaybe)
+import Data.Monoid (First (..), Endo (..), Dual (..), All (..), Any (..))
 import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
@@ -178,8 +179,6 @@ import Data.Profunctor.Unsafe
 #if MIN_VERSION_reflection(2,1,0)
 import Data.Reflection
 #endif
-import Data.Traversable
-import Prelude hiding (foldr)
 
 import qualified Data.Semigroup as Semi
 import Data.List.NonEmpty (NonEmpty(..))
@@ -195,6 +194,7 @@ import Data.List.NonEmpty (NonEmpty(..))
 -- >>> import Control.DeepSeq (NFData (..), force)
 -- >>> import Control.Exception (evaluate)
 -- >>> import Data.Maybe (fromMaybe)
+-- >>> import Data.Monoid (Sum (..))
 -- >>> import System.Timeout (timeout)
 -- >>> import qualified Data.Map as Map
 -- >>> let f :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
@@ -1102,7 +1102,7 @@ sequenceOf_ l = liftM skip . getSequenced #. foldMapOf l Sequenced
 -- 'asumOf' :: 'Alternative' f => 'Prism'' s (f a)     -> s -> f a
 -- @
 asumOf :: Alternative f => Getting (Endo (f a)) s (f a) -> s -> f a
-asumOf l = foldrOf l (<|>) Applicative.empty
+asumOf l = foldrOf l (<|>) empty
 {-# INLINE asumOf #-}
 
 -- | The sum of a collection of actions, generalizing 'concatOf'.

--- a/src/Control/Lens/Internal/Prelude.hs
+++ b/src/Control/Lens/Internal/Prelude.hs
@@ -1,0 +1,118 @@
+{-# LANGUAGE CPP #-}
+-- | Module which does most common imports (and related CPP)
+-- needed across the lens library.
+--
+-- This module is intended to stay in other-modules of lens,
+-- perfectly we'd just use @base-compat-batteries@
+-- and not reinvent the wheel.
+-- That's a reason why this module is different from
+-- other .Internal modules, which are exposed-modules.
+--
+--
+module Control.Lens.Internal.Prelude
+  ( module Prelude
+  , Semigroup (..)
+  , Monoid (..)
+  , Foldable, foldMap, foldr, foldl', null, length, traverse_
+  , Traversable (..)
+  , Applicative (..)
+  , (&), (<&>), (<$>)
+  -- * Functors
+  , Identity (..)
+  , Compose (..)
+  , Const (..)
+  -- * Data.Void
+  , Void, absurd
+  ) where
+
+import Prelude hiding
+    ( userError -- hiding something always helps with CPP
+#if MIN_VERSION_base(4,8,0)
+    , Applicative (..)
+    , Foldable (..)
+    , Traversable (..)
+    , Monoid (..)
+    , (<$>)
+#else
+    , foldr, length, null
+    , mapM, sequence
+#endif
+#if MIN_VERSION_base(4,13,0)
+    , Semigroup (..)
+#endif
+    )
+
+import Control.Applicative (Applicative (..), (<$>)) -- N.B. liftA2
+import Data.Foldable (Foldable, foldMap, foldr, foldl', traverse_) -- N.B. we don't define Foldable instances, so this way is makes less CPP
+import Data.Monoid (Monoid (..))
+import Data.Semigroup (Semigroup (..))
+import Data.Traversable (Traversable (..))
+
+#if MIN_VERSION_base(4,8,0)
+import Data.Function ((&))
+import Data.Foldable (length, null)
+#endif
+
+#if MIN_VERSION_base(4,11,0)
+import Data.Functor ((<&>))
+#endif
+
+import Control.Applicative (Const (..))
+import Data.Functor.Identity (Identity (..))
+import Data.Functor.Compose (Compose (..))
+import Data.Void (Void, absurd)
+
+-- $setup
+-- >>> import Control.Lens
+-- >>> import Control.Monad.State
+-- >>> import Debug.SimpleReflect.Expr
+-- >>> import Debug.SimpleReflect.Vars as Vars hiding (f,g,h)
+-- >>> let f :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
+-- >>> let g :: Expr -> Expr; g = Debug.SimpleReflect.Vars.g
+-- >>> let h :: Expr -> Expr -> Expr; h = Debug.SimpleReflect.Vars.h
+
+#if !(MIN_VERSION_base(4,8,0))
+-- | Passes the result of the left side to the function on the right side (forward pipe operator).
+--
+-- This is the flipped version of ('$'), which is more common in languages like F# as (@|>@) where it is needed
+-- for inference. Here it is supplied for notational convenience and given a precedence that allows it
+-- to be nested inside uses of ('$').
+--
+-- >>> a & f
+-- f a
+--
+-- >>> "hello" & length & succ
+-- 6
+--
+-- This combinator is commonly used when applying multiple 'Lens' operations in sequence.
+--
+-- >>> ("hello","world") & _1.element 0 .~ 'j' & _1.element 4 .~ 'y'
+-- ("jelly","world")
+--
+-- This reads somewhat similar to:
+--
+-- >>> flip execState ("hello","world") $ do _1.element 0 .= 'j'; _1.element 4 .= 'y'
+-- ("jelly","world")
+(&) :: a -> (a -> b) -> b
+a & f = f a
+{-# INLINE (&) #-}
+infixl 1 &
+
+null :: Foldable t => t a -> Bool
+null = foldr (\_ _ -> False) True
+
+length :: Foldable t => t a -> Int
+length = foldl' (\c _ -> c+1) 0
+#endif
+
+#if !(MIN_VERSION_base(4,11,0))
+-- | Infix flipped 'fmap'.
+--
+-- @
+-- ('<&>') = 'flip' 'fmap'
+-- @
+(<&>) :: Functor f => f a -> (a -> b) -> f b
+as <&> f = f <$> as
+{-# INLINE (<&>) #-}
+infixl 1 <&>
+#endif

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -132,10 +132,12 @@ module Control.Lens.Lens
   , fusing
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Arrow
 import Control.Comonad
 import Control.Lens.Internal.Context
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Getter
 import Control.Lens.Internal.Indexed
 import Control.Lens.Type
@@ -147,16 +149,7 @@ import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
-import Data.Semigroup (Semigroup (..))
 import Data.Semigroup.Traversable
-import Data.Void
-import Prelude
-#if MIN_VERSION_base(4,8,0)
-import Data.Function ((&))
-#endif
-#if MIN_VERSION_base(4,11,0)
-import Data.Functor ((<&>))
-#endif
 #if __GLASGOW_HASKELL__ >= 800
 import GHC.Exts (TYPE)
 #endif
@@ -352,47 +345,6 @@ l %%= f = do
 -------------------------------------------------------------------------------
 -- General Purpose Combinators
 -------------------------------------------------------------------------------
-
-
-#if !(MIN_VERSION_base(4,8,0))
--- | Passes the result of the left side to the function on the right side (forward pipe operator).
---
--- This is the flipped version of ('$'), which is more common in languages like F# as (@|>@) where it is needed
--- for inference. Here it is supplied for notational convenience and given a precedence that allows it
--- to be nested inside uses of ('$').
---
--- >>> a & f
--- f a
---
--- >>> "hello" & length & succ
--- 6
---
--- This combinator is commonly used when applying multiple 'Lens' operations in sequence.
---
--- >>> ("hello","world") & _1.element 0 .~ 'j' & _1.element 4 .~ 'y'
--- ("jelly","world")
---
--- This reads somewhat similar to:
---
--- >>> flip execState ("hello","world") $ do _1.element 0 .= 'j'; _1.element 4 .= 'y'
--- ("jelly","world")
-(&) :: a -> (a -> b) -> b
-a & f = f a
-{-# INLINE (&) #-}
-infixl 1 &
-#endif
-
-#if !(MIN_VERSION_base(4,11,0))
--- | Infix flipped 'fmap'.
---
--- @
--- ('<&>') = 'flip' 'fmap'
--- @
-(<&>) :: Functor f => f a -> (a -> b) -> f b
-as <&> f = f <$> as
-{-# INLINE (<&>) #-}
-infixl 1 <&>
-#endif
 
 -- | This is convenient to 'flip' argument order of composite functions defined as:
 --

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -143,11 +143,11 @@ import Control.Monad.State as State
 import Data.Functor.Apply
 import Data.Functor.Reverse
 import Data.Functor.Yoneda
-import Data.Monoid
 import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
+import Data.Semigroup (Semigroup (..))
 import Data.Semigroup.Traversable
 import Data.Void
 import Prelude
@@ -171,6 +171,7 @@ import GHC.Exts (TYPE)
 -- >>> import Control.Monad.State
 -- >>> import Data.Char (chr)
 -- >>> import Data.List.NonEmpty (NonEmpty ((:|)))
+-- >>> import Data.Monoid (Sum (..))
 -- >>> import Data.Tree (Tree (Node))
 -- >>> import Debug.SimpleReflect.Expr
 -- >>> import Debug.SimpleReflect.Vars as Vars hiding (f,g,h)
@@ -887,7 +888,7 @@ l <<||~ b = l $ \a -> (a, b || a)
 l <<&&~ b = l $ \a -> (a, b && a)
 {-# INLINE (<<&&~) #-}
 
--- | Modify the target of a monoidally valued 'Lens' by 'mappend'ing a new value and return the old value.
+-- | Modify the target of a monoidally valued 'Lens' by using ('<>') a new value and return the old value.
 --
 -- When you do not need the old value, ('Control.Lens.Setter.<>~') is more flexible.
 --
@@ -898,11 +899,11 @@ l <<&&~ b = l $ \a -> (a, b && a)
 -- ("Bond",("James","Bond, 007"))
 --
 -- @
--- ('<<<>~') :: 'Monoid' r => 'Lens'' s r -> r -> s -> (r, s)
--- ('<<<>~') :: 'Monoid' r => 'Iso'' s r -> r -> s -> (r, s)
+-- ('<<<>~') :: 'Semigroup' r => 'Lens'' s r -> r -> s -> (r, s)
+-- ('<<<>~') :: 'Semigroup' r => 'Iso'' s r -> r -> s -> (r, s)
 -- @
-(<<<>~) :: Monoid r => LensLike' ((,) r) s r -> r -> s -> (r, s)
-l <<<>~ b = l $ \a -> (a, a `mappend` b)
+(<<<>~) :: Semigroup r => LensLike' ((,) r) s r -> r -> s -> (r, s)
+l <<<>~ b = l $ \a -> (a, a <> b)
 {-# INLINE (<<<>~) #-}
 
 -------------------------------------------------------------------------------
@@ -1217,17 +1218,17 @@ l <<||= b = l %%= \a -> (a, a || b)
 l <<&&= b = l %%= \a -> (a, a && b)
 {-# INLINE (<<&&=) #-}
 
--- | Modify the target of a 'Lens' into your 'Monad''s state by 'mappend'ing a value
+-- | Modify the target of a 'Lens' into your 'Monad''s state by using ('<>')
 -- and return the /old/ value that was replaced.
 --
 -- When you do not need the result of the operation, ('Control.Lens.Setter.<>=') is more flexible.
 --
 -- @
--- ('<<<>=') :: ('MonadState' s m, 'Monoid' r) => 'Lens'' s r -> r -> m r
--- ('<<<>=') :: ('MonadState' s m, 'Monoid' r) => 'Iso'' s r -> r -> m r
+-- ('<<<>=') :: ('MonadState' s m, 'Semigroup' r) => 'Lens'' s r -> r -> m r
+-- ('<<<>=') :: ('MonadState' s m, 'Semigroup' r) => 'Iso'' s r -> r -> m r
 -- @
-(<<<>=) :: (MonadState s m, Monoid r) => LensLike' ((,) r) s r -> r -> m r
-l <<<>= b = l %%= \a -> (a, a `mappend` b)
+(<<<>=) :: (MonadState s m, Semigroup r) => LensLike' ((,) r) s r -> r -> m r
+l <<<>= b = l %%= \a -> (a, a <> b)
 {-# INLINE (<<<>=) #-}
 
 -- | Run a monadic action, and set the target of 'Lens' to its result.
@@ -1246,20 +1247,20 @@ l <<~ mb = do
   return b
 {-# INLINE (<<~) #-}
 
--- | 'mappend' a monoidal value onto the end of the target of a 'Lens' and
+-- | ('<>') a 'Semigroup' value onto the end of the target of a 'Lens' and
 -- return the result.
 --
 -- When you do not need the result of the operation, ('Control.Lens.Setter.<>~') is more flexible.
-(<<>~) :: Monoid m => LensLike ((,)m) s t m m -> m -> s -> (m, t)
-l <<>~ m = l <%~ (`mappend` m)
+(<<>~) :: Semigroup m => LensLike ((,)m) s t m m -> m -> s -> (m, t)
+l <<>~ m = l <%~ (<> m)
 {-# INLINE (<<>~) #-}
 
--- | 'mappend' a monoidal value onto the end of the target of a 'Lens' into
+-- | ('<>') a 'Semigroup' value onto the end of the target of a 'Lens' into
 -- your 'Monad''s state and return the result.
 --
 -- When you do not need the result of the operation, ('Control.Lens.Setter.<>=') is more flexible.
-(<<>=) :: (MonadState s m, Monoid r) => LensLike' ((,)r) s r -> r -> m r
-l <<>= r = l <%= (`mappend` r)
+(<<>=) :: (MonadState s m, Semigroup r) => LensLike' ((,)r) s r -> r -> m r
+l <<>= r = l <%= (<> r)
 {-# INLINE (<<>=) #-}
 
 ------------------------------------------------------------------------------

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -79,9 +79,11 @@ module Control.Lens.Setter
   , mapOf
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Arrow
 import Control.Comonad
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Indexed
 import Control.Lens.Internal.Setter
 import Control.Lens.Type
@@ -90,14 +92,10 @@ import Control.Monad.Reader.Class as Reader
 import Control.Monad.State.Class  as State
 import Control.Monad.Writer.Class as Writer
 import Data.Functor.Contravariant
-import Data.Functor.Identity
-import Data.Monoid (Monoid (..))
 import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
-import Data.Semigroup (Semigroup (..))
-import Prelude
 
 #ifdef HLINT
 {-# ANN module "HLint: ignore Avoid lambda" #-}
@@ -109,6 +107,7 @@ import Prelude
 -- >>> import Control.Monad.State
 -- >>> import Data.Char
 -- >>> import Data.Map as Map
+-- >>> import Data.Semigroup (Sum (..), Product (..))
 -- >>> import Debug.SimpleReflect.Expr as Expr
 -- >>> import Debug.SimpleReflect.Vars as Vars
 -- >>> let f :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
@@ -117,7 +116,6 @@ import Prelude
 -- >>> let getter :: Expr -> Expr; getter = fun "getter"
 -- >>> let setter :: Expr -> Expr -> Expr; setter = fun "setter"
 -- >>> :set -XNoOverloadedStrings
--- >>> import Data.Semigroup (Sum (..), Product (..))
 
 infixr 4 %@~, .@~, .~, +~, *~, -~, //~, ^~, ^^~, **~, &&~, <>~, ||~, %~, <.~, ?~, <?~
 infix  4 %@=, .@=, .=, +=, *=, -=, //=, ^=, ^^=, **=, &&=, <>=, ||=, %=, <.=, ?=, <?=

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -91,11 +91,12 @@ import Control.Monad.State.Class  as State
 import Control.Monad.Writer.Class as Writer
 import Data.Functor.Contravariant
 import Data.Functor.Identity
-import Data.Monoid
+import Data.Monoid (Monoid (..))
 import Data.Profunctor
 import Data.Profunctor.Rep
 import Data.Profunctor.Sieve
 import Data.Profunctor.Unsafe
+import Data.Semigroup (Semigroup (..))
 import Prelude
 
 #ifdef HLINT
@@ -116,6 +117,7 @@ import Prelude
 -- >>> let getter :: Expr -> Expr; getter = fun "getter"
 -- >>> let setter :: Expr -> Expr -> Expr; setter = fun "setter"
 -- >>> :set -XNoOverloadedStrings
+-- >>> import Data.Semigroup (Sum (..), Product (..))
 
 infixr 4 %@~, .@~, .~, +~, *~, -~, //~, ^~, ^^~, **~, &&~, <>~, ||~, %~, <.~, ?~, <?~
 infix  4 %@=, .@=, .=, +=, *=, -=, //=, ^=, ^^=, **=, &&=, <>=, ||=, %=, <.=, ?=, <?=
@@ -1043,7 +1045,7 @@ l <?= b = do
   return b
 {-# INLINE (<?=) #-}
 
--- | Modify the target of a monoidally valued by 'mappend'ing another value.
+-- | Modify the target of a 'Semigroup' value by using @('<>')@.
 --
 -- >>> (Sum a,b) & _1 <>~ Sum c
 -- (Sum {getSum = a + c},b)
@@ -1055,16 +1057,16 @@ l <?= b = do
 -- ("hello!!!","world!!!")
 --
 -- @
--- ('<>~') :: 'Monoid' a => 'Setter' s t a a    -> a -> s -> t
--- ('<>~') :: 'Monoid' a => 'Iso' s t a a       -> a -> s -> t
--- ('<>~') :: 'Monoid' a => 'Lens' s t a a      -> a -> s -> t
--- ('<>~') :: 'Monoid' a => 'Traversal' s t a a -> a -> s -> t
+-- ('<>~') :: 'Semigroup' a => 'Setter' s t a a    -> a -> s -> t
+-- ('<>~') :: 'Semigroup' a => 'Iso' s t a a       -> a -> s -> t
+-- ('<>~') :: 'Semigroup' a => 'Lens' s t a a      -> a -> s -> t
+-- ('<>~') :: 'Semigroup' a => 'Traversal' s t a a -> a -> s -> t
 -- @
-(<>~) :: Monoid a => ASetter s t a a -> a -> s -> t
-l <>~ n = over l (`mappend` n)
+(<>~) :: Semigroup a => ASetter s t a a -> a -> s -> t
+l <>~ n = over l (<> n)
 {-# INLINE (<>~) #-}
 
--- | Modify the target(s) of a 'Lens'', 'Iso', 'Setter' or 'Traversal' by 'mappend'ing a value.
+-- | Modify the target(s) of a 'Lens'', 'Iso', 'Setter' or 'Traversal' by using @('<>')@.
 --
 -- >>> execState (do _1 <>= Sum c; _2 <>= Product d) (Sum a,Product b)
 -- (Sum {getSum = a + c},Product {getProduct = b * d})
@@ -1073,12 +1075,12 @@ l <>~ n = over l (`mappend` n)
 -- ("hello!!!","world!!!")
 --
 -- @
--- ('<>=') :: ('MonadState' s m, 'Monoid' a) => 'Setter'' s a -> a -> m ()
--- ('<>=') :: ('MonadState' s m, 'Monoid' a) => 'Iso'' s a -> a -> m ()
--- ('<>=') :: ('MonadState' s m, 'Monoid' a) => 'Lens'' s a -> a -> m ()
--- ('<>=') :: ('MonadState' s m, 'Monoid' a) => 'Traversal'' s a -> a -> m ()
+-- ('<>=') :: ('MonadState' s m, 'Semigroup' a) => 'Setter'' s a -> a -> m ()
+-- ('<>=') :: ('MonadState' s m, 'Semigroup' a) => 'Iso'' s a -> a -> m ()
+-- ('<>=') :: ('MonadState' s m, 'Semigroup' a) => 'Lens'' s a -> a -> m ()
+-- ('<>=') :: ('MonadState' s m, 'Semigroup' a) => 'Traversal'' s a -> a -> m ()
 -- @
-(<>=) :: (MonadState s m, Monoid a) => ASetter' s a -> a -> m ()
+(<>=) :: (MonadState s m, Semigroup a) => ASetter' s a -> a -> m ()
 l <>= a = State.modify (l <>~ a)
 {-# INLINE (<>=) #-}
 

--- a/src/Control/Lens/Unsound.hs
+++ b/src/Control/Lens/Unsound.hs
@@ -5,10 +5,6 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 
-#ifndef MIN_VERSION_mtl
-#define MIN_VERSION_mtl(x,y,z) 1
-#endif
-
 #if __GLASGOW_HASKELL__ < 708
 {-# LANGUAGE Trustworthy #-}
 #endif
@@ -37,9 +33,9 @@ module Control.Lens.Unsound
   , adjoin
   ) where
 
-import Control.Applicative
 import Control.Lens
-import Prelude
+import Control.Lens.Internal.Prelude
+import Prelude ()
 
 -- | A lens product. There is no law-abiding way to do this in general.
 -- Result is only a valid 'Lens' if the input lenses project disjoint parts of


### PR DESCRIPTION
I'm keen on doing this, as the next release could be the `4.19` if we also include e.g. GHC-8.10 required template-haskell changes

This change is "requested" on IRC

```
<idnar> is there a Semigroup version of (<>~)?
```
