### PR TITLE
Consolidate CPP in lens-common.h, lens.cabal, and C.L.Internal.Prelude

### DIFF
--- a/include/lens-common.h
+++ b/include/lens-common.h
@@ -7,4 +7,44 @@
 # define KVS(kvs)
 #endif
 
+#ifndef MIN_VERSION_base
+#define MIN_VERSION_base(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_bytestring
+#define MIN_VERSION_bytestring(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_containers
+#define MIN_VERSION_containers(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_exceptions
+#define MIN_VERSION_exceptions 1
+#endif
+
+#ifndef MIN_VERSION_free
+#define MIN_VERSION_free(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_mtl
+#define MIN_VERSION_mtl(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_parallel
+#define MIN_VERSION_parallel(x,y,z) (defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL > 700)
+#endif
+
+#ifndef MIN_VERSION_reflection
+#define MIN_VERSION_reflection(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_template_haskell
+#define MIN_VERSION_template_haskell(x,y,z) 1
+#endif
+
+#ifndef MIN_VERSION_vector
+#define MIN_VERSION_vector(x,y,z) 1
+#endif
+
 #endif

--- a/lens.cabal
+++ b/lens.cabal
@@ -346,8 +346,12 @@ library
   if impl(ghc<7.4)
     ghc-options: -fno-spec-constr-count
 
+  if impl(ghc >= 7.10)
+    ghc-options: -fno-warn-trustworthy-safe
+
   if impl(ghc >= 8)
     ghc-options: -Wno-missing-pattern-synonym-signatures
+    ghc-options: -Wno-redundant-constraints
 
   if flag(j) && impl(ghc>=7.8)
     ghc-options: -j4

--- a/src/Control/Exception/Lens.hs
+++ b/src/Control/Exception/Lens.hs
@@ -14,17 +14,12 @@
 {-# LANGUAGE ViewPatterns #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_exceptions
-#define MIN_VERSION_exceptions 1
-#endif
+#include "lens-common.h"
 
 #if !(MIN_VERSION_exceptions(0,4,0))
 #define MonadThrow MonadCatch
 #endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Exception.Lens

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -14,17 +14,8 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#if __GLASGOW_HASKELL__ >= 711
-{-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
-#endif
+#include "lens-common.h"
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_containers
-#define MIN_VERSION_containers(x,y,z) 1
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.At

--- a/src/Control/Lens/Each.hs
+++ b/src/Control/Lens/Each.hs
@@ -10,9 +10,8 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Each

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -4,16 +4,9 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ConstraintKinds #-}
-
-#ifndef MIN_VERSION_reflection
-#define MIN_VERSION_reflection(x,y,z) 1
-#endif
-
 {-# LANGUAGE Trustworthy #-}
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
 
+#include "lens-common.h"
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 ----------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Getter.hs
+++ b/src/Control/Lens/Getter.hs
@@ -16,9 +16,6 @@
 {-# OPTIONS_GHC -fno-warn-redundant-constraints #-}
 #endif
 
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Getter

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -12,13 +12,8 @@
 {-# LANGUAGE Trustworthy #-} -- vector, hashable
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
 
-#ifndef MIN_VERSION_containers
-#define MIN_VERSION_containers(x,y,z) 1
-#endif
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Indexed

--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -7,13 +7,7 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_bytestring
-#define MIN_VERSION_bytestring(x,y,z) 1
-#endif
+#include "lens-common.h"
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Internal/Deque.hs
+++ b/src/Control/Lens/Internal/Deque.hs
@@ -3,10 +3,8 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 
+#include "lens-common.h"
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Internal.Deque

--- a/src/Control/Lens/Internal/Exception.hs
+++ b/src/Control/Lens/Internal/Exception.hs
@@ -12,9 +12,8 @@
 {-# LANGUAGE RoleAnnotations #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Internal.Exception

--- a/src/Control/Lens/Internal/Prelude.hs
+++ b/src/Control/Lens/Internal/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+#include "lens-common.h"
 -- | Module which does most common imports (and related CPP)
 -- needed across the lens library.
 --
@@ -16,7 +17,7 @@ module Control.Lens.Internal.Prelude
   , Foldable, foldMap, foldr, foldl', null, length, traverse_
   , Traversable (..)
   , Applicative (..)
-  , (&), (<&>), (<$>)
+  , (&), (<&>), (<$>), (<$)
   -- * Functors
   , Identity (..)
   , Compose (..)
@@ -32,7 +33,7 @@ import Prelude hiding
     , Foldable (..)
     , Traversable (..)
     , Monoid (..)
-    , (<$>)
+    , (<$>), (<$)
 #else
     , foldr, length, null
     , mapM, sequence
@@ -42,7 +43,7 @@ import Prelude hiding
 #endif
     )
 
-import Control.Applicative (Applicative (..), (<$>)) -- N.B. liftA2
+import Control.Applicative (Applicative (..), (<$>), (<$)) -- N.B. liftA2
 import Data.Foldable (Foldable, foldMap, foldr, foldl', traverse_) -- N.B. we don't define Foldable instances, so this way is makes less CPP
 import Data.Monoid (Monoid (..))
 import Data.Semigroup (Semigroup (..))

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -3,13 +3,8 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
+#include "lens-common.h"
 
-#ifndef MIN_VERSION_template_haskell
-#define MIN_VERSION_template_haskell(x,y,z) 1
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Internal.PrismTH

--- a/src/Control/Lens/Internal/TH.hs
+++ b/src/Control/Lens/Internal/TH.hs
@@ -7,17 +7,8 @@
 # endif
 #endif
 
-#ifndef MIN_VERSION_template_haskell
-#define MIN_VERSION_template_haskell(x,y,z) (defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706)
-#endif
+#include "lens-common.h"
 
-#ifndef MIN_VERSION_containers
-#define MIN_VERSION_containers(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Internal.TH

--- a/src/Control/Lens/Internal/Zoom.hs
+++ b/src/Control/Lens/Internal/Zoom.hs
@@ -4,10 +4,6 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE Trustworthy #-}
 
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
-
 {-# OPTIONS_GHC -fno-warn-orphans -fno-warn-warnings-deprecations #-}
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Iso.hs
+++ b/src/Control/Lens/Iso.hs
@@ -14,9 +14,7 @@
 {-# LANGUAGE TypeInType #-}
 #endif
 
-#ifndef MIN_VERSION_bytestring
-#define MIN_VERSION_bytestring(x,y,z) 1
-#endif
+#include "lens-common.h"
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -10,13 +10,7 @@
 {-# LANGUAGE TypeInType #-}
 #endif
 
-#ifndef MIN_VERSION_mtl
-#define MIN_VERSION_mtl(x,y,z) 1
-#endif
-
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
+#include "lens-common.h"
 
 -------------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Plated.hs
+++ b/src/Control/Lens/Plated.hs
@@ -10,6 +10,10 @@
 {-# LANGUAGE PolyKinds #-} -- gplate1
 #endif
 
+#ifdef TRUSTWORTHY
+{-# LANGUAGE Trustworthy #-} -- template-haskell
+#endif
+
 #if __GLASGOW_HASKELL__ < 710
 {-# LANGUAGE OverlappingInstances #-}
 #define OVERLAPPING_PRAGMA
@@ -17,25 +21,8 @@
 #define OVERLAPPING_PRAGMA {-# OVERLAPPING #-}
 #endif
 
-#ifdef TRUSTWORTHY
-{-# LANGUAGE Trustworthy #-} -- template-haskell
-#endif
+#include "lens-common.h"
 
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
-
-#ifndef MIN_VERSION_template_haskell
-#define MIN_VERSION_template_haskell(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_free
-#define MIN_VERSION_free(x,y,z) 1
-#endif
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Plated

--- a/src/Control/Lens/Prism.hs
+++ b/src/Control/Lens/Prism.hs
@@ -5,9 +5,7 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
 
 -------------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -5,9 +5,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE Trustworthy #-}
 
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Setter

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -8,13 +8,8 @@
 # endif
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
 
-#ifndef MIN_VERSION_template_haskell
-#define MIN_VERSION_template_haskell(x,y,z) (defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL__ >= 706)
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.TH

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -8,9 +8,8 @@
 {-# LANGUAGE Trustworthy #-}
 {-# LANGUAGE ConstraintKinds #-}
 
-#ifndef MIN_VERSION_containers
-#define MIN_VERSION_containers(x,y,z) 1
-#endif
+#include "lens-common.h"
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Traversal

--- a/src/Control/Lens/Tuple.hs
+++ b/src/Control/Lens/Tuple.hs
@@ -14,9 +14,7 @@
 {-# LANGUAGE PolyKinds #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
 
 -------------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -13,9 +13,6 @@
 {-# LANGUAGE TypeInType #-}
 #endif
 {-# LANGUAGE Trustworthy #-}
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Lens.Type

--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -23,9 +23,7 @@
 
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
+#include "lens-common.h"
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Control/Lens/Zoom.hs
+++ b/src/Control/Lens/Zoom.hs
@@ -7,13 +7,11 @@
 {-# LANGUAGE RankNTypes #-}
 {-# OPTIONS_GHC -fno-warn-warnings-deprecations #-}
 
-#ifndef MIN_VERSION_mtl
-#define MIN_VERSION_mtl(x,y,z) 1
-#endif
-
 #if __GLASGOW_HASKELL__ < 708
 {-# LANGUAGE Trustworthy #-}
 #endif
+
+#include "lens-common.h"
 
 -------------------------------------------------------------------------------
 -- |

--- a/src/Control/Parallel/Strategies/Lens.hs
+++ b/src/Control/Parallel/Strategies/Lens.hs
@@ -2,9 +2,9 @@
 #ifdef TRUSTWORTHY
 {-# LANGUAGE Trustworthy #-}
 #endif
-#ifndef MIN_VERSION_parallel
-#define MIN_VERSION_parallel(x,y,z) (defined(__GLASGOW_HASKELL__) && __GLASGOW_HASKELL > 700)
-#endif
+
+#include "lens-common.h"
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Parallel.Strategies.Lens

--- a/src/Data/Bits/Lens.hs
+++ b/src/Data/Bits/Lens.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE FlexibleContexts #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -25,14 +20,14 @@ module Data.Bits.Lens
   , bytewise
   ) where
 
+import Prelude ()
+
 import Control.Lens
+import Control.Lens.Internal.Prelude
 import Control.Monad.State
 import Data.Bits
 import Data.Word
 
-#if !MIN_VERSION_base(4,8,0)
-import Data.Functor
-#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings
@@ -278,9 +273,9 @@ byteAt i f b = back <$> indexed f i (forward b) where
 -- If you supply this an 'Integer', the result will be an infinite 'Traversal', which
 -- can be productively consumed, but not reassembled.
 bits :: (Num b, Bits b) => IndexedTraversal' Int b Bool
-bits f b = Prelude.foldr step 0 <$> traverse g bs where
+bits f b = foldr step 0 <$> traverse g bs where
   g n      = (,) n <$> indexed f n (testBit b n)
-  bs       = Prelude.takeWhile hasBit [0..]
+  bs       = takeWhile hasBit [0..]
   hasBit n = complementBit b n /= b -- test to make sure that complementing this bit actually changes the value
   step (n,True) r = setBit r n
   step _        r = r
@@ -299,9 +294,9 @@ bits f b = Prelude.foldr step 0 <$> traverse g bs where
 -- Why isn't this function called @bytes@ to match 'bits'? Alas, there
 -- is already a function by that name in "Data.ByteString.Lens".
 bytewise :: (Integral b, Bits b) => IndexedTraversal' Int b Word8
-bytewise f b = Prelude.foldr step 0 <$> traverse g bs where
+bytewise f b = foldr step 0 <$> traverse g bs where
   g n = (,) n <$> indexed f n (fromIntegral $ b `shiftR` (n*8))
-  bs = Prelude.takeWhile hasByte [0..]
+  bs = takeWhile hasByte [0..]
   hasByte n = complementBit b (n*8) /= b
   step (n,x) r = r .|. (fromIntegral x `shiftL` (n*8))
 {-# INLINE bytewise #-}

--- a/src/Data/Complex/Lens.hs
+++ b/src/Data/Complex/Lens.hs
@@ -5,10 +5,6 @@
 {-# LANGUAGE PatternSynonyms #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Complex.Lens
@@ -37,12 +33,11 @@ module Data.Complex.Lens
 #endif
   ) where
 
-import Control.Lens
-import Data.Complex
+import Prelude ()
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
+import Control.Lens
+import Control.Lens.Internal.Prelude
+import Data.Complex
 
 -- $setup
 -- >>> import Debug.SimpleReflect

--- a/src/Data/List/Lens.hs
+++ b/src/Data/List/Lens.hs
@@ -1,10 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE FlexibleContexts #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -99,13 +94,12 @@ module Data.List.Lens
   , stripSuffix
   ) where
 
+import Prelude ()
+
 import Control.Monad (guard)
+import Control.Lens.Internal.Prelude
 import Control.Lens
 import Data.List
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Functor
-#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings

--- a/src/Data/Set/Lens.hs
+++ b/src/Data/Set/Lens.hs
@@ -1,14 +1,9 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 
-#ifndef MIN_VERSION_containers
-#define MIN_VERSION_containers(x,y,z) 1
-#endif
-
 {-# LANGUAGE Trustworthy #-}
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
+
+#include "lens-common.h"
 
 -----------------------------------------------------------------------------
 -- |

--- a/src/Data/Tree/Lens.hs
+++ b/src/Data/Tree/Lens.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts #-}
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -21,12 +17,11 @@ module Data.Tree.Lens
   , branches
   ) where
 
+import Prelude ()
+
+import Control.Lens.Internal.Prelude
 import Control.Lens
 import Data.Tree
-
-#if !MIN_VERSION_base(4,8,0)
-import Data.Functor
-#endif
 
 -- | A 'Lens' that focuses on the root of a 'Tree'.
 --

--- a/src/Data/Typeable/Lens.hs
+++ b/src/Data/Typeable/Lens.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
 
 -----------------------------------------------------------------------------
 -- |
@@ -20,13 +15,12 @@ module Data.Typeable.Lens
   , _gcast
   ) where
 
-import Control.Lens
-import Data.Typeable
-import Data.Maybe
+import Prelude ()
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
+import Control.Lens
+import Control.Lens.Internal.Prelude
+import Data.Maybe (fromMaybe)
+import Data.Typeable
 
 -- | A 'Traversal'' for working with a 'cast' of a 'Typeable' value.
 _cast :: (Typeable s, Typeable a) => Traversal' s a

--- a/src/Data/Vector/Generic/Lens.hs
+++ b/src/Data/Vector/Generic/Lens.hs
@@ -5,9 +5,8 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#ifndef MIN_VERSION_vector
-#define MIN_VERSION_vector(x,y,z) 1
-#endif
+#include "lens-common.h"
+
 -------------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Vector.Generic.Lens

--- a/src/Language/Haskell/TH/Lens.hs
+++ b/src/Language/Haskell/TH/Lens.hs
@@ -4,13 +4,8 @@
 #endif
 {-# LANGUAGE Rank2Types #-}
 
-#if __GLASGOW_HASKELL__ >= 800
-{-# OPTIONS_GHC -Wno-trustworthy-safe #-}
-#endif
+#include "lens-common.h"
 
-#ifndef MIN_VERSION_template_haskell
-#define MIN_VERSION_template_haskell(x,y,z) 1
-#endif
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Language.Haskell.TH.Lens

--- a/src/System/Exit/Lens.hs
+++ b/src/System/Exit/Lens.hs
@@ -7,10 +7,6 @@
 {-# LANGUAGE ViewPatterns #-}
 #endif
 
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.Exit.Lens
@@ -32,14 +28,13 @@ module System.Exit.Lens
 #endif
   ) where
 
+import Prelude ()
+
 import Control.Exception
 import Control.Exception.Lens
 import Control.Lens
+import Control.Lens.Internal.Prelude
 import System.Exit
-
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 
 -- | Exit codes that a program can return with:
 class AsExitCode t where

--- a/src/System/FilePath/Lens.hs
+++ b/src/System/FilePath/Lens.hs
@@ -1,9 +1,3 @@
-{-# LANGUAGE CPP #-}
-
-#ifndef MIN_VERSION_base
-#define MIN_VERSION_base(x,y,z) 1
-#endif
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  System.FilePath.Lens
@@ -23,9 +17,7 @@ module System.FilePath.Lens
   , basename, directory, extension, filename
   ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative ((<$>))
-#endif
+import Prelude ()
 
 import Control.Monad.State as State
 import System.FilePath
@@ -34,6 +26,7 @@ import System.FilePath
   , takeExtension, takeFileName
   )
 
+import Control.Lens.Internal.Prelude
 import Control.Lens hiding ((<.>))
 
 -- $setup


### PR DESCRIPTION
... and using `Control.Lens.Internal.Prelude` remove `{-# LANGUAGE CPP #-}` from few modules entirely. 