### PR TITLE
More use of Internal.Prelude

### DIFF
--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -43,7 +43,10 @@ module Control.Lens.At
   , icontains
   ) where
 
+import Prelude ()
+
 import Control.Lens.Each
+import Control.Lens.Internal.Prelude
 import Control.Lens.Traversal
 import Control.Lens.Lens
 import Control.Lens.Setter
@@ -60,7 +63,6 @@ import Data.HashSet as HashSet
 import Data.Int
 import Data.IntMap as IntMap
 import Data.IntSet as IntSet
-import Data.List.NonEmpty as NonEmpty
 import Data.Map as Map
 import Data.Set as Set
 import Data.Sequence as Seq
@@ -72,10 +74,6 @@ import Data.Vector.Primitive as Prim
 import Data.Vector.Storable as Storable
 import Data.Vector.Unboxed as Unboxed hiding (indexed)
 import Data.Word
-
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 
 type family Index (s :: *) :: *
 type instance Index (e -> a) = e

--- a/src/Control/Lens/Each.hs
+++ b/src/Control/Lens/Each.hs
@@ -28,17 +28,18 @@ module Control.Lens.Each
     Each(..)
   ) where
 
+import Prelude ()
+
 import Control.Lens.Traversal
 import Control.Lens.Internal.ByteString
+import Control.Lens.Internal.Prelude
 import Data.Array.Unboxed as Unboxed
 import Data.Array.IArray as IArray
 import Data.ByteString as StrictB
 import Data.ByteString.Lazy as LazyB
 import Data.Complex
-import Data.Functor.Identity
 import Data.HashMap.Lazy as HashMap
 import Data.IntMap as IntMap
-import Data.List.NonEmpty
 import Data.Map as Map
 import Data.Sequence as Seq
 import Data.Text.Lens (text)
@@ -54,10 +55,6 @@ import Data.Vector.Storable (Storable)
 import qualified Data.Vector.Unboxed as Unboxed
 import Data.Vector.Unboxed (Unbox)
 import Data.Word
-
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings

--- a/src/Control/Lens/Empty.hs
+++ b/src/Control/Lens/Empty.hs
@@ -28,12 +28,14 @@ module Control.Lens.Empty
 #endif
   ) where
 
+import Prelude ()
+
 import Control.Lens.Iso
 #if __GLASGOW_HASKELL__ >= 710
 import Control.Lens.Fold
 #endif
-import Control.Applicative (ZipList(..))
 import Control.Lens.Prism
+import Control.Lens.Internal.Prelude as Prelude
 import Control.Lens.Review
 import Data.ByteString as StrictB
 import Data.ByteString.Lazy as LazyB
@@ -41,10 +43,9 @@ import Data.HashMap.Lazy as HashMap
 import Data.HashSet as HashSet
 import Data.IntMap as IntMap
 import Data.IntSet as IntSet
+import Data.Monoid
 import Data.Map as Map
 import Data.Maybe
-import Data.Monoid
-import Data.Profunctor.Unsafe
 import qualified Data.Sequence as Seq
 import Data.Set as Set
 import Data.Text as StrictT

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -145,7 +145,6 @@ module Control.Lens.Fold
 
 import Prelude ()
 
-import Control.Applicative (Alternative (..))
 import Control.Applicative.Backwards
 import Control.Comonad
 import Control.Lens.Getter
@@ -160,21 +159,15 @@ import Control.Monad.Reader
 import Control.Monad.State
 import Data.CallStack
 import Data.Functor.Apply hiding ((<.))
-import Data.Functor.Contravariant
 import Data.Int (Int64)
 import Data.List (intercalate)
 import Data.Maybe (fromMaybe)
-import Data.Monoid (First (..), Endo (..), Dual (..), All (..), Any (..))
-import Data.Profunctor
-import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
+import Data.Monoid (First (..), All (..), Any (..))
 #if MIN_VERSION_reflection(2,1,0)
 import Data.Reflection
 #endif
 
 import qualified Data.Semigroup as Semi
-import Data.List.NonEmpty (NonEmpty(..))
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings

--- a/src/Control/Lens/Getter.hs
+++ b/src/Control/Lens/Getter.hs
@@ -51,10 +51,9 @@
 -- A common question is whether you can combine multiple 'Getter's to
 -- retrieve multiple values. Recall that all 'Getter's are 'Fold's and that
 -- we have a @'Monoid' m => 'Applicative' ('Const' m)@ instance to play
--- with. Knowing this, we can use @'Data.Monoid.<>'@ to glue 'Fold's
+-- with. Knowing this, we can use @'Data.Semigroup.<>'@ to glue 'Fold's
 -- together:
 --
--- >>> import Data.Monoid
 -- >>> (1, 2, 3, 4, 5) ^.. (_2 <> _3 <> _5)
 -- [2,3,5]
 --
@@ -87,15 +86,14 @@ module Control.Lens.Getter
   , Const(..)
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Lens.Internal.Indexed
+import Control.Lens.Internal.Prelude
 import Control.Lens.Type
 import Control.Monad.Reader.Class as Reader
 import Control.Monad.State        as State
-import Control.Monad.Writer       as Writer
-import Data.Functor.Contravariant
-import Data.Profunctor
-import Data.Profunctor.Unsafe
+import Control.Monad.Writer (MonadWriter (..))
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -76,7 +76,8 @@ module Control.Lens.Indexed
   , itraverseByOf
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Applicative.Backwards
 import Control.Comonad.Cofree
 import Control.Comonad.Trans.Traced
@@ -89,6 +90,7 @@ import Control.Lens.Fold
 import Control.Lens.Getter
 import Control.Lens.Internal.Fold
 import Control.Lens.Internal.Indexed
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Level
 import Control.Lens.Internal.Magma
 import Control.Lens.Setter
@@ -97,34 +99,22 @@ import Control.Lens.Type
 import Data.Array (Array)
 import qualified Data.Array as Array
 import Data.Foldable
-import Data.Functor.Compose
 import Data.Functor.Constant (Constant (..))
-import Data.Functor.Contravariant
 import Data.Functor.Product
 import Data.Functor.Reverse
 import Data.Functor.Sum
 import Data.HashMap.Lazy as HashMap
 import Data.IntMap as IntMap
 import Data.Ix (Ix)
-import Data.List.NonEmpty as NonEmpty
 import Data.Map as Map
 import Data.Monoid hiding (Sum, Product)
-import Data.Profunctor.Unsafe
-import Data.Proxy
 import Data.Reflection
 import Data.Sequence hiding ((:<), index)
-import Data.Tagged
 import Data.Tree
 import Data.Tuple (swap)
 import Data.Vector (Vector)
-import Data.Void
 import qualified Data.Vector as V
 import GHC.Generics
-import Prelude
-
-#if !(MIN_VERSION_base(4,8,0))
-import Data.Traversable (sequenceA)
-#endif
 
 #ifdef HLINT
 {-# ANN module "HLint: ignore Use fmap" #-}

--- a/src/Control/Lens/Internal/Bazaar.hs
+++ b/src/Control/Lens/Internal/Bazaar.hs
@@ -29,22 +29,16 @@ module Control.Lens.Internal.Bazaar
   , BazaarT1(..), BazaarT1'
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Arrow as Arrow
-import Control.Category
+import qualified Control.Category as C
 import Control.Comonad
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Context
 import Control.Lens.Internal.Indexed
 import Data.Functor.Apply
-import Data.Functor.Compose
-import Data.Functor.Contravariant
-import Data.Functor.Identity
-import Data.Semigroup
-import Data.Profunctor
 import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
-import Prelude hiding ((.),id)
 
 ------------------------------------------------------------------------------
 -- Bizarre
@@ -91,7 +85,7 @@ instance IndexedFunctor (Bazaar p) where
 instance Conjoined p => IndexedComonad (Bazaar p) where
   iextract (Bazaar m) = runIdentity $ m (arr Identity)
   {-# INLINE iextract #-}
-  iduplicate (Bazaar m) = getCompose $ m (Compose #. distrib sell . sell)
+  iduplicate (Bazaar m) = getCompose $ m (Compose #. distrib sell C.. sell)
   {-# INLINE iduplicate #-}
 
 instance Corepresentable p => Sellable p (Bazaar p) where
@@ -172,7 +166,7 @@ instance IndexedFunctor (BazaarT p g) where
 instance Conjoined p => IndexedComonad (BazaarT p g) where
   iextract (BazaarT m) = runIdentity $ m (arr Identity)
   {-# INLINE iextract #-}
-  iduplicate (BazaarT m) = getCompose $ m (Compose #. distrib sell . sell)
+  iduplicate (BazaarT m) = getCompose $ m (Compose #. distrib sell C.. sell)
   {-# INLINE iduplicate #-}
 
 instance Corepresentable p => Sellable p (BazaarT p g) where
@@ -283,7 +277,7 @@ instance IndexedFunctor (Bazaar1 p) where
 instance Conjoined p => IndexedComonad (Bazaar1 p) where
   iextract (Bazaar1 m) = runIdentity $ m (arr Identity)
   {-# INLINE iextract #-}
-  iduplicate (Bazaar1 m) = getCompose $ m (Compose #. distrib sell . sell)
+  iduplicate (Bazaar1 m) = getCompose $ m (Compose #. distrib sell C.. sell)
   {-# INLINE iduplicate #-}
 
 instance Corepresentable p => Sellable p (Bazaar1 p) where
@@ -350,7 +344,7 @@ instance IndexedFunctor (BazaarT1 p g) where
 instance Conjoined p => IndexedComonad (BazaarT1 p g) where
   iextract (BazaarT1 m) = runIdentity $ m (arr Identity)
   {-# INLINE iextract #-}
-  iduplicate (BazaarT1 m) = getCompose $ m (Compose #. distrib sell . sell)
+  iduplicate (BazaarT1 m) = getCompose $ m (Compose #. distrib sell C.. sell)
   {-# INLINE iduplicate #-}
 
 instance Corepresentable p => Sellable p (BazaarT1 p g) where

--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -29,14 +29,13 @@ module Control.Lens.Internal.ByteString
   , unpackLazy8, traversedLazy8
   ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
+import Prelude ()
 
 import Control.Lens.Type
 import Control.Lens.Getter
 import Control.Lens.Fold
 import Control.Lens.Indexed
+import Control.Lens.Internal.Prelude
 import Control.Lens.Setter
 import qualified Data.ByteString               as B
 import qualified Data.ByteString.Char8         as B8
@@ -48,7 +47,6 @@ import Data.Bits
 import Data.Char
 import Data.Int (Int64)
 import Data.Word (Word8)
-import Data.Monoid
 import Foreign.Ptr
 import Foreign.Storable
 #if MIN_VERSION_base(4,8,0)

--- a/src/Control/Lens/Internal/Context.hs
+++ b/src/Control/Lens/Internal/Context.hs
@@ -28,19 +28,15 @@ module Control.Lens.Internal.Context
   , PretextT(..), PretextT'
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Arrow
-import Control.Category
+import qualified Control.Category as C
 import Control.Comonad
 import Control.Comonad.Store.Class
 import Control.Lens.Internal.Indexed
-import Data.Functor.Compose
-import Data.Functor.Contravariant
-import Data.Functor.Identity
-import Data.Profunctor
+import Control.Lens.Internal.Prelude
 import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
 import Prelude hiding ((.),id)
 
 ------------------------------------------------------------------------------
@@ -229,7 +225,7 @@ instance Functor (Pretext p a b) where
 instance Conjoined p => IndexedComonad (Pretext p) where
   iextract (Pretext m) = runIdentity $ m (arr Identity)
   {-# INLINE iextract #-}
-  iduplicate (Pretext m) = getCompose $ m (Compose #. distrib sell . sell)
+  iduplicate (Pretext m) = getCompose $ m (Compose #. distrib sell C.. sell)
   {-# INLINE iduplicate #-}
 
 instance (a ~ b, Conjoined p) => Comonad (Pretext p a b) where
@@ -309,7 +305,7 @@ instance Functor (PretextT p g a b) where
 instance Conjoined p => IndexedComonad (PretextT p g) where
   iextract (PretextT m) = runIdentity $ m (arr Identity)
   {-# INLINE iextract #-}
-  iduplicate (PretextT m) = getCompose $ m (Compose #. distrib sell . sell)
+  iduplicate (PretextT m) = getCompose $ m (Compose #. distrib sell C.. sell)
   {-# INLINE iduplicate #-}
 
 instance (a ~ b, Conjoined p) => Comonad (PretextT p g a b) where

--- a/src/Control/Lens/Internal/Deque.hs
+++ b/src/Control/Lens/Internal/Deque.hs
@@ -24,28 +24,21 @@ module Control.Lens.Internal.Deque
   , singleton
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Lens.Cons
 import Control.Lens.Fold
 import Control.Lens.Indexed hiding ((<.>))
+import Control.Lens.Internal.Prelude hiding (null)
 import Control.Lens.Iso
 import Control.Lens.Lens
 import Control.Lens.Prism
 import Control.Monad
-#if MIN_VERSION_base(4,8,0)
-import Data.Foldable hiding (null)
-import qualified Data.Foldable as Foldable
-#else
-import Data.Foldable as Foldable
-#endif
+import Data.Foldable (toList)
 import Data.Function
 import Data.Functor.Bind
 import Data.Functor.Plus
 import Data.Functor.Reverse
-import Data.Traversable as Traversable
-import Data.Semigroup
-import Data.Profunctor.Unsafe
-import Prelude hiding (null)
 
 -- | A Banker's deque based on Chris Okasaki's \"Purely Functional Data Structures\"
 data Deque a = BD !Int [a] !Int [a]
@@ -83,7 +76,7 @@ size (BD lf _ lr _) = lf + lr
 -- >>> fromList [1,2]
 -- BD 1 [1] 1 [2]
 fromList :: [a] -> Deque a
-fromList = Prelude.foldr cons empty
+fromList = foldr cons empty
 {-# INLINE fromList #-}
 
 instance Eq a => Eq (Deque a) where
@@ -114,8 +107,8 @@ instance Applicative Deque where
 
 instance Alt Deque where
   xs <!> ys
-    | size xs < size ys = Foldable.foldr cons ys xs
-    | otherwise         = Foldable.foldl snoc xs ys
+    | size xs < size ys = foldr cons ys xs
+    | otherwise         = foldl snoc xs ys
   {-# INLINE (<!>) #-}
 
 instance Plus Deque where
@@ -126,8 +119,8 @@ instance Alternative Deque where
   empty = BD 0 [] 0 []
   {-# INLINE empty #-}
   xs <|> ys
-    | size xs < size ys = Foldable.foldr cons ys xs
-    | otherwise         = Foldable.foldl snoc xs ys
+    | size xs < size ys = foldr cons ys xs
+    | otherwise         = foldl snoc xs ys
   {-# INLINE (<|>) #-}
 
 instance Reversing (Deque a) where
@@ -170,16 +163,16 @@ instance TraversableWithIndex Int Deque where
 
 instance Semigroup (Deque a) where
   xs <> ys
-    | size xs < size ys = Foldable.foldr cons ys xs
-    | otherwise         = Foldable.foldl snoc xs ys
+    | size xs < size ys = foldr cons ys xs
+    | otherwise         = foldl snoc xs ys
   {-# INLINE (<>) #-}
 
 instance Monoid (Deque a) where
   mempty = BD 0 [] 0 []
   {-# INLINE mempty #-}
   mappend xs ys
-    | size xs < size ys = Foldable.foldr cons ys xs
-    | otherwise         = Foldable.foldl snoc xs ys
+    | size xs < size ys = foldr cons ys xs
+    | otherwise         = foldl snoc xs ys
   {-# INLINE mappend #-}
 
 -- | Check that a 'Deque' satisfies the balance invariants and rebalance if not.

--- a/src/Control/Lens/Internal/FieldTH.hs
+++ b/src/Control/Lens/Internal/FieldTH.hs
@@ -30,9 +30,12 @@ module Control.Lens.Internal.FieldTH
   , HasFieldClasses
   ) where
 
+import Prelude ()
+
 import Control.Lens.At
 import Control.Lens.Fold
 import Control.Lens.Internal.TH
+import Control.Lens.Internal.Prelude
 import Control.Lens.Lens
 import Control.Lens.Plated
 import Control.Lens.Prism
@@ -40,7 +43,6 @@ import Control.Lens.Setter
 import Control.Lens.Getter
 import Control.Lens.Tuple
 import Control.Lens.Traversal
-import Control.Applicative
 import Control.Monad
 import Control.Monad.State
 import Language.Haskell.TH.Lens
@@ -49,14 +51,13 @@ import qualified Language.Haskell.TH.Datatype as D
 import Data.Maybe (isJust,maybeToList)
 import Data.List (nub, findIndices)
 import Data.Either (partitionEithers)
-import Data.Semigroup
+import Data.Semigroup (Any (..))
 import Data.Set.Lens
 import           Data.Map ( Map )
 import           Data.Set ( Set )
 import qualified Data.Set as Set
 import qualified Data.Map as Map
 import qualified Data.Traversable as T
-import Prelude
 
 ------------------------------------------------------------------------
 -- Field generation entry point

--- a/src/Control/Lens/Internal/Fold.hs
+++ b/src/Control/Lens/Internal/Fold.hs
@@ -32,14 +32,13 @@ module Control.Lens.Internal.Fold
   , NonEmptyDList(..)
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Lens.Internal.Getter
+import Control.Lens.Internal.Prelude
 import Data.Functor.Bind
-import Data.Functor.Contravariant
-import Data.Maybe
-import Data.Semigroup hiding (Min, getMin, Max, getMax)
+import Data.Maybe (fromMaybe)
 import Data.Reflection
-import Prelude
 
 import qualified Data.List.NonEmpty as NonEmpty
 

--- a/src/Control/Lens/Internal/Getter.hs
+++ b/src/Control/Lens/Internal/Getter.hs
@@ -18,16 +18,14 @@ module Control.Lens.Internal.Getter
   , AlongsideRight(..)
   ) where
 
-import Control.Applicative
+import Prelude ()
+
+import Control.Lens.Internal.Prelude
 import Data.Bifoldable
 import Data.Bifunctor
 import Data.Bitraversable
-import Data.Foldable
-import Data.Functor.Contravariant
 import Data.Semigroup.Foldable
 import Data.Semigroup.Traversable
-import Data.Traversable
-import Prelude
 
 -- | The 'mempty' equivalent for a 'Contravariant' 'Applicative' 'Functor'.
 noEffect :: (Contravariant f, Applicative f) => f a

--- a/src/Control/Lens/Internal/Indexed.hs
+++ b/src/Control/Lens/Internal/Indexed.hs
@@ -39,27 +39,20 @@ module Control.Lens.Internal.Indexed
   , asIndex
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Arrow as Arrow
-import Control.Category
+import qualified Control.Category as C
 import Control.Comonad
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Instances ()
-import Control.Monad
 import Control.Monad.Fix
 import Data.Distributive
 import Data.Functor.Bind
-import Data.Functor.Contravariant
 import Data.Int
-import Data.Monoid
 import Data.Profunctor.Closed
-import Data.Profunctor
 import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import qualified Data.Semigroup as Semi
-import Data.Traversable
-import Prelude hiding ((.),id)
 #ifndef SAFE
-import Data.Profunctor.Unsafe
 import Control.Lens.Internal.Coerce
 #endif
 
@@ -202,7 +195,7 @@ instance Strong (Indexed i) where
   second' = second
   {-# INLINE second' #-}
 
-instance Category (Indexed i) where
+instance C.Category (Indexed i) where
   id = Indexed (const id)
   {-# INLINE id #-}
   Indexed f . Indexed g = Indexed $ \i -> f i . g i
@@ -278,10 +271,10 @@ instance Contravariant f => Contravariant (Indexing f) where
     (j, ff) -> (j, contramap f ff)
   {-# INLINE contramap #-}
 
-instance Semi.Semigroup (f a) => Semi.Semigroup (Indexing f a) where
+instance Semigroup (f a) => Semigroup (Indexing f a) where
     Indexing mx <> Indexing my = Indexing $ \i -> case mx i of
       (j, x) -> case my j of
-         ~(k, y) -> (k, x Semi.<> y)
+         ~(k, y) -> (k, x <> y)
     {-# INLINE (<>) #-}
 
 -- |

--- a/src/Control/Lens/Internal/Level.hs
+++ b/src/Control/Lens/Internal/Level.hs
@@ -26,16 +26,10 @@ module Control.Lens.Internal.Level
   , Flows(..)
   ) where
 
-import Control.Applicative
-import Control.Category
-import Control.Comonad
-import Data.Foldable
+import Prelude ()
+
+import Control.Lens.Internal.Prelude
 import Data.Functor.Apply
-import Data.Int
-import Data.Semigroup
-import Data.Traversable
-import Data.Word
-import Prelude hiding ((.),id)
 
 ------------------------------------------------------------------------------
 -- Levels

--- a/src/Control/Lens/Internal/Magma.hs
+++ b/src/Control/Lens/Internal/Magma.hs
@@ -34,21 +34,14 @@ module Control.Lens.Internal.Magma
   , runTakingWhile
   ) where
 
-import Control.Applicative
-import Control.Category
+import Prelude ()
+
 import Control.Comonad
 import Control.Lens.Internal.Bazaar
 import Control.Lens.Internal.Context
 import Control.Lens.Internal.Indexed
-import Data.Foldable
+import Control.Lens.Internal.Prelude
 import Data.Functor.Apply
-import Data.Functor.Contravariant
-import Data.Monoid
-import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
-import Data.Traversable
-import Prelude hiding ((.),id)
 
 ------------------------------------------------------------------------------
 -- Magma

--- a/src/Control/Lens/Internal/Prelude.hs
+++ b/src/Control/Lens/Internal/Prelude.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE Trustworthy #-}
 #include "lens-common.h"
 -- | Module which does most common imports (and related CPP)
 -- needed across the lens library.
@@ -9,21 +10,47 @@
 -- That's a reason why this module is different from
 -- other .Internal modules, which are exposed-modules.
 --
+-- Also this is a "fat" Prelude, re-exporting commonly used,
+-- non conflicting symbols.
 --
 module Control.Lens.Internal.Prelude
   ( module Prelude
   , Semigroup (..)
   , Monoid (..)
-  , Foldable, foldMap, foldr, foldl', null, length, traverse_
+  , Foldable, foldMap, foldr, foldl, foldl', elem, null, length, traverse_
   , Traversable (..)
   , Applicative (..)
   , (&), (<&>), (<$>), (<$)
+  -- * Data types
+  , ZipList (..)
+  , NonEmpty (..)
   -- * Functors
   , Identity (..)
   , Compose (..)
   , Const (..)
+  -- * Control.Applicative
+  , Alternative (..), WrappedMonad (..)
+#if !MIN_VERSION_base(4,10,0)
+  , liftA2
+#endif
+  -- * Data.Contravariant
+  , Contravariant (..), phantom
+  -- * Data.Monoid
+  , Endo (..), Dual (..)
+  -- * Data.Profunctor
+  , Profunctor (..)
+  , Choice (..), Cochoice (..)
+  , Strong (..), Costrong (..)
+  , Corepresentable (..)
+  , Sieve (..), Cosieve (..)
+  -- * Data.Proxy
+  , Proxy (..)
+  -- * Data.Tagged
+  , Tagged (..)
   -- * Data.Void
   , Void, absurd
+  -- * Data.Word
+  , Word
   ) where
 
 import Prelude hiding
@@ -35,32 +62,51 @@ import Prelude hiding
     , Monoid (..)
     , (<$>), (<$)
 #else
-    , foldr, length, null
+    , foldr, foldl, length, elem, null
     , mapM, sequence
 #endif
 #if MIN_VERSION_base(4,13,0)
     , Semigroup (..)
 #endif
+#if MIN_VERSION_base(4,8,0)
+    , Word
+#endif
     )
 
+-- Prelude
 import Control.Applicative (Applicative (..), (<$>), (<$)) -- N.B. liftA2
-import Data.Foldable (Foldable, foldMap, foldr, foldl', traverse_) -- N.B. we don't define Foldable instances, so this way is makes less CPP
+import Data.Foldable (Foldable, foldMap, elem, foldr, foldl, foldl', traverse_) -- N.B. we don't define Foldable instances, so this way is makes less CPP
 import Data.Monoid (Monoid (..))
 import Data.Semigroup (Semigroup (..))
 import Data.Traversable (Traversable (..))
+import Data.Word (Word)
 
+-- Extras
 #if MIN_VERSION_base(4,8,0)
 import Data.Function ((&))
 import Data.Foldable (length, null)
+#endif
+
+#if !MIN_VERSION_base(4,10,0)
+import Control.Applicative (liftA2)
 #endif
 
 #if MIN_VERSION_base(4,11,0)
 import Data.Functor ((<&>))
 #endif
 
-import Control.Applicative (Const (..))
-import Data.Functor.Identity (Identity (..))
+import Control.Applicative (Alternative (..), Const (..), WrappedMonad (..), ZipList (..))
 import Data.Functor.Compose (Compose (..))
+import Data.Functor.Contravariant (Contravariant (..), phantom)
+import Data.Functor.Identity (Identity (..))
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Monoid (Endo (..), Dual (..))
+import Data.Profunctor (Strong (..), Choice (..), Cochoice (..), Costrong (..))
+import Data.Profunctor.Rep (Corepresentable (..)) -- N.B. no Representable
+import Data.Profunctor.Sieve (Sieve (..), Cosieve (..))
+import Data.Profunctor.Unsafe (Profunctor (..))
+import Data.Proxy (Proxy (..))
+import Data.Tagged (Tagged (..))
 import Data.Void (Void, absurd)
 
 -- $setup

--- a/src/Control/Lens/Internal/Prism.hs
+++ b/src/Control/Lens/Internal/Prism.hs
@@ -14,9 +14,11 @@ module Control.Lens.Internal.Prism
   , Market'
   ) where
 
-import Data.Profunctor
+import Prelude ()
+
+import Control.Lens.Internal.Prelude
+
 #ifndef SAFE
-import Data.Profunctor.Unsafe
 import Control.Lens.Internal.Coerce
 #endif
 

--- a/src/Control/Lens/Internal/Setter.hs
+++ b/src/Control/Lens/Internal/Setter.hs
@@ -20,15 +20,11 @@ module Control.Lens.Internal.Setter
     Settable(..)
   ) where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Applicative.Backwards
+import Control.Lens.Internal.Prelude
 import Data.Distributive
-import Data.Functor.Compose
-import Data.Functor.Identity
-import Data.Profunctor
-import Data.Profunctor.Unsafe
-import Data.Traversable
-import Prelude
 
 -----------------------------------------------------------------------------
 -- Settable

--- a/src/Control/Lens/Internal/Zoom.hs
+++ b/src/Control/Lens/Internal/Zoom.hs
@@ -30,15 +30,12 @@ module Control.Lens.Internal.Zoom
   , EffectRWS(..)
   ) where
 
-import Control.Applicative
-import Control.Category
-import Control.Comonad
+import Prelude ()
+
+import Control.Lens.Internal.Prelude
 import Control.Monad.Reader as Reader
 import Control.Monad.Trans.Free
 import Data.Functor.Bind
-import Data.Functor.Contravariant
-import Data.Semigroup
-import Prelude hiding ((.),id)
 
 ------------------------------------------------------------------------------
 -- Focusing

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -139,10 +139,6 @@ import Control.Monad.State as State
 import Data.Functor.Apply
 import Data.Functor.Reverse
 import Data.Functor.Yoneda
-import Data.Profunctor
-import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
 import Data.Semigroup.Traversable
 #if __GLASGOW_HASKELL__ >= 800
 import GHC.Exts (TYPE)

--- a/src/Control/Lens/Plated.hs
+++ b/src/Control/Lens/Plated.hs
@@ -97,13 +97,15 @@ module Control.Lens.Plated
   )
   where
 
-import Control.Applicative
+import Prelude ()
+
 import Control.Comonad.Cofree
 import qualified Control.Comonad.Trans.Cofree as CoTrans
 import Control.Lens.Fold
 import Control.Lens.Getter
 import Control.Lens.Indexed
 import Control.Lens.Internal.Context
+import Control.Lens.Internal.Prelude
 import Control.Lens.Type
 import Control.Lens.Setter
 import Control.Lens.Traversal
@@ -116,7 +118,6 @@ import Control.MonadPlus.Free as MonadPlus
 import qualified Language.Haskell.TH as TH
 import Data.Data
 import Data.Data.Lens
-import Data.Monoid
 import Data.Tree
 import GHC.Generics
 

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -88,11 +88,6 @@ import Control.Monad (liftM)
 import Control.Monad.Reader.Class as Reader
 import Control.Monad.State.Class  as State
 import Control.Monad.Writer.Class as Writer
-import Data.Functor.Contravariant
-import Data.Profunctor
-import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
 
 #ifdef HLINT
 {-# ANN module "HLint: ignore Avoid lambda" #-}
@@ -103,6 +98,7 @@ import Data.Profunctor.Unsafe
 -- >>> import Control.Lens
 -- >>> import Control.Monad.State
 -- >>> import Data.Char
+-- >>> import Data.Functor.Contravariant (Predicate (..), Op (..))
 -- >>> import Data.Map as Map
 -- >>> import Data.Semigroup (Sum (..), Product (..))
 -- >>> import Debug.SimpleReflect.Expr as Expr

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -79,9 +79,8 @@ module Control.Lens.TH
   , abbreviatedNamer
   ) where
 
-#if !MIN_VERSION_base(4,8,0)
-import Control.Applicative
-#endif
+import Prelude ()
+
 #if !(MIN_VERSION_template_haskell(2,7,0))
 import Control.Monad (ap)
 #endif
@@ -94,6 +93,7 @@ import Control.Lens.Lens
 import Control.Lens.Setter
 import Control.Lens.Tuple
 import Control.Lens.Traversal
+import Control.Lens.Internal.Prelude as Prelude
 import Control.Lens.Internal.TH
 import Control.Lens.Internal.FieldTH
 import Control.Lens.Internal.PrismTH
@@ -101,11 +101,10 @@ import Control.Lens.Wrapped () -- haddocks
 import Control.Lens.Type () -- haddocks
 import Data.Char (toLower, toUpper, isUpper)
 import Data.Foldable hiding (concat, any)
-import Data.List as List
+import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Data.Maybe (maybeToList)
-import Data.Monoid
 import qualified Data.Set as Set
 import Data.Set (Set)
 import Data.Set.Lens
@@ -677,7 +676,7 @@ camelCaseFields = defaultFieldRules
 camelCaseNamer :: FieldNamer
 camelCaseNamer tyName fields field = maybeToList $ do
 
-  fieldPart <- stripPrefix expectedPrefix (nameBase field)
+  fieldPart <- List.stripPrefix expectedPrefix (nameBase field)
   method    <- computeMethod fieldPart
   let cls = "Has" ++ fieldPart
   return (MethodName (mkName cls) (mkName method))
@@ -685,7 +684,7 @@ camelCaseNamer tyName fields field = maybeToList $ do
   where
   expectedPrefix = optUnderscore ++ overHead toLower (nameBase tyName)
 
-  optUnderscore  = ['_' | any (isPrefixOf "_" . nameBase) fields ]
+  optUnderscore  = ['_' | any (List.isPrefixOf "_" . nameBase) fields ]
 
   computeMethod (x:xs) | isUpper x = Just (toLower x : xs)
   computeMethod _                  = Nothing
@@ -704,7 +703,7 @@ classUnderscoreNoPrefixFields =
 -- | A 'FieldNamer' for 'classUnderscoreNoPrefixFields'.
 classUnderscoreNoPrefixNamer :: FieldNamer
 classUnderscoreNoPrefixNamer _ _ field = maybeToList $ do
-  fieldUnprefixed <- stripPrefix "_" (nameBase field)
+  fieldUnprefixed <- List.stripPrefix "_" (nameBase field)
   let className  = "Has" ++ overHead toUpper fieldUnprefixed
       methodName = fieldUnprefixed
   return (MethodName (mkName className) (mkName methodName))
@@ -730,11 +729,11 @@ abbreviatedNamer _ fields field = maybeToList $ do
   return (MethodName (mkName cls) (mkName method))
 
   where
-  stripMaxLc f = do x <- stripPrefix optUnderscore f
+  stripMaxLc f = do x <- List.stripPrefix optUnderscore f
                     case break isUpper x of
                       (p,s) | List.null p || List.null s -> Nothing
                             | otherwise                  -> Just s
-  optUnderscore  = ['_' | any (isPrefixOf "_" . nameBase) fields ]
+  optUnderscore  = ['_' | any (List.isPrefixOf "_" . nameBase) fields ]
 
   computeMethod (x:xs) | isUpper x = Just (toLower x : xs)
   computeMethod _                  = Nothing

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -130,7 +130,6 @@ module Control.Lens.Traversal
 
 import Prelude ()
 
-import Control.Applicative (WrappedMonad (..), ZipList (..), Alternative (..))
 import Control.Applicative.Backwards
 import qualified Control.Category as C
 import Control.Comonad
@@ -152,16 +151,12 @@ import Data.Functor.Day.Curried
 import Data.Functor.Yoneda
 import Data.Int
 import qualified Data.IntMap as IntMap
-import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.Map as Map
 import Data.Map (Map)
+import Data.Monoid (Any (..))
 import Data.Sequence (Seq, mapWithIndex)
 import Data.Vector as Vector (Vector, imap)
-import Data.Monoid (Any (..), Endo (..))
-import Data.Profunctor
-import Data.Profunctor.Rep
-import Data.Profunctor.Sieve
-import Data.Profunctor.Unsafe
+import Data.Profunctor.Rep (Representable (..))
 import Data.Reflection
 import Data.Semigroup.Traversable
 import Data.Semigroup.Bitraversable

--- a/src/Control/Lens/Tuple.hs
+++ b/src/Control/Lens/Tuple.hs
@@ -54,17 +54,12 @@ module Control.Lens.Tuple
   , _17', _18', _19'
   ) where
 
+import           Prelude ()
 import           Control.Lens.Lens
-import           Data.Functor.Identity
-import           Data.Functor.Product
-import           Data.Profunctor       (dimap)
-import           Data.Proxy            (Proxy (Proxy))
+import           Control.Lens.Internal.Prelude
+import           Data.Functor.Product  (Product (..))
 import           GHC.Generics          ((:*:) (..), Generic (..), K1 (..),
                                         M1 (..), U1 (..))
-
-#if !MIN_VERSION_base(4,8,0)
-import           Control.Applicative
-#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings

--- a/src/Control/Lens/Type.hs
+++ b/src/Control/Lens/Type.hs
@@ -63,26 +63,22 @@ module Control.Lens.Type
   , Optic, Optic'
   ) where
 
-import Control.Applicative
+import Prelude ()
+
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Setter
 import Control.Lens.Internal.Indexed
 import Data.Bifunctor
-import Data.Functor.Identity
-import Data.Functor.Contravariant
 import Data.Functor.Apply
 #if __GLASGOW_HASKELL__ >= 800
 import Data.Kind
 #endif
-import Data.Profunctor
-import Data.Tagged
-import Prelude ()
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings
 -- >>> import Control.Lens
 -- >>> import Debug.SimpleReflect.Expr
 -- >>> import Debug.SimpleReflect.Vars as Vars hiding (f,g,h)
--- >>> import Prelude
 -- >>> let f :: Expr -> Expr; f = Debug.SimpleReflect.Vars.f
 -- >>> let g :: Expr -> Expr; g = Debug.SimpleReflect.Vars.g
 -- >>> let h :: Expr -> Expr -> Expr; h = Debug.SimpleReflect.Vars.h

--- a/src/Control/Lens/Zoom.hs
+++ b/src/Control/Lens/Zoom.hs
@@ -30,8 +30,11 @@ module Control.Lens.Zoom
   , Zoomed
   ) where
 
+import Prelude ()
+
 import Control.Lens.Getter
 import Control.Lens.Internal.Coerce
+import Control.Lens.Internal.Prelude
 import Control.Lens.Internal.Zoom
 import Control.Lens.Type
 import Control.Monad
@@ -49,9 +52,6 @@ import Control.Monad.Trans.List
 import Control.Monad.Trans.Identity
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Free
-import Data.Monoid
-import Data.Profunctor.Unsafe
-import Prelude
 
 #ifdef HLINT
 {-# ANN module "HLint: ignore Use fmap" #-}


### PR DESCRIPTION
I think we lie about `safe` flag, but I think that with `Internal.Prelude` it's actually easier to make that promise true, if we really want to.

The diff TL;DR is, more re-exports in `Internal.Prelude`, less imports elsewhere. Especially less unqualified wild imports