### PR TITLE
Use -Wall everywhere

### DIFF
--- a/benchmarks/alongside.hs
+++ b/benchmarks/alongside.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+module Main (main) where
+
 import Control.Applicative
 import Control.Comonad
 import Control.Comonad.Store.Class
@@ -9,7 +11,6 @@ import Control.Lens.Internal
 import Control.Lens
 import Criterion.Main
 import Data.Functor.Compose
-import Data.Functor.Identity
 
 -- | A finally encoded Store
 newtype Experiment a b s = Experiment { runExperiment :: forall f. Functor f => (a -> f b) -> f s }
@@ -90,11 +91,12 @@ compound5 l l' l'' l''' l''''
          (\(s, (s', (s'', (s''', s'''')))) (t, (t', (t'', (t''', t''''))))
            -> (set l t s, (set l' t' s', (set l'' t'' s'', (set l''' t''' s''', set l'''' t'''' s'''')))) )
 
+main :: IO ()
 main = defaultMain
-    [ bench "alongside1" $ nf (view $ alongside _1 _2) (("hi", 1), (2, "there!"))
-    , bench "trial1" $ nf (view $ trial _1 _2) (("hi", 1), (2, "there!"))
-    , bench "half1" $ nf (view $ half _1 _2) (("hi", 1), (2, "there!"))
-    , bench "compound1"  $ nf (view $ compound _1 _2) (("hi", 1), (2, "there!"))
+    [ bench "alongside1" $ nf (view $ alongside _1 _2) (("hi", v), (w, "there!"))
+    , bench "trial1" $ nf (view $ trial _1 _2) (("hi", v), (w, "there!"))
+    , bench "half1" $ nf (view $ half _1 _2) (("hi", v), (w, "there!"))
+    , bench "compound1"  $ nf (view $ compound _1 _2) (("hi", v), (w, "there!"))
     , bench "alongside5"  $ nf (view $ (alongside _1 (alongside _1 (alongside _1 (alongside _1 _1)))))
       ((v,v),((v,v),((v,v),((v,v),(v,v)))))
     , bench "trial5"  $ nf (view $ (trial _1 (trial _1 (trial _1 (trial _1 _1)))))
@@ -105,3 +107,4 @@ main = defaultMain
       ((v,v),((v,v),((v,v),((v,v),(v,v)))))
     ]
   where v = 1 :: Int
+        w = 2 :: Int

--- a/benchmarks/folds.hs
+++ b/benchmarks/folds.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE BangPatterns #-}
+module Main (main) where
 
 import qualified Data.ByteString as BS
 import qualified Data.Foldable as F

--- a/benchmarks/plated.hs
+++ b/benchmarks/plated.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
 {-# OPTIONS_GHC -funbox-strict-fields #-}
+module Main (main) where
 
 #ifndef MIN_VERSION_base
 #define MIN_VERSION_base(x,y,z) 1

--- a/benchmarks/traversals.hs
+++ b/benchmarks/traversals.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE BangPatterns #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+module Main (main) where
 
 import qualified Data.ByteString as BS
 import qualified Data.HashMap.Strict as HM

--- a/benchmarks/unsafe.hs
+++ b/benchmarks/unsafe.hs
@@ -1,16 +1,10 @@
 {-# LANGUAGE BangPatterns #-}
-module Main where
+module Main (main) where
 
 import Control.Lens
-import Control.Lens.Internal
-import Control.Exception
 
 import Criterion.Main
 import Criterion.Types (Config(..))
-
-import Data.Functor.Identity (Identity(..))
-
-import GHC.Exts
 
 overS :: ASetter s t a b -> (a -> b) -> s -> t
 overS l f = runIdentity . l (Identity . f)

--- a/lens-properties/lens-properties.cabal
+++ b/lens-properties/lens-properties.cabal
@@ -43,3 +43,4 @@ library
     Control.Lens.Properties
 
   hs-source-dirs: src
+  ghc-options: -Wall

--- a/lens-properties/src/Control/Lens/Properties.hs
+++ b/lens-properties/src/Control/Lens/Properties.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE LiberalTypeSynonyms #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -12,11 +13,12 @@ module Control.Lens.Properties
     , isPrism
     ) where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 import Control.Lens
 import Data.Functor.Compose
 import Test.QuickCheck
-import Test.QuickCheck.Function
 
 --------------------------------------------------------------------------------
 -- | A 'Setter' is only legal if the following 3 laws hold:

--- a/lens.cabal
+++ b/lens.cabal
@@ -388,7 +388,7 @@ test-suite properties
   main-is: properties.hs
   other-modules:
     Control.Lens.Properties
-  ghc-options: -w -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs:
     tests
     lens-properties/src
@@ -409,7 +409,7 @@ test-suite properties
 test-suite hunit
   type: exitcode-stdio-1.0
   main-is: hunit.hs
-  ghc-options: -w -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   hs-source-dirs: tests
   default-language: Haskell2010
 
@@ -486,7 +486,7 @@ benchmark plated
 benchmark alongside
   type:             exitcode-stdio-1.0
   main-is:          alongside.hs
-  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  ghc-options:      -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
   hs-source-dirs:   benchmarks
   default-language: Haskell2010
   build-depends:
@@ -501,7 +501,7 @@ benchmark alongside
 benchmark folds
   type:             exitcode-stdio-1.0
   main-is:          folds.hs
-  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  ghc-options:      -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
   hs-source-dirs:   benchmarks
   default-language: Haskell2010
   build-depends:
@@ -517,7 +517,7 @@ benchmark folds
 benchmark traversals
   type:             exitcode-stdio-1.0
   main-is:          traversals.hs
-  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  ghc-options:      -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
   hs-source-dirs:   benchmarks
   default-language: Haskell2010
   build-depends:
@@ -534,7 +534,7 @@ benchmark traversals
 benchmark unsafe
   type:             exitcode-stdio-1.0
   main-is:          unsafe.hs
-  ghc-options:      -w -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  ghc-options:      -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
   hs-source-dirs:   benchmarks
   default-language: Haskell2010
   build-depends:

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -1,5 +1,12 @@
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TemplateHaskell #-}
+
+#if __GLASGOW_HASKELL__ < 706
+-- Needed to avoid spurious warnings on GHC 7.4 due to an old TH bug
+{-# OPTIONS_GHC -fno-warn-name-shadowing #-}
+#endif
+
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Main (hunit)
@@ -16,14 +23,16 @@
 -- of what is possible using the lens package; there are a great many use cases
 -- (and lens functions) that aren't covered.
 -----------------------------------------------------------------------------
-module Main where
+module Main (main) where
 
 import Control.Lens
 import Control.Monad.State
 import Data.Char
 import Data.List as List
-import Data.Monoid
 import Data.Map as Map
+#if !(MIN_VERSION_base(4,11,0))
+import Data.Monoid
+#endif
 import Test.Framework.Providers.HUnit
 import Test.Framework.TH
 import Test.Framework

--- a/tests/properties.hs
+++ b/tests/properties.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -26,18 +27,19 @@
 -----------------------------------------------------------------------------
 module Main where
 
+#if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
+#endif
 import Control.Lens
 import Test.QuickCheck
-import Test.QuickCheck.Function
 import Test.Framework.TH
 import Test.Framework.Providers.QuickCheck2
 import Data.Char (isAlphaNum, isAscii, toUpper)
 import Data.Text.Strict.Lens
-import Data.Maybe
 import Data.List.Lens
-import Data.Functor.Compose
+#if __GLASGOW_HASKELL__ >= 708
 import GHC.Exts (Constraint)
+#endif
 import Numeric (showHex, showOct, showSigned)
 import Numeric.Lens
 import Control.Lens.Properties (isIso, isLens, isPrism, isSetter, isTraversal)
@@ -106,7 +108,7 @@ prop_base_read (n :: Integer) =
           ]
 prop_base_readFail (s :: String) =
   forAll (choose (2,36)) $ \b ->
-    not isValid ==> s ^? base b == Nothing
+    not isValid ==> s ^? base b == (Nothing :: Maybe Integer)
   where
     isValid = (not . null) sPos && all isValidChar sPos
     sPos = case s of { ('-':s') -> s'; _ -> s }
@@ -125,7 +127,7 @@ sampleExtremePoly f foo = f foo
 samplePolyEquality :: Equality Monad Identity Monad Identity
 samplePolyEquality f = f
 
-lessSimplePoly :: forall KVS(k1 k2) (s :: k1) (t :: k2) (a :: k1) (b :: k2) .
+lessSimplePoly :: forall KVS(k1 k2) (a :: k1) (b :: k2) .
                   Equality a b a b
 lessSimplePoly f = f
 


### PR DESCRIPTION
We were inconsistently using `-Wall` and `-w` in different places. This patch switches to using `-Wall` everywhere and fixing the various warnings that were uncovered in the process.