### PR TITLE
Add compatibility functions for Profunctor optics

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -285,6 +285,7 @@ library
     Control.Lens.Operators
     Control.Lens.Plated
     Control.Lens.Prism
+    Control.Lens.Profunctor
     Control.Lens.Reified
     Control.Lens.Review
     Control.Lens.Setter

--- a/src/Control/Lens/Profunctor.hs
+++ b/src/Control/Lens/Profunctor.hs
@@ -1,5 +1,13 @@
 {-# LANGUAGE RankNTypes #-}
 
+-------------------------------------------------------------------------------
+-- | This module provides conversion functions between the optics defined in
+-- this library and 'Profunctor'-based optics.
+--
+-- The goal of these functions is to provide an interoperability layer between
+-- the two styles of optics, and not to reimplement all the library in terms of
+-- 'Profunctor' optics.
+
 module Control.Lens.Profunctor
   ( -- * Conversion from Van Laarhoven optics
     fromLens
@@ -13,7 +21,7 @@ module Control.Lens.Profunctor
   , toTraversal
   ) where
 
-import Control.Applicative (pure)
+import Control.Applicative (Applicative (..))
 import Control.Lens.Type (Lens, Prism, Setter, Traversal)
 import Control.Lens.Internal.Context (Context (..), sell)
 import Data.Functor.Identity (Identity (..))

--- a/src/Control/Lens/Profunctor.hs
+++ b/src/Control/Lens/Profunctor.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE RankNTypes #-}
+
+module Control.Lens.Profunctor
+  ( -- * Conversion from Van Laarhoven optics
+    fromLens
+  , fromPrism
+  , fromSetter
+  , fromTraversal
+    -- * Conversion to Van Laarhoven optics
+  , toLens
+  , toPrism
+  , toSetter
+  , toTraversal
+  ) where
+
+import Control.Applicative (pure)
+import Control.Lens.Type (Lens, Prism, Setter, Traversal)
+import Control.Lens.Internal.Context (Context (..), sell)
+import Data.Functor.Identity (Identity (..))
+import Data.Profunctor (Choice (..), Profunctor (..), Strong (..), Star (..))
+import Data.Profunctor.Mapping (Mapping (..))
+import Data.Profunctor.Traversing (Traversing (..))
+
+--------------------------------------------------------------------------------
+-- Conversion from Van Laarhoven optics
+--------------------------------------------------------------------------------
+
+-- | Converts a 'Lens' to a 'Profunctor'-based one.
+fromLens :: Strong p => Lens s t a b -> p a b -> p s t
+fromLens l p =
+  dimap
+    (\s -> let (Context f a) = l sell s in (f, a))
+    (uncurry id)
+    (second' p)
+
+-- | Converts a 'Prism' to a 'Profunctor'-based one.
+fromPrism :: Choice p => Prism s t a b -> p a b -> p s t
+fromPrism p pab = rmap runIdentity (p (rmap Identity pab))
+
+-- | Converts a 'Setter' to a 'Profunctor'-based one.
+fromSetter :: Mapping p => Setter s t a b -> p a b -> p s t
+fromSetter s = roam s'
+  where
+    s' f = runIdentity . s (Identity . f)
+
+-- | Converts a 'Traversal' to a 'Profunctor'-based one.
+fromTraversal :: Traversing p => Traversal s t a b -> p a b -> p s t
+fromTraversal = wander
+
+--------------------------------------------------------------------------------
+-- Conversion to Van Laarhoven optics
+--------------------------------------------------------------------------------
+
+newtype PrismWrapper f p a b = PrismWrapper { runPrismWrapper :: p a (f b) }
+
+instance (Functor f, Profunctor p) => Profunctor (PrismWrapper f p) where
+  dimap f g (PrismWrapper p) = PrismWrapper $ dimap f (fmap g) p
+
+instance (Applicative f, Choice p) => Choice (PrismWrapper f p) where
+  left' (PrismWrapper p) = PrismWrapper $ rmap sequenceL $ left' p
+    where
+      sequenceL (Left a) = fmap Left a
+      sequenceL (Right a) = pure $ Right a
+
+-- | Obtain a 'Prism' from a 'Profunctor'-based one.
+toPrism :: (forall p. Choice p => p a b -> p s t) -> Prism s t a b
+toPrism p = runPrismWrapper . p . PrismWrapper
+
+-- | Obtain a 'Lens' from a 'Profunctor'-based one.
+toLens :: (forall p. Strong p => p a b -> p s t) -> Lens s t a b
+toLens p = runStar . p . Star
+
+-- | Obtain a 'Setter' from a 'Profunctor'-based one.
+toSetter :: (forall p. Mapping p => p a b -> p s t) -> Setter s t a b
+toSetter p = runStar . p . Star
+
+-- | Obtain a 'Traversal' from a 'Profunctor'-based one.
+toTraversal :: (forall p. Traversing p => p a b -> p s t) -> Traversal s t a b
+toTraversal p = runStar . p . Star


### PR DESCRIPTION
This PR adds two functions:

- `overP`, which transforms a `Lens` into a profunctor one, based on `overA`;
- `applyPrism`, which transforms a `Prism` into a profunctor one.

These are very simple functions, which shouldn't introduce any extra burden to the maintenance of the library. They also open the way for some interoperation with profunctor optics libraries.

I think the name of `overP` is good, since it follows the pattern of `overA`. I choose `applyPrism` so that it can be used as:

```haskell
applyPrism _Left :: Choice p => p a b -> p (Either a c) (Either b c)
```

I don't know if any `INLINE`s would be appropriate.