### PR TITLE
Import liftM2 from Control.Monad instead of Control.Monad.Reader

### DIFF
--- a/src/Control/Lens/Internal/Zoom.hs
+++ b/src/Control/Lens/Internal/Zoom.hs
@@ -33,7 +33,7 @@ module Control.Lens.Internal.Zoom
 import Prelude ()
 
 import Control.Lens.Internal.Prelude
-import Control.Monad.Reader as Reader
+import Control.Monad
 import Control.Monad.Trans.Free
 import Data.Functor.Bind
 


### PR DESCRIPTION
There is an intention to stop re-exporting functions from `base` in future versions of `mtl`: https://github.com/haskell/mtl/pull/74
This PR brings `lens` in line with the proposed change, because at the moment `Control.Lens.Internal.Zoom` imports `liftM2` (originally from `Control.Monad`) from `Control.Monad.Reader`.