### PR TITLE
Remove unused Min and Max

### DIFF
--- a/src/Control/Lens/Internal/Fold.hs
+++ b/src/Control/Lens/Internal/Fold.hs
@@ -23,8 +23,6 @@ module Control.Lens.Internal.Fold
   , Traversed(..)
   , TraversedF(..)
   , Sequenced(..)
-  , Max(..), getMax
-  , Min(..), getMin
   , Leftmost(..), getLeftmost
   , Rightmost(..), getRightmost
   , ReifiedMonoid(..)
@@ -122,60 +120,6 @@ instance Monad m => Monoid (Sequenced a m) where
   {-# INLINE mempty #-}
   Sequenced ma `mappend` Sequenced mb = Sequenced (ma >> mb)
   {-# INLINE mappend #-}
-
-------------------------------------------------------------------------------
--- Min
-------------------------------------------------------------------------------
-
--- | Used for 'Control.Lens.Fold.minimumOf'.
-data Min a = NoMin | Min a
-
-instance Ord a => Semigroup (Min a) where
-  NoMin <> m     = m
-  m <> NoMin     = m
-  Min a <> Min b = Min (min a b)
-  {-# INLINE (<>) #-}
-
-instance Ord a => Monoid (Min a) where
-  mempty = NoMin
-  {-# INLINE mempty #-}
-  mappend NoMin m = m
-  mappend m NoMin = m
-  mappend (Min a) (Min b) = Min (min a b)
-  {-# INLINE mappend #-}
-
--- | Obtain the minimum.
-getMin :: Min a -> Maybe a
-getMin NoMin   = Nothing
-getMin (Min a) = Just a
-{-# INLINE getMin #-}
-
-------------------------------------------------------------------------------
--- Max
-------------------------------------------------------------------------------
-
--- | Used for 'Control.Lens.Fold.maximumOf'.
-data Max a = NoMax | Max a
-
-instance Ord a => Semigroup (Max a) where
-  NoMax <> m = m
-  m <> NoMax = m
-  Max a <> Max b = Max (max a b)
-  {-# INLINE (<>) #-}
-
-instance Ord a => Monoid (Max a) where
-  mempty = NoMax
-  {-# INLINE mempty #-}
-  mappend NoMax m = m
-  mappend m NoMax = m
-  mappend (Max a) (Max b) = Max (max a b)
-  {-# INLINE mappend #-}
-
--- | Obtain the maximum.
-getMax :: Max a -> Maybe a
-getMax NoMax   = Nothing
-getMax (Max a) = Just a
-{-# INLINE getMax #-}
 
 ------------------------------------------------------------------------------
 -- NonEmptyDList


### PR DESCRIPTION
The comment says there are used in minimumOf and maximumOf,
but these use `Endo (Endo (Maybe a))`.

cc used weeder by @ocharles for this. It seems to easily report false positives, but I this are true ones.