### PR TITLE
Safe Haskell support: Mark Control.Lens.Equality as Trustworthy

### DIFF
--- a/src/Control/Lens/Equality.hs
+++ b/src/Control/Lens/Equality.hs
@@ -8,6 +8,7 @@
 #endif
 #if __GLASGOW_HASKELL__ >= 800
 {-# LANGUAGE TypeInType #-}
+{-# LANGUAGE Trustworthy #-}
 #endif
 
 -----------------------------------------------------------------------------


### PR DESCRIPTION
The module imports TYPE (which is harmess) from GHC.Exts (which is unsafe).