### PR TITLE
Add an operator for constructing singleton maps

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,7 @@ next [2020.xx.yy]
 * Add `Control.Lens.Profunctor` with conversion functions to and from
   profunctor optic representation
 * Mark `Control.Lens.Equality` as Trustworthy
+* Add `Control.Lens.At.==>` for constructing singleton maps.
 
 4.19.2 [2020.04.15]
 -------------------

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -31,6 +31,7 @@ module Control.Lens.At
   -- * At
     At(at)
     , sans
+    , (==>)
     , iat
   -- * Ixed
   , Index
@@ -46,6 +47,7 @@ module Control.Lens.At
 import Prelude ()
 
 import Control.Lens.Each
+import Control.Lens.Empty
 import Control.Lens.Internal.Prelude
 import Control.Lens.Traversal
 import Control.Lens.Lens
@@ -65,7 +67,7 @@ import Data.IntMap as IntMap
 import Data.IntSet as IntSet
 import Data.Map as Map
 import Data.Set as Set
-import Data.Sequence as Seq
+import Data.Sequence as Seq hiding (Empty)
 import Data.Text as StrictT
 import Data.Text.Lazy as LazyT
 import Data.Tree
@@ -424,6 +426,20 @@ class Ixed m => At m where
 sans :: At m => Index m -> m -> m
 sans k m = m & at k .~ Nothing
 {-# INLINE sans #-}
+
+-- | Create a singleton container. Useful for making small maps.
+--
+-- >>> "foo" ==> "bar" :: Map String String
+-- fromList [("foo","bar")]
+--
+-- This operator has low precedence and is right-associative, so you can use it to create nested maps:
+--
+-- >>> "foo" ==> "bar" ==> "baz" :: Map String (Map String String)
+-- fromList [("foo",fromList [("bar","baz")])]
+(==>) :: (At m, AsEmpty m) => Index m -> IxValue m -> m
+k ==> v = Empty & at k ?~ v
+
+infixr 1 ==>
 
 -- | An indexed version of 'at'.
 --

--- a/src/Control/Lens/Operators.hs
+++ b/src/Control/Lens/Operators.hs
@@ -15,8 +15,10 @@
 ----------------------------------------------------------------------------
 module Control.Lens.Operators
   ( -- output from scripts/operators -h
+  -- * "Control.Lens.At"
+    (==>)
   -- * "Control.Lens.Cons"
-    (<|)
+  , (<|)
   , (|>)
   -- * "Control.Lens.Fold"
   , (^..)

--- a/tests/properties.hs
+++ b/tests/properties.hs
@@ -27,7 +27,7 @@ module Main where
 #if !(MIN_VERSION_base(4,8,0))
 import Control.Applicative
 #endif
-import Control.Lens
+import Control.Lens hiding ((==>))
 import Test.QuickCheck
 import Test.Framework
 import Test.Framework.Providers.QuickCheck2


### PR DESCRIPTION
I've often wanted a compact way to make singleton maps, and lens gives me generic tools to do that.

I'm not wedded to the use of `(==>)`; it matches a similar operator from Data.Dependent.Sum which is nice but clashes with an operator from QuickCheck. Maybe `(=:)`? Maybe something else?

I've picked `infixr 1` pretty arbitrarily but maybe a different fixity is appropriate.