### PR TITLE
Remove the last unsafeCoerce

### DIFF
--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -3,5 +3,3 @@ unconstrained:          False
 hlint:                  True
 apt:                    freeglut3-dev
 irc-channels:           irc.freenode.org#haskell-lens
--- Work around https://github.com/haskell/haddock/issues/242
-haddock:                <7.6 || >=7.8

--- a/experimental/Control/Lens/Format.hs
+++ b/experimental/Control/Lens/Format.hs
@@ -40,7 +40,7 @@ import Data.Distributive
 import Data.Monoid
 import Data.Profunctor.Unsafe
 import Data.Profunctor.Rep
-import Unsafe.Coerce
+import Data.Coerce
 
 ------------------------------------------------------------------------------
 -- Formattable
@@ -74,7 +74,7 @@ instance Profunctor (Formatted m) where
   lmap _ (Formatted mb) = Formatted mb
   rmap bc (Formatted mb) = Formatted (bc . mb)
   Formatted mb .# _ = Formatted mb
-  (#.) _ = unsafeCoerce
+  (#.) _ = coerce
 
 instance Corepresentable (Formatted m) where
   type Corep (Formatted m) = Const m

--- a/lens.cabal
+++ b/lens.cabal
@@ -174,11 +174,6 @@ flag test-templates
   default: True
   manual: True
 
--- Disallow unsafeCoerce
-flag safe
-  default: False
-  manual: True
-
 -- Assert that we are trustworthy when we can
 flag trustworthy
   default: True
@@ -320,9 +315,6 @@ library
   other-modules:
     Control.Lens.Internal.Prelude
     Paths_lens
-
-  if flag(safe)
-    cpp-options: -DSAFE=1
 
   if flag(trustworthy) && impl(ghc)
     other-extensions: Trustworthy


### PR DESCRIPTION
`SAFE` CPP definition wasn't used anywhere anymore. 