### PR TITLE
Use strict and assoc

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,6 +4,26 @@
 * Add `Control.Lens.Profunctor` with conversion functions to and from
   profunctor optic representation
 * Mark `Control.Lens.Equality` as Trustworthy
+* The `Swapped` type class is removed in favor of `Swap` from the `assoc` package
+* The `Strict` type class is removed in favor of `Strict` from the `strict` package
+
+  The `swapped`, `strict` and `lazy` isomorphisms are now defined using "new" type classes.
+
+  Users which define own instances of old type classes are advised to
+  define instances of the new ones.
+
+  ```haskell
+  import qualified Data.Bifunctor.Swap as Swap
+  import qualified Control.Lens        as Lens
+
+  instance Swap.Swap MyType where
+    swap = ...
+
+  #if !MIN_VERSION_lens(4,20,0)
+  instance Lens.Swapped MyType where
+    swapped = iso Swap.swap Swap.swap
+  #endif
+  ```
 
 4.19.2 [2020.04.15]
 -------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -187,6 +187,7 @@ flag j
 library
   build-depends:
     array                     >= 0.5.0.0  && < 0.6,
+    assoc                     >= 1.0.2    && < 1.1,
     base                      >= 4.7      && < 5,
     base-orphans              >= 0.5.2    && < 1,
     bifunctors                >= 5.1      && < 6,
@@ -207,8 +208,10 @@ library
     profunctors               >= 5.5.2    && < 6,
     reflection                >= 2.1      && < 3,
     semigroupoids             >= 5        && < 6,
+    strict                    >= 0.4      && < 0.5,
     tagged                    >= 0.4.4    && < 1,
     template-haskell          >= 2.9.0.0  && < 2.18,
+    these                     >= 1.1.1.1  && < 1.2,
     th-abstraction            >= 0.4      && < 0.5,
     text                      >= 1.2.3.0  && < 1.3,
     transformers              >= 0.3.0.0  && < 0.6,

--- a/src/Control/Lens/Tuple.hs
+++ b/src/Control/Lens/Tuple.hs
@@ -56,6 +56,7 @@ import           Prelude ()
 import           Control.Lens.Lens
 import           Control.Lens.Internal.Prelude
 import           Data.Functor.Product  (Product (..))
+import           Data.Strict           (Pair (..))
 import           GHC.Generics          ((:*:) (..), Generic (..), K1 (..),
                                         M1 (..), U1 (..))
 
@@ -106,6 +107,10 @@ instance Field1 (Product f g a) (Product f' g a) (f a) (f' a) where
 
 instance Field1 ((f :*: g) p) ((f' :*: g) p) (f p) (f' p) where
   _1 f (l :*: r) = (:*: r) <$> f l
+
+-- | @since 4.20
+instance Field1 (Pair a b) (Pair a' b) a a' where
+  _1 f (a :!: b) = (:!: b) <$> f a
 
 -- | @
 -- '_1' k ~(a,b) = (\\a' -> (a',b)) 'Data.Functor.<$>' k a
@@ -212,6 +217,10 @@ instance Field2 (Product f g a) (Product f g' a) (g a) (g' a) where
 
 instance Field2 ((f :*: g) p) ((f :*: g') p) (g p) (g' p) where
   _2 f (l :*: r) = (l :*:) <$> f r
+
+-- | @since 4.20
+instance Field2 (Pair a b) (Pair a b') b b' where
+  _2 f (a :!: b) = (a :!:) <$> f b
 
 -- | @
 -- '_2' k ~(a,b) = (\\b' -> (a,b')) 'Data.Functor.<$>' k b


### PR DESCRIPTION
Fixes #936. We also depend on assoc for Swap(ped), as `strict`
depends on `assoc` to provide `Swap` instances.

I hope that some day `Swap` class will migrate to `bifunctors`
or even to `base`.

There is `strict-lens`, with `Data.Strict.Lens` module,
adding some optics for types in `Data.Strict`.
It can be merged into `lens` or kept separate.