### PR TITLE
Make the TH machinery handle PolyKinds more robustly

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -21,6 +21,13 @@
     swapped = iso Swap.swap Swap.swap
   #endif
   ```
+* Make the functions in `Control.Lens.TH` work more robustly with poly-kinded
+  data types. This can cause a breaking change under certain situations:
+  * TH-generated optics for poly-kinded data types are now much more likely to
+    mention kind variables in their definitions, which will require enabling
+    the `PolyKinds` extension at use sites in order to typecheck.
+  * Because TH-generated optics now quantify more kind variables than they did
+    previously, this can affect the order of visible type applications.
 * Add `Control.Lens.Profunctor` with conversion functions to and from
   profunctor optic representation
 * Add `Control.Lens.Review.reviewing`, which is like `review` but with a more

--- a/lens.cabal
+++ b/lens.cabal
@@ -212,7 +212,7 @@ library
     tagged                    >= 0.4.4    && < 1,
     template-haskell          >= 2.9.0.0  && < 2.18,
     these                     >= 1.1.1.1  && < 1.2,
-    th-abstraction            >= 0.4      && < 0.5,
+    th-abstraction            >= 0.4.1    && < 0.5,
     text                      >= 1.2.3.0  && < 1.3,
     transformers              >= 0.3.0.0  && < 0.6,
     transformers-compat       >= 0.4      && < 1,
@@ -353,10 +353,15 @@ library
 test-suite templates
   type: exitcode-stdio-1.0
   main-is: templates.hs
-  other-modules: T799
+  other-modules:
+    T799
+    T917
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
   default-language: Haskell2010
+
+  if impl(ghc >= 8.6)
+    ghc-options: -Wno-star-is-type
 
   if flag(dump-splices)
     ghc-options: -ddump-splices

--- a/src/Control/Lens/Internal/TH.hs
+++ b/src/Control/Lens/Internal/TH.hs
@@ -22,7 +22,11 @@
 module Control.Lens.Internal.TH where
 
 import Data.Functor.Contravariant
+import qualified Data.Set as Set
+import Data.Set (Set)
 import Language.Haskell.TH
+import qualified Language.Haskell.TH.Datatype as D
+import qualified Language.Haskell.TH.Datatype.TyVarBndr as D
 import Language.Haskell.TH.Syntax
 #ifndef CURRENT_PACKAGE_KEY
 import Data.Version (showVersion)
@@ -87,6 +91,80 @@ unfoldType = go []
     go acc (AppKindT ty _)  = go acc ty
 #endif
     go acc ty               = (ty, acc)
+
+-- Construct a 'Type' using the datatype's type constructor and type
+-- parameters. Unlike 'D.datatypeType', kind signatures are preserved to
+-- some extent. (See the comments for 'dropSigsIfNonDataFam' below for more
+-- details on this.)
+datatypeTypeKinded :: D.DatatypeInfo -> Type
+datatypeTypeKinded di
+  = foldl AppT (ConT (D.datatypeName di))
+  $ dropSigsIfNonDataFam
+  $ D.datatypeInstTypes di
+  where
+    {-
+    In an effort to prevent users from having to enable KindSignatures every
+    time that they use lens' TH functionality, we strip off reified kind
+    annotations from when:
+
+    1. The kind of a type does not contain any kind variables. If it *does*
+       contain kind variables, we want to preserve them so that we can generate
+       type signatures that preserve the dependency order of kind and type
+       variables. (The data types in test/T917.hs contain examples where this
+       is important.) This will require enabling `PolyKinds`, but since
+       `PolyKinds` implies `KindSignatures`, we can at least accomplish two
+       things at once.
+    2. The data type is not an instance of a data family. We make an exception
+       for data family instances, since the presence or absence of a kind
+       annotation can be the difference between typechecking or not.
+       (See T917DataFam in tests/T917.hs for an example.) Moreover, the
+       `TypeFamilies` extension implies `KindSignatures`.
+    -}
+    dropSigsIfNonDataFam :: [Type] -> [Type]
+    dropSigsIfNonDataFam
+      | isDataFamily (D.datatypeVariant di) = id
+      | otherwise                           = map dropSig
+
+    dropSig :: Type -> Type
+    dropSig (SigT t k) | null (D.freeVariables k) = t
+    dropSig t                                     = t
+
+-- | Template Haskell wants type variables declared in a forall, so
+-- we find all free type variables in a given type and declare them.
+quantifyType :: Cxt -> Type -> Type
+quantifyType = quantifyType' Set.empty
+
+-- | This function works like 'quantifyType' except that it takes
+-- a list of variables to exclude from quantification.
+quantifyType' :: Set Name -> Cxt -> Type -> Type
+quantifyType' exclude c t = ForallT vs c t
+  where
+  vs = filter (\tvb -> D.tvName tvb `Set.notMember` exclude)
+     $ D.changeTVFlags D.SpecifiedSpec
+     $ D.freeVariablesWellScoped (t:concatMap predTypes c) -- stable order
+
+  predTypes :: Pred -> [Type]
+#if MIN_VERSION_template_haskell(2,10,0)
+  predTypes p = [p]
+#else
+  predTypes (ClassP _ ts)  = ts
+  predTypes (EqualP t1 t2) = [t1, t2]
+#endif
+
+-- | Convert a 'TyVarBndr' into its corresponding 'Type'.
+tvbToType :: D.TyVarBndr_ flag -> Type
+tvbToType = D.elimTV VarT (SigT . VarT)
+
+-- | Peel off a kind signature from a Type (if it has one).
+unSigT :: Type -> Type
+unSigT (SigT t _) = t
+unSigT t          = t
+
+isDataFamily :: D.DatatypeVariant -> Bool
+isDataFamily D.Datatype        = False
+isDataFamily D.Newtype         = False
+isDataFamily D.DataInstance    = True
+isDataFamily D.NewtypeInstance = True
 
 ------------------------------------------------------------------------
 -- Manually quoted names

--- a/tests/T917.hs
+++ b/tests/T917.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeFamilies #-}
+
+#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+module T917 where
+
+import Control.Lens
+import Data.Proxy
+
+#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 806
+import Data.Kind
+#endif
+
+-- Like Data.Functor.Const, but redfined to ensure that it is poly-kinded
+-- across all versions of GHC, not just 8.0+
+newtype Constant a (b :: k) = Constant a
+
+data T917OneA (a :: k -> *) (b :: k -> *) = MkT917OneA
+data T917OneB a b = MkT917OneB (T917OneA a (Const b))
+$(makePrisms ''T917OneB)
+
+data T917TwoA (a :: k -> *) (b :: k -> *) = MkT917TwoA
+data T917TwoB a b = MkT917TwoB (T917TwoA a (Const b))
+$(makeClassyPrisms ''T917TwoB)
+
+data family   T917DataFam (a :: k)
+data instance T917DataFam (a :: *) = MkT917DataFam { _unT917DataFam :: Proxy a }
+$(makeLenses 'MkT917DataFam)
+
+#if __GLASGOW_HASKELL__ >= 800
+data T917GadtOne (a :: k) where
+  MkT917GadtOne :: T917GadtOne (a :: *)
+$(makePrisms ''T917GadtOne)
+
+data T917GadtTwo (a :: k) where
+  MkT917GadtTwo :: T917GadtTwo (a :: *)
+$(makePrisms ''T917GadtTwo)
+#endif

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -27,6 +27,7 @@ module Main where
 import Control.Lens
 -- import Test.QuickCheck (quickCheck)
 import T799 ()
+import T917 ()
 
 data Bar a b c = Bar { _baz :: (a, b) }
 makeLenses ''Bar


### PR DESCRIPTION
This is a collection of various Template Haskell–related fixes that, when all put together, fixes #917. This does the following:

* Rather than use `th-abstraction`'s `datatypeType` function, which strips off important kind information from type arguments, I defined a similar `datatypeTypeKinded` function that preserves kinds.
* `Control.Lens.Internal.{FieldTH,PrismTH}` is now more careful to use `freeVariablesWellScoped` (from `th-abstraction`) instead of `typeVars` to ensure that the resulting types are well scoped. This is particularly important for poly-kinded types, as the kind variables must always appear before the type variables.
* I deleted the `close` function from `Control.Lens.Internal.PrismTH` in favor of `quantifyType` and `quantifyType'`, which I have moved to `Control.Lens.Internal.TH` so that they may be used by `FieldTH` and `PrismTH` alike. Moreover, I now use `quantifyType'` in the definition of `PrismTH.makeClassyPrismClass` so that any type variables bound by the class itself do not get requantified in any class methods. The previous code was not doing this at all, which was just plain wrong.