### PR TITLE
Allow bytestring-0.11 in examples

### DIFF
--- a/examples/lens-examples.cabal
+++ b/examples/lens-examples.cabal
@@ -40,7 +40,7 @@ library
   build-depends:
     aeson,
     base       >= 4.5      && < 5,
-    bytestring >= 0.9.1.10 && < 0.11,
+    bytestring >= 0.9.1.10 && < 0.12,
     data-default-class,
     ghc-prim,
     lens


### PR DESCRIPTION
Answering questions in #948, one can test it using this config:
```
packages: .
          ./examples
          ./lens-properties
tests: True

constraints:
  bytestring >=0.11, lens -test-doctests

allow-newer:
  -- https://github.com/tibbe/hashable/pull/191
  hashable:bytestring,
  -- https://github.com/haskellari/strict/pull/23
  strict:bytestring,
  -- TODO
  uuid-types:bytestring,
  regex-posix:bytestring,
  regex-base:bytestring

source-repository-package
  type: git
  location: https://github.com/haskell/text
  tag: v1.2.4.1-rc1

-- https://github.com/bgamari/attoparsec/pull/5
source-repository-package
  type: git
  location: https://github.com/phadej/attoparsec
  tag: 7efaa371058c1092b728c973c778704a167bc04c
```
Doctests are disabled in this configuration, because they depend on `ghc` package, which requires wired-in `bytestring`.

Somehow `stack` seems happy to override the latter, so I was able to run doctests using this:
```
resolver: nightly-2020-09-28
packages:
- .
- ./examples
- ./lens-properties
extra-deps:
- bytestring-0.11.0.0
- splitmix-0.1
- doctest-0.17
- smallcheck-1.2.0
- directory-1.3.6.1
- process-1.6.10.0
- unix-2.7.2.2
- binary-0.8.8.0
- parsec-3.1.14.0
- th-abstraction-0.4.0.0
- random-1.2.0
- assoc-1.0.2
- hashable-1.3.0.0
- kan-extensions-5.2.1
- tagged-0.8.6
- strict-0.4
- transformers-compat-0.6.6
- transformers-0.5.6.2
- these-1.1.1.1
- ghc-paths-0.1.0.12
- cabal-doctest-1.0.8
- profunctors-5.6
- github: haskell/cabal
  commit: 81fd8d935a25212d9b38c9b8b41fac2c22d42d58
  subdir: Cabal
- github: haskell/text
  commit: be54b46175db603aafea3e3f19a6a75e87a29828
allow-newer: true
```