### PR TITLE
Use indexed-traversable

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -33,6 +33,16 @@
 * Add `Control.Lens.Review.reviewing`, which is like `review` but with a more
   polymorphic type.
 * Mark `Control.Lens.Equality` as Trustworthy
+* The `FunctorWithIndex`, `FoldableWithIndex` and `TraversableWithIndex` type classes
+  have been migrated to a new package, [`indexed-traversable`](https://hackage.haskell.org/package/indexed-traversable)
+
+  The `imapped`, `ifolded` and `itraversed` methods are now top-level functions.
+  If you are not defining these methods in your instances,
+  you don't need to change your definitions.
+
+  Beware: the `optics-core` package (versions <0.4) defines similar classes,
+  and will also migrate to use `indexed-traversable` classes. Therefore you
+  might get duplicate instance errors if your package defines both.
 
 4.19.2 [2020.04.15]
 -------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -193,12 +193,12 @@ library
     bifunctors                >= 5.1      && < 6,
     bytestring                >= 0.10.4.0 && < 0.12,
     call-stack                >= 0.1      && < 0.3,
-    comonad                   >= 4        && < 6,
+    comonad                   >= 5.0.7    && < 6,
     contravariant             >= 1.3      && < 2,
     containers                >= 0.5.5.1  && < 0.7,
     distributive              >= 0.3      && < 1,
     filepath                  >= 1.2.0.0  && < 1.5,
-    free                      >= 4        && < 6,
+    free                      >= 5.1.5    && < 6,
     ghc-prim,
     hashable                  >= 1.1.2.3  && < 1.4,
     kan-extensions            >= 5        && < 6,
@@ -217,7 +217,9 @@ library
     transformers              >= 0.3.0.0  && < 0.6,
     transformers-compat       >= 0.4      && < 1,
     unordered-containers      >= 0.2.4    && < 0.3,
-    vector                    >= 0.9      && < 0.13
+    vector                    >= 0.9      && < 0.13,
+    indexed-traversable           >= 0.1      && < 0.2,
+    indexed-traversable-instances >= 0.1      && < 0.2
 
   if !impl(ghc >= 8.0)
     build-depends:

--- a/src/Control/Lens/Indexed.hs
+++ b/src/Control/Lens/Indexed.hs
@@ -1,12 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE DefaultSignatures #-}
-{-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 
 #ifdef TRUSTWORTHY
 {-# LANGUAGE Trustworthy #-} -- vector, hashable
@@ -82,43 +77,31 @@ module Control.Lens.Indexed
 
 import Prelude ()
 
-import Control.Applicative.Backwards
-import Control.Comonad.Cofree
-import Control.Comonad.Trans.Traced
-import Control.Monad (void, liftM)
-import Control.Monad.Trans.Identity
-import Control.Monad.Trans.Reader
-import Control.Monad.Trans.State.Lazy as Lazy
-import Control.Monad.Free
+import Data.Functor.WithIndex
+import Data.Foldable.WithIndex
+import Data.Traversable.WithIndex
+
 import Control.Lens.Fold
 import Control.Lens.Getter
 import Control.Lens.Internal.Fold
 import Control.Lens.Internal.Indexed
 import Control.Lens.Internal.Prelude
-import Control.Lens.Internal.Level
-import Control.Lens.Internal.Magma
 import Control.Lens.Setter
 import Control.Lens.Traversal
 import Control.Lens.Type
-import Data.Array (Array)
-import qualified Data.Array as Array
-import Data.Foldable
-import Data.Functor.Constant (Constant (..))
-import Data.Functor.Product
-import Data.Functor.Reverse
-import Data.Functor.Sum
-import Data.HashMap.Lazy as HashMap
-import Data.IntMap as IntMap
-import Data.Ix (Ix)
-import Data.Map as Map
-import Data.Monoid hiding (Sum, Product)
 import Data.Reflection
-import Data.Sequence hiding ((:<), index)
-import Data.Tree
-import Data.Tuple (swap)
+
+import Data.HashMap.Lazy (HashMap)
+import Data.IntMap (IntMap)
+import Data.Map (Map)
+import Data.Sequence (Seq)
 import Data.Vector (Vector)
-import qualified Data.Vector as V
-import GHC.Generics
+
+import qualified Data.HashMap.Lazy as HashMap
+import qualified Data.IntMap as IntMap
+import qualified Data.Map as Map
+import qualified Data.Sequence as Seq
+import qualified Data.Vector as Vector
 
 infixr 9 <.>, <., .>
 
@@ -215,21 +198,6 @@ index j f = Indexed $ \i a -> if j == i then indexed f i a else pure a
 -- FunctorWithIndex
 -------------------------------------------------------------------------------
 
--- | A 'Functor' with an additional index.
---
--- Instances must satisfy a modified form of the 'Functor' laws:
---
--- @
--- 'imap' f '.' 'imap' g ≡ 'imap' (\\i -> f i '.' g i)
--- 'imap' (\\_ a -> a) ≡ 'id'
--- @
-class Functor f => FunctorWithIndex i f | f -> i where
-  -- | Map with access to the index.
-  imap :: (i -> a -> b) -> f a -> f b
-  default imap :: TraversableWithIndex i f => (i -> a -> b) -> f a -> f b
-  imap f = runIdentity #. itraverse (\i a -> Identity (f i a))
-  {-# INLINE imap #-}
-
 -- | The 'IndexedSetter' for a 'FunctorWithIndex'.
 --
 -- If you don't need access to the index, then 'mapped' is more flexible in what it accepts.
@@ -241,69 +209,6 @@ imapped = conjoined mapped (isets imap)
 -- FoldableWithIndex
 -------------------------------------------------------------------------------
 
--- | A container that supports folding with an additional index.
-class Foldable f => FoldableWithIndex i f | f -> i where
-  --
-  -- | Fold a container by mapping value to an arbitrary 'Monoid' with access to the index @i@.
-  --
-  -- When you don't need access to the index then 'foldMap' is more flexible in what it accepts.
-  --
-  -- @
-  -- 'foldMap' ≡ 'ifoldMap' '.' 'const'
-  -- @
-  ifoldMap :: Monoid m => (i -> a -> m) -> f a -> m
-#ifndef HLINT
-  default ifoldMap :: (TraversableWithIndex i f, Monoid m) => (i -> a -> m) -> f a -> m
-  ifoldMap f = getConst #. itraverse (\i a -> Const (f i a))
-  {-# INLINE ifoldMap #-}
-#endif
-
-  -- | Right-associative fold of an indexed container with access to the index @i@.
-  --
-  -- When you don't need access to the index then 'Data.Foldable.foldr' is more flexible in what it accepts.
-  --
-  -- @
-  -- 'Data.Foldable.foldr' ≡ 'ifoldr' '.' 'const'
-  -- @
-  ifoldr   :: (i -> a -> b -> b) -> b -> f a -> b
-  ifoldr f z t = appEndo (ifoldMap (\i -> Endo #. f i) t) z
-  {-# INLINE ifoldr #-}
-
-  -- | Left-associative fold of an indexed container with access to the index @i@.
-  --
-  -- When you don't need access to the index then 'Data.Foldable.foldl' is more flexible in what it accepts.
-  --
-  -- @
-  -- 'Data.Foldable.foldl' ≡ 'ifoldl' '.' 'const'
-  -- @
-  ifoldl :: (i -> b -> a -> b) -> b -> f a -> b
-  ifoldl f z t = appEndo (getDual (ifoldMap (\i -> Dual #. Endo #. flip (f i)) t)) z
-  {-# INLINE ifoldl #-}
-
-  -- | /Strictly/ fold right over the elements of a structure with access to the index @i@.
-  --
-  -- When you don't need access to the index then 'foldr'' is more flexible in what it accepts.
-  --
-  -- @
-  -- 'foldr'' ≡ 'ifoldr'' '.' 'const'
-  -- @
-  ifoldr' :: (i -> a -> b -> b) -> b -> f a -> b
-  ifoldr' f z0 xs = ifoldl f' id xs z0
-    where f' i k x z = k $! f i x z
-  {-# INLINE ifoldr' #-}
-
-  -- | Fold over the elements of a structure with an index, associating to the left, but /strictly/.
-  --
-  -- When you don't need access to the index then 'Control.Lens.Fold.foldlOf'' is more flexible in what it accepts.
-  --
-  -- @
-  -- 'Control.Lens.Fold.foldlOf'' l ≡ 'ifoldlOf'' l '.' 'const'
-  -- @
-  ifoldl' :: (i -> b -> a -> b) -> b -> f a -> b
-  ifoldl' f z0 xs = ifoldr f' id xs z0
-    where f' i x k z = k $! f i z x
-  {-# INLINE ifoldl' #-}
-
 -- | The 'IndexedFold' of a 'FoldableWithIndex' container.
 --
 -- @'ifolded' '.' 'asIndex'@ is a fold over the keys of a 'FoldableWithIndex'.
@@ -314,387 +219,25 @@ ifolded :: FoldableWithIndex i f => IndexedFold i (f a) a
 ifolded = conjoined folded $ \f -> phantom . getFolding . ifoldMap (\i -> Folding #. indexed f i)
 {-# INLINE ifolded #-}
 
--- | Return whether or not any element in a container satisfies a predicate, with access to the index @i@.
---
--- When you don't need access to the index then 'any' is more flexible in what it accepts.
---
--- @
--- 'any' ≡ 'iany' '.' 'const'
--- @
-iany :: FoldableWithIndex i f => (i -> a -> Bool) -> f a -> Bool
-iany f = getAny #. ifoldMap (\i -> Any #. f i)
-{-# INLINE iany #-}
-
--- | Return whether or not all elements in a container satisfy a predicate, with access to the index @i@.
---
--- When you don't need access to the index then 'all' is more flexible in what it accepts.
---
--- @
--- 'all' ≡ 'iall' '.' 'const'
--- @
-iall :: FoldableWithIndex i f => (i -> a -> Bool) -> f a -> Bool
-iall f = getAll #. ifoldMap (\i -> All #. f i)
-{-# INLINE iall #-}
-
--- | Return whether or not none of the elements in a container satisfy a predicate, with access to the index @i@.
---
--- When you don't need access to the index then 'none' is more flexible in what it accepts.
---
--- @
--- 'none' ≡ 'inone' '.' 'const'
--- 'inone' f ≡ 'not' '.' 'iany' f
--- @
-inone :: FoldableWithIndex i f => (i -> a -> Bool) -> f a -> Bool
-inone f = not . iany f
-{-# INLINE inone #-}
-
--- | Determines whether no elements of the structure satisfy the predicate.
---
--- @
--- 'none' f ≡ 'not' '.' 'any' f
--- @
-none :: Foldable f => (a -> Bool) -> f a -> Bool
-none f = not . Data.Foldable.any f
-{-# INLINE none #-}
-
--- | Traverse elements with access to the index @i@, discarding the results.
---
--- When you don't need access to the index then 'traverse_' is more flexible in what it accepts.
---
--- @
--- 'traverse_' l = 'itraverse' '.' 'const'
--- @
-itraverse_ :: (FoldableWithIndex i t, Applicative f) => (i -> a -> f b) -> t a -> f ()
-itraverse_ f = void . getTraversed #. ifoldMap (\i -> Traversed #. f i)
-{-# INLINE itraverse_ #-}
-
--- | Traverse elements with access to the index @i@, discarding the results (with the arguments flipped).
---
--- @
--- 'ifor_' ≡ 'flip' 'itraverse_'
--- @
---
--- When you don't need access to the index then 'for_' is more flexible in what it accepts.
---
--- @
--- 'for_' a ≡ 'ifor_' a '.' 'const'
--- @
-ifor_ :: (FoldableWithIndex i t, Applicative f) => t a -> (i -> a -> f b) -> f ()
-ifor_ = flip itraverse_
-{-# INLINE ifor_ #-}
-
--- | Run monadic actions for each target of an 'IndexedFold' or 'Control.Lens.IndexedTraversal.IndexedTraversal' with access to the index,
--- discarding the results.
---
--- When you don't need access to the index then 'Control.Lens.Fold.mapMOf_' is more flexible in what it accepts.
---
--- @
--- 'mapM_' ≡ 'imapM' '.' 'const'
--- @
-imapM_ :: (FoldableWithIndex i t, Monad m) => (i -> a -> m b) -> t a -> m ()
-imapM_ f = liftM skip . getSequenced #. ifoldMap (\i -> Sequenced #. f i)
-{-# INLINE imapM_ #-}
-
--- | Run monadic actions for each target of an 'IndexedFold' or 'Control.Lens.IndexedTraversal.IndexedTraversal' with access to the index,
--- discarding the results (with the arguments flipped).
---
--- @
--- 'iforM_' ≡ 'flip' 'imapM_'
--- @
---
--- When you don't need access to the index then 'Control.Lens.Fold.forMOf_' is more flexible in what it accepts.
---
--- @
--- 'Control.Lens.Fold.forMOf_' l a ≡ 'iforMOf' l a '.' 'const'
--- @
-iforM_ :: (FoldableWithIndex i t, Monad m) => t a -> (i -> a -> m b) -> m ()
-iforM_ = flip imapM_
-{-# INLINE iforM_ #-}
-
--- | Concatenate the results of a function of the elements of an indexed container with access to the index.
---
--- When you don't need access to the index then 'concatMap' is more flexible in what it accepts.
---
--- @
--- 'concatMap' ≡ 'iconcatMap' '.' 'const'
--- 'iconcatMap' ≡ 'ifoldMap'
--- @
-iconcatMap :: FoldableWithIndex i f => (i -> a -> [b]) -> f a -> [b]
-iconcatMap = ifoldMap
-{-# INLINE iconcatMap #-}
-
--- | Searches a container with a predicate that is also supplied the index, returning the left-most element of the structure
--- matching the predicate, or 'Nothing' if there is no such element.
---
--- When you don't need access to the index then 'find' is more flexible in what it accepts.
---
--- @
--- 'find' ≡ 'ifind' '.' 'const'
--- @
-ifind :: FoldableWithIndex i f => (i -> a -> Bool) -> f a -> Maybe (i, a)
-ifind p = ifoldr (\i a y -> if p i a then Just (i, a) else y) Nothing
-{-# INLINE ifind #-}
-
--- | Monadic fold right over the elements of a structure with an index.
---
--- When you don't need access to the index then 'foldrM' is more flexible in what it accepts.
---
--- @
--- 'foldrM' ≡ 'ifoldrM' '.' 'const'
--- @
-ifoldrM :: (FoldableWithIndex i f, Monad m) => (i -> a -> b -> m b) -> b -> f a -> m b
-ifoldrM f z0 xs = ifoldl f' return xs z0
-  where f' i k x z = f i x z >>= k
-{-# INLINE ifoldrM #-}
-
--- | Monadic fold over the elements of a structure with an index, associating to the left.
---
--- When you don't need access to the index then 'foldlM' is more flexible in what it accepts.
---
--- @
--- 'foldlM' ≡ 'ifoldlM' '.' 'const'
--- @
-ifoldlM :: (FoldableWithIndex i f, Monad m) => (i -> b -> a -> m b) -> b -> f a -> m b
-ifoldlM f z0 xs = ifoldr f' return xs z0
-  where f' i x k z = f i z x >>= k
-{-# INLINE ifoldlM #-}
-
--- | Extract the key-value pairs from a structure.
---
--- When you don't need access to the indices in the result, then 'Data.Foldable.toList' is more flexible in what it accepts.
---
--- @
--- 'Data.Foldable.toList' ≡ 'Data.List.map' 'snd' '.' 'itoList'
--- @
-itoList :: FoldableWithIndex i f => f a -> [(i,a)]
-itoList = ifoldr (\i c -> ((i,c):)) []
-{-# INLINE itoList #-}
-
 -------------------------------------------------------------------------------
 -- TraversableWithIndex
 -------------------------------------------------------------------------------
-
--- | A 'Traversable' with an additional index.
---
--- An instance must satisfy a (modified) form of the 'Traversable' laws:
---
--- @
--- 'itraverse' ('const' 'Identity') ≡ 'Identity'
--- 'fmap' ('itraverse' f) '.' 'itraverse' g ≡ 'Data.Functor.Compose.getCompose' '.' 'itraverse' (\\i -> 'Data.Functor.Compose.Compose' '.' 'fmap' (f i) '.' g i)
--- @
-class (FunctorWithIndex i t, FoldableWithIndex i t, Traversable t) => TraversableWithIndex i t | t -> i where
-  -- | Traverse an indexed container.
-  --
-  -- @
-  -- 'itraverse' ≡ 'itraverseOf' 'itraversed'
-  -- @
-  itraverse :: Applicative f => (i -> a -> f b) -> t a -> f (t b)
-#ifndef HLINT
-  default itraverse :: (i ~ Int, Applicative f) => (i -> a -> f b) -> t a -> f (t b)
-  itraverse f s = snd $ runIndexing (traverse (\a -> Indexing (\i -> i `seq` (i + 1, f i a))) s) 0
-  {-# INLINE itraverse #-}
-#endif
 
 -- | The 'IndexedTraversal' of a 'TraversableWithIndex' container.
 itraversed :: TraversableWithIndex i t => IndexedTraversal i (t a) (t b) a b
 itraversed = conjoined traverse (itraverse . indexed)
 {-# INLINE [0] itraversed #-}
 
--- | Traverse with an index (and the arguments flipped).
---
--- @
--- 'for' a ≡ 'ifor' a '.' 'const'
--- 'ifor' ≡ 'flip' 'itraverse'
--- @
-ifor :: (TraversableWithIndex i t, Applicative f) => t a -> (i -> a -> f b) -> f (t b)
-ifor = flip itraverse
-{-# INLINE ifor #-}
-
--- | Map each element of a structure to a monadic action,
--- evaluate these actions from left to right, and collect the results, with access
--- the index.
---
--- When you don't need access to the index 'mapM' is more liberal in what it can accept.
---
--- @
--- 'mapM' ≡ 'imapM' '.' 'const'
--- @
-imapM :: (TraversableWithIndex i t, Monad m) => (i -> a -> m b) -> t a -> m (t b)
-imapM f = unwrapMonad #. itraverse (\i -> WrapMonad #. f i)
-{-# INLINE imapM #-}
-
--- | Map each element of a structure to a monadic action,
--- evaluate these actions from left to right, and collect the results, with access
--- its position (and the arguments flipped).
---
--- @
--- 'forM' a ≡ 'iforM' a '.' 'const'
--- 'iforM' ≡ 'flip' 'imapM'
--- @
-iforM :: (TraversableWithIndex i t, Monad m) => t a -> (i -> a -> m b) -> m (t b)
-iforM = flip imapM
-{-# INLINE iforM #-}
-
--- | Generalizes 'Data.Traversable.mapAccumR' to add access to the index.
---
--- 'imapAccumROf' accumulates state from right to left.
---
--- @
--- 'Control.Lens.Traversal.mapAccumR' ≡ 'imapAccumR' '.' 'const'
--- @
-imapAccumR :: TraversableWithIndex i t => (i -> s -> a -> (s, b)) -> s -> t a -> (s, t b)
-imapAccumR f s0 a = swap (Lazy.runState (forwards (itraverse (\i c -> Backwards (Lazy.state (\s -> swap (f i s c)))) a)) s0)
-{-# INLINE imapAccumR #-}
-
--- | Generalizes 'Data.Traversable.mapAccumL' to add access to the index.
---
--- 'imapAccumLOf' accumulates state from left to right.
---
--- @
--- 'Control.Lens.Traversal.mapAccumLOf' ≡ 'imapAccumL' '.' 'const'
--- @
-imapAccumL :: TraversableWithIndex i t => (i -> s -> a -> (s, b)) -> s -> t a -> (s, t b)
-imapAccumL f s0 a = swap (Lazy.runState (itraverse (\i c -> Lazy.state (\s -> swap (f i s c))) a) s0)
-{-# INLINE imapAccumL #-}
-
 -------------------------------------------------------------------------------
 -- Instances
 -------------------------------------------------------------------------------
 
-instance FunctorWithIndex i f => FunctorWithIndex i (Backwards f) where
-  imap f  = Backwards . imap f . forwards
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i f => FoldableWithIndex i (Backwards f) where
-  ifoldMap f = ifoldMap f . forwards
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i f => TraversableWithIndex i (Backwards f) where
-  itraverse f = fmap Backwards . itraverse f . forwards
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i f => FunctorWithIndex i (Reverse f) where
-  imap f = Reverse . imap f . getReverse
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i f => FoldableWithIndex i (Reverse f) where
-  ifoldMap f = getDual . ifoldMap (\i -> Dual #. f i) . getReverse
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i f => TraversableWithIndex i (Reverse f) where
-  itraverse f = fmap Reverse . forwards . itraverse (\i -> Backwards . f i) . getReverse
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex () Identity where
-  imap f (Identity a) = Identity (f () a)
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex () Identity where
-  ifoldMap f (Identity a) = f () a
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex () Identity where
-  itraverse f (Identity a) = Identity <$> f () a
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex Void (Const e) where
-  imap _ (Const a) = Const a
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex Void (Const e) where
-  ifoldMap _ _ = mempty
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex Void (Const e) where
-  itraverse _ (Const a) = pure (Const a)
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex Void (Constant e) where
-  imap _ (Constant a) = Constant a
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex Void (Constant e) where
-  ifoldMap _ _ = mempty
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex Void (Constant e) where
-  itraverse _ (Constant a) = pure (Constant a)
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex k ((,) k) where
-  imap f (k,a) = (k, f k a)
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex k ((,) k) where
-  ifoldMap = uncurry
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex k ((,) k) where
-  itraverse f (k, a) = (,) k <$> f k a
-  {-# INLINE itraverse #-}
-
--- | The position in the list is available as the index.
-instance FunctorWithIndex Int []
-instance FoldableWithIndex Int []
-instance TraversableWithIndex Int []
-
--- | Same instance as for @[]@.
-instance FunctorWithIndex Int ZipList
-instance FoldableWithIndex Int ZipList
-instance TraversableWithIndex Int ZipList
-
-instance FunctorWithIndex Int NonEmpty
-instance FoldableWithIndex Int NonEmpty
-instance TraversableWithIndex Int NonEmpty
-
-instance FunctorWithIndex () Maybe where
-  imap f = fmap (f ())
-  {-# INLINE imap #-}
-instance FoldableWithIndex () Maybe where
-  ifoldMap f = foldMap (f ())
-  {-# INLINE ifoldMap #-}
-instance TraversableWithIndex () Maybe where
-  itraverse f = traverse (f ())
-  {-# INLINE itraverse #-}
-
--- | The position in the 'Seq' is available as the index.
-instance FunctorWithIndex Int Seq where
-  imap = mapWithIndex
-instance FoldableWithIndex Int Seq where
-#if MIN_VERSION_containers(0,5,8)
-  ifoldMap = foldMapWithIndex
-#else
-  ifoldMap f = Data.Foldable.fold . mapWithIndex f
-#endif
-  ifoldr = foldrWithIndex
-  ifoldl f = foldlWithIndex (flip f)
-  {-# INLINE ifoldl #-}
-instance TraversableWithIndex Int Seq where
-#if MIN_VERSION_containers(0,5,8)
-  itraverse = traverseWithIndex
-#else
-  itraverse f = sequenceA . mapWithIndex f
-#endif
-
-instance FunctorWithIndex Int Vector where
-  imap = V.imap
-  {-# INLINE imap #-}
-instance FoldableWithIndex Int Vector where
-  ifoldr = V.ifoldr
-  {-# INLINE ifoldr #-}
-  ifoldl = V.ifoldl . flip
-  {-# INLINE ifoldl #-}
-  ifoldr' = V.ifoldr'
-  {-# INLINE ifoldr' #-}
-  ifoldl' = V.ifoldl' . flip
-  {-# INLINE ifoldl' #-}
-instance TraversableWithIndex Int Vector
-
-instance FunctorWithIndex Int IntMap
-instance FoldableWithIndex Int IntMap
-instance TraversableWithIndex Int IntMap where
-  itraverse = IntMap.traverseWithKey
-  {-# INLINE [0] itraverse #-}
+{-# RULES
+"itraversed -> mapList"    itraversed = sets fmap        :: ASetter [a] [b] a b;
+"itraversed -> imapList"   itraversed = isets imap       :: AnIndexedSetter Int [a] [b] a b;
+"itraversed -> foldrList"  itraversed = foldring foldr   :: Getting (Endo r) [a] a;
+"itraversed -> ifoldrList" itraversed = ifoldring ifoldr :: IndexedGetting Int (Endo r) [a] a;
+ #-}
 
 {-# RULES
 "itraversed -> mapIntMap"    itraversed = sets IntMap.map               :: ASetter (IntMap a) (IntMap b) a b;
@@ -703,24 +246,12 @@ instance TraversableWithIndex Int IntMap where
 "itraversed -> ifoldrIntMap" itraversed = ifoldring IntMap.foldrWithKey :: IndexedGetting Int (Endo r) (IntMap a) a;
  #-}
 
-instance FunctorWithIndex k (Map k)
-instance FoldableWithIndex k (Map k)
-instance TraversableWithIndex k (Map k) where
-  itraverse = Map.traverseWithKey
-  {-# INLINE [0] itraverse #-}
-
 {-# RULES
 "itraversed -> mapMap"    itraversed = sets Map.map               :: ASetter (Map k a) (Map k b) a b;
 "itraversed -> imapMap"   itraversed = isets Map.mapWithKey       :: AnIndexedSetter k (Map k a) (Map k b) a b;
 "itraversed -> foldrMap"  itraversed = foldring Map.foldr         :: Getting (Endo r) (Map k a) a;
 "itraversed -> ifoldrMap" itraversed = ifoldring Map.foldrWithKey :: IndexedGetting k (Endo r) (Map k a) a;
  #-}
-
-instance FunctorWithIndex k (HashMap k)
-instance FoldableWithIndex k (HashMap k)
-instance TraversableWithIndex k (HashMap k) where
-  itraverse = HashMap.traverseWithKey
-  {-# INLINE [0] itraverse #-}
 
 {-# RULES
 "itraversed -> mapHashMap"    itraversed = sets HashMap.map               :: ASetter (HashMap k a) (HashMap k b) a b;
@@ -729,290 +260,19 @@ instance TraversableWithIndex k (HashMap k) where
 "itraversed -> ifoldrHashMap" itraversed = ifoldring HashMap.foldrWithKey :: IndexedGetting k (Endo r) (HashMap k a) a;
  #-}
 
-instance FunctorWithIndex r ((->) r) where
-  imap f g x = f x (g x)
-  {-# INLINE imap #-}
-
-instance FunctorWithIndex i (Level i) where
-  imap f = go where
-    go (Two n l r) = Two n (go l) (go r)
-    go (One i a)   = One i (f i a)
-    go Zero        = Zero
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i (Level i) where
-  ifoldMap f = go where
-    go (Two _ l r) = go l `mappend` go r
-    go (One i a)   = f i a
-    go Zero        = mempty
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i (Level i) where
-  itraverse f = go where
-    go (Two n l r) = Two n <$> go l <*> go r
-    go (One i a)   = One i <$> f i a
-    go Zero        = pure Zero
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i (Magma i t b) where
-  imap f (MagmaAp x y)    = MagmaAp (imap f x) (imap f y)
-  imap _ (MagmaPure x)    = MagmaPure x
-  imap f (MagmaFmap xy x) = MagmaFmap xy (imap f x)
-  imap f (Magma i a)      = Magma i (f i a)
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i (Magma i t b) where
-  ifoldMap f (MagmaAp x y)   = ifoldMap f x `mappend` ifoldMap f y
-  ifoldMap _ MagmaPure{}     = mempty
-  ifoldMap f (MagmaFmap _ x) = ifoldMap f x
-  ifoldMap f (Magma i a)     = f i a
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i (Magma i t b) where
-  itraverse f (MagmaAp x y)    = MagmaAp <$> itraverse f x <*> itraverse f y
-  itraverse _ (MagmaPure x)    = pure (MagmaPure x)
-  itraverse f (MagmaFmap xy x) = MagmaFmap xy <$> itraverse f x
-  itraverse f (Magma i a)      = Magma i <$> f i a
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i f => FunctorWithIndex [i] (Free f) where
-  imap f (Pure a) = Pure $ f [] a
-  imap f (Free s) = Free $ imap (\i -> imap (f . (:) i)) s
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i f => FoldableWithIndex [i] (Free f) where
-  ifoldMap f (Pure a) = f [] a
-  ifoldMap f (Free s) = ifoldMap (\i -> ifoldMap (f . (:) i)) s
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i f => TraversableWithIndex [i] (Free f) where
-  itraverse f (Pure a) = Pure <$> f [] a
-  itraverse f (Free s) = Free <$> itraverse (\i -> itraverse (f . (:) i)) s
-  {-# INLINE itraverse #-}
-
-instance Ix i => FunctorWithIndex i (Array i) where
-  imap f arr = Array.listArray (Array.bounds arr) . fmap (uncurry f) $ Array.assocs arr
-  {-# INLINE imap #-}
-
-instance Ix i => FoldableWithIndex i (Array i) where
-  ifoldMap f = foldMap (uncurry f) . Array.assocs
-  {-# INLINE ifoldMap #-}
-
-instance Ix i => TraversableWithIndex i (Array i) where
-  itraverse f arr = Array.listArray (Array.bounds arr) <$> traverse (uncurry f) (Array.assocs arr)
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i f => FunctorWithIndex [i] (Cofree f) where
-  imap f (a :< as) = f [] a :< imap (\i -> imap (f . (:) i)) as
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i f => FoldableWithIndex [i] (Cofree f) where
-  ifoldMap f (a :< as) = f [] a `mappend` ifoldMap (\i -> ifoldMap (f . (:) i)) as
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i f => TraversableWithIndex [i] (Cofree f) where
-  itraverse f (a :< as) = (:<) <$> f [] a <*> itraverse (\i -> itraverse (f . (:) i)) as
-  {-# INLINE itraverse #-}
-
-instance (FunctorWithIndex i f, FunctorWithIndex j g) => FunctorWithIndex (i, j) (Compose f g) where
-  imap f (Compose fg) = Compose $ imap (\k -> imap (f . (,) k)) fg
-  {-# INLINE imap #-}
-
-instance (FoldableWithIndex i f, FoldableWithIndex j g) => FoldableWithIndex (i, j) (Compose f g) where
-  ifoldMap f (Compose fg) = ifoldMap (\k -> ifoldMap (f . (,) k)) fg
-  {-# INLINE ifoldMap #-}
-
-instance (TraversableWithIndex i f, TraversableWithIndex j g) => TraversableWithIndex (i, j) (Compose f g) where
-  itraverse f (Compose fg) = Compose <$> itraverse (\k -> itraverse (f . (,) k)) fg
-  {-# INLINE itraverse #-}
-
-instance (FunctorWithIndex i f, FunctorWithIndex j g) => FunctorWithIndex (Either i j) (Sum f g) where
-  imap q (InL fa) = InL (imap (q . Left)  fa)
-  imap q (InR ga) = InR (imap (q . Right) ga)
-  {-# INLINE imap #-}
-
-instance (FoldableWithIndex i f, FoldableWithIndex j g) => FoldableWithIndex (Either i j) (Sum f g) where
-  ifoldMap q (InL fa) = ifoldMap (q . Left)  fa
-  ifoldMap q (InR ga) = ifoldMap (q . Right) ga
-  {-# INLINE ifoldMap #-}
-
-instance (TraversableWithIndex i f, TraversableWithIndex j g) => TraversableWithIndex (Either i j) (Sum f g) where
-  itraverse q (InL fa) = InL <$> itraverse (q . Left)  fa
-  itraverse q (InR ga) = InR <$> itraverse (q . Right) ga
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i m => FunctorWithIndex i (IdentityT m) where
-  imap f (IdentityT m) = IdentityT $ imap f m
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i m => FoldableWithIndex i (IdentityT m) where
-  ifoldMap f (IdentityT m) = ifoldMap f m
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i m => TraversableWithIndex i (IdentityT m) where
-  itraverse f (IdentityT m) = IdentityT <$> itraverse f m
-  {-# INLINE itraverse #-}
-
-instance (FunctorWithIndex i f, FunctorWithIndex j g) => FunctorWithIndex (Either i j) (Product f g) where
-  imap f (Pair a b) = Pair (imap (f . Left) a) (imap (f . Right) b)
-  {-# INLINE imap #-}
-
-instance (FoldableWithIndex i f, FoldableWithIndex j g) => FoldableWithIndex (Either i j) (Product f g) where
-  ifoldMap f (Pair a b) = ifoldMap (f . Left) a `mappend` ifoldMap (f . Right) b
-  {-# INLINE ifoldMap #-}
-
-instance (TraversableWithIndex i f, TraversableWithIndex j g) => TraversableWithIndex (Either i j) (Product f g) where
-  itraverse f (Pair a b) = Pair <$> itraverse (f . Left) a <*> itraverse (f . Right) b
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i m => FunctorWithIndex (e, i) (ReaderT e m) where
-  imap f (ReaderT m) = ReaderT $ \k -> imap (f . (,) k) (m k)
-  {-# INLINE imap #-}
-
-instance FunctorWithIndex i w => FunctorWithIndex (s, i) (TracedT s w) where
-  imap f (TracedT w) = TracedT $ imap (\k' g k -> f (k, k') (g k)) w
-  {-# INLINE imap #-}
-
-instance FunctorWithIndex [Int] Tree where
-  imap f (Node a as) = Node (f [] a) $ imap (\i -> imap (f . (:) i)) as
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex [Int] Tree where
-  ifoldMap f (Node a as) = f [] a `mappend` ifoldMap (\i -> ifoldMap (f . (:) i)) as
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex [Int] Tree where
-  itraverse f (Node a as) = Node <$> f [] a <*> itraverse (\i -> itraverse (f . (:) i)) as
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex Void Proxy where
-  imap _ Proxy = Proxy
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex Void Proxy where
-  ifoldMap _ _ = mempty
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex Void Proxy where
-  itraverse _ _ = pure Proxy
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex () (Tagged a) where
-  imap f (Tagged a) = Tagged (f () a)
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex () (Tagged a) where
-  ifoldMap f (Tagged a) = f () a
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex () (Tagged a) where
-  itraverse f (Tagged a) = Tagged <$> f () a
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex Void V1 where
-  imap _ v = v `seq` undefined
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex Void V1 where
-  ifoldMap _ v = v `seq` undefined
-
-instance TraversableWithIndex Void V1 where
-  itraverse _ v = v `seq` undefined
-
-instance FunctorWithIndex Void U1 where
-  imap _ U1 = U1
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex Void U1 where
-  ifoldMap _ _ = mempty
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex Void U1 where
-  itraverse _ U1 = pure U1
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex () Par1 where
-  imap f = fmap (f ())
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex () Par1 where
-  ifoldMap f (Par1 a) = f () a
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex () Par1 where
-  itraverse f (Par1 a) = Par1 <$> f () a
-  {-# INLINE itraverse #-}
-
-instance (FunctorWithIndex i f, FunctorWithIndex j g) => FunctorWithIndex (i, j) (f :.: g) where
-  imap q (Comp1 fga) = Comp1 (imap (\k -> imap (q . (,) k)) fga)
-  {-# INLINE imap #-}
-
-instance (FoldableWithIndex i f, FoldableWithIndex j g) => FoldableWithIndex (i, j) (f :.: g) where
-  ifoldMap q (Comp1 fga) = ifoldMap (\k -> ifoldMap (q . (,) k)) fga
-  {-# INLINE ifoldMap #-}
-
-instance (TraversableWithIndex i f, TraversableWithIndex j g) => TraversableWithIndex (i, j) (f :.: g) where
-  itraverse q (Comp1 fga) = Comp1 <$> itraverse (\k -> itraverse (q . (,) k)) fga
-  {-# INLINE itraverse #-}
-
-instance (FunctorWithIndex i f, FunctorWithIndex j g) => FunctorWithIndex (Either i j) (f :*: g) where
-  imap q (fa :*: ga) = imap (q . Left) fa :*: imap (q . Right) ga
-  {-# INLINE imap #-}
-
-instance (FoldableWithIndex i f, FoldableWithIndex j g) => FoldableWithIndex (Either i j) (f :*: g) where
-  ifoldMap q (fa :*: ga) = ifoldMap (q . Left) fa `mappend` ifoldMap (q . Right) ga
-  {-# INLINE ifoldMap #-}
-
-instance (TraversableWithIndex i f, TraversableWithIndex j g) => TraversableWithIndex (Either i j) (f :*: g) where
-  itraverse q (fa :*: ga) = (:*:) <$> itraverse (q . Left) fa <*> itraverse (q . Right) ga
-  {-# INLINE itraverse #-}
-
-instance (FunctorWithIndex i f, FunctorWithIndex j g) => FunctorWithIndex (Either i j) (f :+: g) where
-  imap q (L1 fa) = L1 (imap (q . Left) fa)
-  imap q (R1 ga) = R1 (imap (q . Right) ga)
-  {-# INLINE imap #-}
-
-instance (FoldableWithIndex i f, FoldableWithIndex j g) => FoldableWithIndex (Either i j) (f :+: g) where
-  ifoldMap q (L1 fa) = ifoldMap (q . Left) fa
-  ifoldMap q (R1 ga) = ifoldMap (q . Right) ga
-  {-# INLINE ifoldMap #-}
-
-instance (TraversableWithIndex i f, TraversableWithIndex j g) => TraversableWithIndex (Either i j) (f :+: g) where
-  itraverse q (L1 fa) = L1 <$> itraverse (q . Left) fa
-  itraverse q (R1 ga) = R1 <$> itraverse (q . Right) ga
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex i f => FunctorWithIndex i (Rec1 f) where
-  imap q (Rec1 f) = Rec1 (imap q f)
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex i f => FoldableWithIndex i (Rec1 f) where
-  ifoldMap q (Rec1 f) = ifoldMap q f
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex i f => TraversableWithIndex i (Rec1 f) where
-  itraverse q (Rec1 f) = Rec1 <$> itraverse q f
-  {-# INLINE itraverse #-}
-
-instance FunctorWithIndex Void (K1 i c) where
-  imap _ (K1 c) = K1 c
-  {-# INLINE imap #-}
-
-instance FoldableWithIndex Void (K1 i c) where
-  ifoldMap _ _ = mempty
-  {-# INLINE ifoldMap #-}
-
-instance TraversableWithIndex Void (K1 i c) where
-  itraverse _ (K1 a) = pure (K1 a)
-  {-# INLINE itraverse #-}
-
--------------------------------------------------------------------------------
--- Misc.
--------------------------------------------------------------------------------
-
-skip :: a -> ()
-skip _ = ()
-{-# INLINE skip #-}
+{-# RULES
+"itraversed -> mapSeq"    itraversed = sets fmap                    :: ASetter (Seq a) (Seq b) a b;
+"itraversed -> imapSeq"   itraversed = isets Seq.mapWithIndex       :: AnIndexedSetter Int (Seq a) (Seq b) a b;
+"itraversed -> foldrSeq"  itraversed = foldring foldr               :: Getting (Endo r) (Seq a) a;
+"itraversed -> ifoldrSeq" itraversed = ifoldring Seq.foldrWithIndex :: IndexedGetting Int (Endo r) (Seq a) a;
+ #-}
+
+{-# RULES
+"itraversed -> mapVector"    itraversed = sets Vector.map         :: ASetter (Vector a) (Vector b) a b;
+"itraversed -> imapVector"   itraversed = isets Vector.imap       :: AnIndexedSetter Int (Vector a) (Vector b) a b;
+"itraversed -> foldrVector"  itraversed = foldring Vector.foldr   :: Getting (Endo r) (Vector a) a;
+"itraversed -> ifoldrVector" itraversed = ifoldring Vector.ifoldr :: IndexedGetting Int (Endo r) (Vector a) a;
+ #-}
 
 -------------------------------------------------------------------------------
 -- Indexed Folds with Reified Monoid

--- a/src/Control/Lens/Internal/Level.hs
+++ b/src/Control/Lens/Internal/Level.hs
@@ -30,6 +30,9 @@ import Prelude ()
 
 import Control.Lens.Internal.Prelude
 import Data.Functor.Apply
+import Data.Functor.WithIndex
+import Data.Foldable.WithIndex
+import Data.Traversable.WithIndex
 
 ------------------------------------------------------------------------------
 -- Levels
@@ -85,6 +88,27 @@ instance Traversable (Level i) where
     go (One i a) = One i <$> f a
     go Zero = pure Zero
   {-# INLINE traverse #-}
+
+instance FunctorWithIndex i (Level i) where
+  imap f = go where
+    go (Two n l r) = Two n (go l) (go r)
+    go (One i a)   = One i (f i a)
+    go Zero        = Zero
+  {-# INLINE imap #-}
+
+instance FoldableWithIndex i (Level i) where
+  ifoldMap f = go where
+    go (Two _ l r) = go l `mappend` go r
+    go (One i a)   = f i a
+    go Zero        = mempty
+  {-# INLINE ifoldMap #-}
+
+instance TraversableWithIndex i (Level i) where
+  itraverse f = go where
+    go (Two n l r) = Two n <$> go l <*> go r
+    go (One i a)   = One i <$> f i a
+    go Zero        = pure Zero
+  {-# INLINE itraverse #-}
 
 ------------------------------------------------------------------------------
 -- Generating Levels

--- a/src/Control/Lens/Internal/Prelude.hs
+++ b/src/Control/Lens/Internal/Prelude.hs
@@ -109,6 +109,10 @@ import Data.Proxy (Proxy (..))
 import Data.Tagged (Tagged (..))
 import Data.Void (Void, absurd)
 
+-- TraversableWithIndex instances for tagged, vector and unordered-containers
+-- We import this here, so the instances propagate through all (most) of @lens@.
+import Data.Functor.WithIndex.Instances ()
+
 -- $setup
 -- >>> import Control.Lens
 -- >>> import Control.Monad.State


### PR DESCRIPTION
TODO:
- [x] package name
- [x] Bump `free` version (once it has instances)

### benchmark: traversals

```
Benchmark                       traversals-4.19.2  traversals-master            traversals-after          
bytestring/imap/bytes                     5.41e-5            5.53e-5    +2.17%           5.44e-5    +0.56%
bytestring/map/each                       4.70e-5            3.28e-5   -30.28%           3.32e-5   -29.51%
bytestring/map/native                     5.02e-4            4.76e-4    -5.11%           4.79e-4    -4.47%
hash map/imap/imap                        8.04e-4            7.29e-4    -9.33%           8.08e-4    +0.55%
hash map/imap/native                      3.58e-4            3.76e-4    +4.98%           3.58e-4    +0.02%
hash map/map/each                         7.08e-4            7.03e-4    -0.75%           7.32e-4    +3.35%
hash map/map/native                       3.47e-4            3.55e-4    +2.31%           3.59e-4    +3.59%
list/imap/imap                            1.41e-4            1.24e-4   -11.98%           9.83e-5   -30.28%
list/map/each                             1.07e-4            9.70e-5    -9.48%           9.18e-5   -14.34%
list/map/native                           1.08e-4            9.27e-5   -14.40%           9.27e-5   -14.42%
map/imap/each                             5.34e-4            3.94e-4   -26.27%           5.31e-4    -0.49%
map/imap/native                           5.38e-4            5.28e-4    -1.77%           5.28e-4    -1.74%
map/map/each                              4.00e-4            3.87e-4    -3.16%           3.98e-4    -0.44%
map/map/itraversed                        3.97e-4            3.92e-4    -1.32%           4.01e-4    +0.88%
map/map/native                            4.01e-4            3.91e-4    -2.55%           3.99e-4    -0.53%
sequence/imap/imap                        2.35e-4            2.33e-4    -0.50%           2.18e-4    -7.19%
sequence/imap/native                      2.32e-4            2.30e-4    -0.91%           2.15e-4    -7.46%
sequence/map/each                         2.07e-4            2.04e-4    -1.29%           2.03e-4    -1.61%
sequence/map/native                       2.06e-4            2.05e-4    -0.84%           2.02e-4    -2.02%
unboxed-vector/imap/itraversed            7.17e-5            7.21e-5    +0.47%           7.10e-5    -1.02%
unboxed-vector/imap/native                7.98e-5            7.79e-5    -2.37%           7.85e-5    -1.69%
unboxed-vector/map/itraversed             7.22e-5            6.94e-5    -3.81%           7.09e-5    -1.77%
unboxed-vector/map/native                 7.22e-5            7.13e-5    -1.27%           7.10e-5    -1.70%
vector/imap/imap                          9.43e-5            9.39e-5    -0.43%           1.01e-4    +6.78%
vector/imap/itraversed                    9.66e-5            5.03e-4  +421.16%           3.68e-4  +280.86%
vector/imap/native                        9.53e-5            9.37e-5    -1.75%           9.90e-5    +3.80%
vector/map/itraversed                     8.75e-5            1.60e-4   +83.17%           1.70e-4   +94.31%
vector/map/native                         8.23e-5            8.46e-5    +2.81%           9.99e-5   +21.39%
zzz-geom-mean                             1.79e-4            1.85e-4    +3.46%           1.86e-4    +3.77%
```

Why the jump in between? Not sure.

```
map/imap/each                             5.34e-4            3.94e-4   -26.27%           5.31e-4    -0.49%
```

Vector seems regressed, have to check if this is RULES not firing.

```
vector/imap/imap                          9.43e-5            9.39e-5    -0.43%           1.01e-4    +6.78%
vector/imap/itraversed                    9.66e-5            5.03e-4  +421.16%           3.68e-4  +280.86%
vector/imap/native                        9.53e-5            9.37e-5    -1.75%           9.90e-5    +3.80%
vector/map/itraversed                     8.75e-5            1.60e-4   +83.17%           1.70e-4   +94.31%
vector/map/native                         8.23e-5            8.46e-5    +2.81%           9.99e-5   +21.39%
```

### benchmark: folds

```
Benchmark                         folds-4.19.2  folds-master            folds-after          
bytestring/itoList/bytes               7.68e-5       7.63e-5    -0.64%      7.70e-5    +0.17%
bytestring/itoList/native              9.48e-5       9.41e-5    -0.73%      9.33e-5    -1.59%
bytestring/toList/bytes                6.07e-5       6.18e-5    +1.70%      6.19e-5    +1.99%
bytestring/toList/each                 6.09e-5       6.15e-5    +1.10%      6.16e-5    +1.26%
bytestring/toList/native               4.28e-5       4.26e-5    -0.46%      4.26e-5    -0.54%
hash map/itoList/itoList               1.96e-4       2.06e-4    +5.12%      1.14e-4   -41.75%
hash map/itoList/itraversed            2.16e-4       2.04e-4    -5.61%      2.01e-4    -6.93%
hash map/itoList/native                1.16e-4       1.14e-4    -1.95%      1.22e-4    +4.53%
hash map/sum/each                      6.49e-4       5.50e-4   -15.30%      5.95e-4    -8.41%
hash map/sum/native                    5.49e-4       5.35e-4    -2.52%      5.32e-4    -3.04%
hash map/toList/each                   2.61e-4       1.81e-4   -30.65%      1.93e-4   -26.11%
hash map/toList/native                 1.10e-4       1.03e-4    -6.75%      1.00e-4    -9.11%
list/itoList/itraversed                7.36e-5       1.28e-4   +73.83%      3.11e-4  +321.76%
list/itoList/native                    7.36e-5       7.27e-5    -1.21%      7.31e-5    -0.57%
list/toList/each                       5.70e-5       5.64e-5    -0.98%      5.62e-5    -1.33%
list/toList/native                     3.34e-5       3.34e-5    +0.00%      3.34e-5    +0.01%
map/itoList/itraversed                 2.20e-4       2.03e-4    -7.72%      2.00e-4    -9.40%
map/itoList/native                     1.85e-4       1.80e-4    -3.15%      1.76e-4    -4.99%
map/toList/each                        1.09e-4       1.10e-4    +1.13%      9.69e-5   -10.76%
map/toList/native                      9.37e-5       9.19e-5    -1.90%      8.92e-5    -4.87%
sequence/itoList/itraversed            1.28e-4       1.12e-3  +773.63%      1.01e-3  +688.80%
sequence/itoList/native                2.38e-4       2.20e-4    -7.88%      2.11e-4   -11.37%
sequence/toList/each                   6.82e-5       6.55e-5    -4.03%      6.47e-5    -5.10%
sequence/toList/native                 8.68e-5       8.80e-5    +1.34%      8.75e-5    +0.80%
unboxed-vector/itoList/native          7.54e-5       7.47e-5    -0.82%      7.49e-5    -0.66%
unboxed-vector/itoList/vTraverse       7.51e-5       7.30e-5    -2.81%      7.48e-5    -0.32%
unboxed-vector/toList/each             5.80e-5       5.87e-5    +1.21%      5.86e-5    +0.95%
unboxed-vector/toList/native           5.80e-5       5.82e-5    +0.47%      5.88e-5    +1.50%
vector/itoList/itraversed              7.01e-5       1.31e-4   +86.45%      1.12e-4   +59.09%
vector/itoList/native                  6.88e-5       6.99e-5    +1.53%      6.92e-5    +0.62%
vector/toList/each                     5.50e-5       5.47e-5    -0.48%      5.48e-5    -0.34%
vector/toList/native                   5.34e-5       5.33e-5    -0.23%      5.35e-5    +0.27%
zzz-geom-mean                          1.01e-4       1.09e-4    +7.90%      1.09e-4    +7.85%
```


The `itoList/itraversed` combo doesn't seem to work well.

```
list/itoList/itraversed                7.36e-5       1.28e-4   +73.83%      3.11e-4  +321.76%
sequence/itoList/itraversed            1.28e-4       1.12e-3  +773.63%      1.01e-3  +688.80%
vector/itoList/itraversed              7.01e-5       1.31e-4   +86.45%      1.12e-4   +59.09%
```