### PR TITLE
Bump version number to 5

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,5 @@
-4.20 [2020.xx.yy]
------------------
+5 [2020.xx.yy]
+--------------
 * Support building with GHC 9.0.
 * Remove the `Swapped` type class in favor of `Swap` from the `assoc` package.
 * Remove the `Strict` type class in favor of `Strict` from the `strict` package.

--- a/lens-properties/lens-properties.cabal
+++ b/lens-properties/lens-properties.cabal
@@ -33,7 +33,7 @@ source-repository head
 library
   build-depends:
     base         >= 4.5 && < 5,
-    lens         >= 4   && < 5,
+    lens         >= 4   && < 6,
     QuickCheck   >= 2.4 && < 2.15,
     transformers >= 0.2 && < 0.6
 

--- a/lens.cabal
+++ b/lens.cabal
@@ -1,6 +1,6 @@
 name:          lens
 category:      Data, Lenses, Generics
-version:       4.20
+version:       5
 license:       BSD2
 cabal-version: 1.18
 license-file:  LICENSE


### PR DESCRIPTION
The next `lens` release will migrate to using the `{Functor,Foldable,Traversable}WithIndex` classes from the `indexed-traversable` package. As discussed in https://github.com/ekmett/lens/pull/951#issuecomment-747404770, this poses a challenge for downstream code that use instances of `{Functor,Foldable,Traversable}WithIndex` from `indexed-traversable` while also indirectly importing `lens`. This is because the code can succeed or fail to compile depending on what version of `lens` is picked in the build plan, even if there isn't a direct dependency declared against `lens`!

The best way to mitigate this possibility is to ensure that packages that depend on `lens` and define `{Functor,Foldable,Traversable}WithIndex` have appropriately tight version bounds on `lens`. At the time of writing, the most recent Hackage release is `lens-4.19.*`, so we could ensure that packages either declare `< 4.20` or `< 5`. As it turns out, many packages in the Kmettiverse already declare `< 5`, so in order to avoid making more Hackage revisions than we absolutely need to, we have decided to just bump the version number to 5. In other words, we are bumping the "Kmett-major" version number. It's probably a good time to do this regardless, as there are enough breaking changes in the next release that it makes sense marketing-wise.