### PR TITLE
Remove unneccessary #ifndef HLINTs

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,4 +1,4 @@
-- arguments: [--cpp-define=HLINT, --cpp-ansi, --cpp-include=include]
+- arguments: [--cpp-ansi, --cpp-include=include]
 
 - ignore: {name: Reduce duplication}
 - ignore: {name: Redundant lambda}

--- a/examples/.hlint.yaml
+++ b/examples/.hlint.yaml
@@ -1,4 +1,4 @@
-- arguments: [--cpp-define=HLINT, --cpp-ansi]
+- arguments: [--cpp-ansi]
 
 - fixity: "infixr 9 ..."
 - fixity: "infixl 1 &~"

--- a/experimental/Control/Lens/Internal/Jacket.hs
+++ b/experimental/Control/Lens/Internal/Jacket.hs
@@ -208,13 +208,11 @@ ijacket l = iso (tailored `rmap` l (Indexed $ \i a -> Tailor 1 $ \o -> JacketLea
 -- Paths
 ------------------------------------------------------------------------------
 
-#ifndef HLINT
 -- | A 'Path' into a 'Jacket' that ends at a 'JacketLeaf'.
 data Path :: * -> * -> * -> * -> * -> * where
   ApL :: Int -> Int -> !(Path i t y b a) -> !(Jacket i x b a) -> Path i t (x -> y) b a
   ApR :: Int -> Int -> !(Jacket i (x -> y) b a) -> !(Path i t y b a) -> Path i t x b a
   Start :: Path i t t b a
-#endif
 
 instance (Show i, Show a) => Show (Path i t y b a) where
   showsPrec d (ApL _ _ l r) = showParen (d > 4) $

--- a/experimental/Control/Lens/Internal/Zip.hs
+++ b/experimental/Control/Lens/Internal/Zip.hs
@@ -126,10 +126,8 @@ data Top
 -- unpacked and stored in 'Coil' form. Only one value of type @_ ':>' _@ exists
 -- at any particular time for any particular 'Zipper'.
 
-#ifndef HLINT
 data Zipper l h i b a x where
   Zipper :: Ord i => !(Coil l h i t b a) -> Int -> !(Path i t b b x) -> Int -> i -> x -> Zipper l h i b a x
-#endif
 
 instance Functor (Zipper l h i b a) where
   fmap f (Zipper h n p o i a) = Zipper h n (fmap f p) o i (f a)
@@ -157,11 +155,9 @@ instance Comonad (Zipper h i b a) where
 -- of a 'Coil' is known at compile time.
 --
 -- This is part of the internal structure of a 'Zipper'. You shouldn't need to manipulate this directly.
-#ifndef HLINT
 data Coil :: (* -> * -> * -> * -> * -> *) -> * -> * -> * -> * -> * -> * where
   Coil :: Coil SomeLens Top Int b b a
   Snoc :: Ord i => !(Coil l' h j v t s) -> Int -> SomeTraversal l i s t a b -> !(Path j v t t s) -> Int -> j -> (Jacket i s b b -> s) -> Coil l (Zipper l' h j t s s) i t b a
-#endif
 
 -- | This enables changing the type of the focus to change the current level's type if we're viewing through a lens.
 class Focused t x y where

--- a/lens-properties/.hlint.yaml
+++ b/lens-properties/.hlint.yaml
@@ -1,4 +1,4 @@
-- arguments: [--cpp-define=HLINT, --cpp-ansi]
+- arguments: [--cpp-ansi]
 - ignore: { name: Use camelCase }
 - fixity: "infixr 9 ..."
 - fixity: "infixl 1 &~"

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -249,10 +249,8 @@ computeIsoType t' fields =
          b = toTupleT (map return                    fields)
          a = toTupleT (map return (substTypeVars sub fields))
 
-#ifndef HLINT
          ty | Map.null sub = appsT (conT iso'TypeName) [t,b]
             | otherwise    = appsT (conT isoTypeName) [s,t,a,b]
-#endif
 
      quantifyType [] <$> ty
 
@@ -415,9 +413,7 @@ makeClassyPrismClass ::
   DecQ
 makeClassyPrismClass t className methodName cons =
   do r <- newName "r"
-#ifndef HLINT
      let methodType = appsT (conT prism'TypeName) [varT r,return t]
-#endif
      methodss <- traverse (mkMethod r) cons'
      classD (cxt[]) className (D.plainTV r : vs) (fds r)
        ( sigD methodName methodType

--- a/src/Data/Data/Lens.hs
+++ b/src/Data/Data/Lens.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE Rank2Types #-}
-#ifndef HLINT
 {-# LANGUAGE UnboxedTuples #-}
-#endif
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -325,13 +323,11 @@ fixEq f = go where
        where x' = f x
 {-# INLINE fixEq #-}
 
-#ifndef HLINT
 -- | inlineable 'unsafePerformIO'
 inlinePerformIO :: IO a -> a
 inlinePerformIO (IO m) = case m realWorld# of
   (# _, r #) -> r
 {-# INLINE inlinePerformIO #-}
-#endif
 
 -------------------------------------------------------------------------------
 -- Cache


### PR DESCRIPTION
Those were probably needed when added 8 years ago at 873e13904a2c4d48022467d56150405b59cf710d,
but testing now, they no longer seem necessary,
either hlint has evolved or the .hlint.yaml has?