### PR TITLE
Eager seq ix

### DIFF
--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -365,30 +365,30 @@ instance (IArray UArray e, Ix i) => Ixed (UArray i e) where
 
 type instance IxValue (Vector.Vector a) = a
 instance Ixed (Vector.Vector a) where
-  ix i f v
-    | 0 <= i && i < Vector.length v = f (v Vector.! i) <&> \a -> v Vector.// [(i, a)]
-    | otherwise                     = pure v
+  ix i f v = case v Vector.!? i of
+    Just x -> f x <&> \x' -> v Vector.// [(i, x')]
+    Nothing -> pure v
   {-# INLINE ix #-}
 
 type instance IxValue (Prim.Vector a) = a
 instance Prim a => Ixed (Prim.Vector a) where
-  ix i f v
-    | 0 <= i && i < Prim.length v = f (v Prim.! i) <&> \a -> v Prim.// [(i, a)]
-    | otherwise                   = pure v
+  ix i f v = case v Prim.!? i of
+    Just x -> f x <&> \x' -> v Prim.// [(i, x')]
+    Nothing -> pure v
   {-# INLINE ix #-}
 
 type instance IxValue (Storable.Vector a) = a
 instance Storable a => Ixed (Storable.Vector a) where
-  ix i f v
-    | 0 <= i && i < Storable.length v = f (v Storable.! i) <&> \a -> v Storable.// [(i, a)]
-    | otherwise                       = pure v
+  ix i f v = case v Storable.!? i of
+    Just x -> f x <&> \x' -> v Storable.// [(i, x')]
+    Nothing -> pure v
   {-# INLINE ix #-}
 
 type instance IxValue (Unboxed.Vector a) = a
 instance Unbox a => Ixed (Unboxed.Vector a) where
-  ix i f v
-    | 0 <= i && i < Unboxed.length v = f (v Unboxed.! i) <&> \a -> v Unboxed.// [(i, a)]
-    | otherwise                      = pure v
+  ix i f v = case v Unboxed.!? i of
+    Just x -> f x <&> \x' -> v Unboxed.// [(i, x')]
+    Nothing -> pure v
   {-# INLINE ix #-}
 
 type instance IxValue StrictT.Text = Char

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -286,9 +286,15 @@ instance Ixed (Tree a) where
 
 type instance IxValue (Seq a) = a
 instance Ixed (Seq a) where
+#if MIN_VERSION_containers(0,5,8)
+  ix i f m = case Seq.lookup i m of
+    Just x -> f x <&> \x' -> Seq.update i x' m
+    Nothing -> pure m
+#else
   ix i f m
     | 0 <= i && i < Seq.length m = f (Seq.index m i) <&> \a -> Seq.update i a m
     | otherwise                  = pure m
+#endif
   {-# INLINE ix #-}
 
 type instance IxValue (IntMap a) = a


### PR DESCRIPTION
* Make `ix` look up eagerly for `Seq`.
* Make `ix` use `!?` for vectors, which [should eventually](https://github.com/haskell/vector/pull/347) make those lookups eager too.