### PR TITLE
Close over kind variables when computing fixed type variables

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.11.20201230
+# version: 0.11.20210222
 #
-# REGENDATA ("0.11.20201230",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.11.20210222",["--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -43,7 +43,7 @@ jobs:
           nickname: github-actions
           server: irc.freenode.org
   linux:
-    name: Haskell-CI Linux - GHC ${{ matrix.ghc }}
+    name: Haskell-CI - Linux - GHC ${{ matrix.ghc }}
     runs-on: ubuntu-18.04
     container:
       image: buildpack-deps:bionic
@@ -51,9 +51,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: 8.10.1
+          - ghc: 9.0.1
             allow-failure: false
-          - ghc: 8.8.3
+          - ghc: 8.10.4
+            allow-failure: false
+          - ghc: 8.8.4
             allow-failure: false
           - ghc: 8.6.5
             allow-failure: false
@@ -75,7 +77,7 @@ jobs:
           apt-get install -y --no-install-recommends gnupg ca-certificates dirmngr curl git software-properties-common
           apt-add-repository -y 'ppa:hvr/ghc'
           apt-get update
-          apt-get install -y ghc-$GHC_VERSION cabal-install-3.2 freeglut3-dev
+          apt-get install -y ghc-$GHC_VERSION cabal-install-3.4 freeglut3-dev
         env:
           GHC_VERSION: ${{ matrix.ghc }}
       - name: Set PATH and environment variables
@@ -88,12 +90,13 @@ jobs:
           echo "HC=$HC" >> $GITHUB_ENV
           echo "HCPKG=/opt/ghc/$GHC_VERSION/bin/ghc-pkg" >> $GITHUB_ENV
           echo "HADDOCK=/opt/ghc/$GHC_VERSION/bin/haddock" >> $GITHUB_ENV
-          echo "CABAL=/opt/cabal/3.2/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
+          echo "CABAL=/opt/cabal/3.4/bin/cabal -vnormal+nowrap" >> $GITHUB_ENV
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> $GITHUB_ENV
           echo "ARG_TESTS=--enable-tests" >> $GITHUB_ENV
           echo "ARG_BENCH=--enable-benchmarks" >> $GITHUB_ENV
-          echo "ARG_COMPILER=--ghc --with-compiler=/opt/ghc/$GHC_VERSION/bin/ghc" >> $GITHUB_ENV
+          echo "HEADHACKAGE=false" >> $GITHUB_ENV
+          echo "ARG_COMPILER=--ghc --with-compiler=$HC" >> $GITHUB_ENV
           echo "GHCJSARITH=0" >> $GITHUB_ENV
         env:
           GHC_VERSION: ${{ matrix.ghc }}
@@ -131,7 +134,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.ghc }}-tools-c71e24d1
+          key: ${{ runner.os }}-${{ matrix.ghc }}-tools-44f6870a
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -145,26 +148,32 @@ jobs:
       - name: install cabal-docspec
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20201230.1/cabal-docspec-0.0.0.20201230.1.xz > cabal-docspec.xz
-          echo '18caf4f361fadd978782f08e78f42d21d4f177567419055ffccae19b8214852d  cabal-docspec.xz' | sha256sum -c -
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20210111/cabal-docspec-0.0.0.20210111.xz > cabal-docspec.xz
+          echo '0829bd034fba901cbcfe491d98ed8b28fd54f9cb5c91fa8e1ac62dc4413c9562  cabal-docspec.xz' | sha256sum -c -
           xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
           rm -f cabal-docspec.xz
           chmod a+x $HOME/.cabal/bin/cabal-docspec
           cabal-docspec --version
       - name: install hlint
         run: |
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint ==3.2.*' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then if [ ! -e $HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint ]; then echo "Downloading HLint version $HLINTVER"; mkdir -p $HOME/.haskell-ci-tools; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\n' --silent --location --output $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz "https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz"; tar -xzv -f $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz -C $HOME/.haskell-ci-tools; fi ; fi
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then mkdir -p $CABAL_DIR/bin && ln -sf "$HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint" $CABAL_DIR/bin/hlint ; fi
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then hlint --version ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then HLINTVER=$(cd /tmp && (${CABAL} v2-install -v $ARG_COMPILER --dry-run hlint  --constraint='hlint >=3.2 && <3.3' |  perl -ne 'if (/\bhlint-(\d+(\.\d+)*)\b/) { print "$1"; last; }')); echo "HLint version $HLINTVER" ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then if [ ! -e $HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint ]; then echo "Downloading HLint version $HLINTVER"; mkdir -p $HOME/.haskell-ci-tools; curl --write-out 'Status Code: %{http_code} Redirects: %{num_redirects} Total time: %{time_total} Total Dsize: %{size_download}\n' --silent --location --output $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz "https://github.com/ndmitchell/hlint/releases/download/v$HLINTVER/hlint-$HLINTVER-x86_64-linux.tar.gz"; tar -xzv -f $HOME/.haskell-ci-tools/hlint-$HLINTVER.tar.gz -C $HOME/.haskell-ci-tools; fi ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then mkdir -p $CABAL_DIR/bin && ln -sf "$HOME/.haskell-ci-tools/hlint-$HLINTVER/hlint" $CABAL_DIR/bin/hlint ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then hlint --version ; fi
       - name: checkout
         uses: actions/checkout@v2
         with:
           path: source
+      - name: initial cabal.project for sdist
+        run: |
+          touch cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/./examples" >> cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/./lens-properties" >> cabal.project
+          cat cabal.project
       - name: sdist
         run: |
           mkdir -p sdist
-          cd source || false
           $CABAL sdist all --output-dir $GITHUB_WORKSPACE/sdist
       - name: unpack
         run: |
@@ -190,6 +199,8 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens-properties" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: cassava:base
+          allow-newer: vector-binary-instances:base
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(lens|lens-examples|lens-properties)$/; }' >> cabal.project.local
           cat cabal.project
@@ -220,9 +231,9 @@ jobs:
           cabal-docspec $ARG_COMPILER
       - name: hlint
         run: |
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then (cd ${PKGDIR_lens} && hlint src) ; fi
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then (cd ${PKGDIR_lens_examples} && hlint .) ; fi
-          if [ $((HCNUMVER >= 81000)) -ne 0 ] ; then (cd ${PKGDIR_lens_properties} && hlint src) ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then (cd ${PKGDIR_lens} && hlint src) ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then (cd ${PKGDIR_lens_examples} && hlint .) ; fi
+          if [ $((HCNUMVER >= 81000 && HCNUMVER < 90000)) -ne 0 ] ; then (cd ${PKGDIR_lens_properties} && hlint src) ; fi
       - name: cabal check
         run: |
           cd ${PKGDIR_lens} || false

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,8 @@
+next [????.??.??]
+-----------------
+* Fix a bug in which `makeLenses` could produce ill kinded optics for
+  poly-kinded datatypes in certain situations.
+
 5 [2021.02.17]
 --------------
 * Support building with GHC 9.0.

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -5,3 +5,7 @@ apt:                    freeglut3-dev
 irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True
 docspec:                True
+
+-- Temporary hacks needed to make the GHC 9.0.* job work
+hlint-job:              8.10.4
+copy-fields:            some

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,7 @@
 packages: .
           ./examples
           ./lens-properties
+
+allow-newer:
+  cassava:base,
+  vector-binary-instances:base

--- a/examples/lens-examples.cabal
+++ b/examples/lens-examples.cabal
@@ -22,8 +22,9 @@ tested-with:   GHC == 7.8.4
              , GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.5
-             , GHC == 8.8.3
-             , GHC == 8.10.1
+             , GHC == 8.8.4
+             , GHC == 8.10.4
+             , GHC == 9.0.1
 
 source-repository head
   type: git

--- a/lens-properties/lens-properties.cabal
+++ b/lens-properties/lens-properties.cabal
@@ -19,8 +19,9 @@ tested-with:   GHC == 7.8.4
              , GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.5
-             , GHC == 8.8.3
-             , GHC == 8.10.1
+             , GHC == 8.8.4
+             , GHC == 8.10.4
+             , GHC == 9.0.1
 
 extra-source-files:
   .hlint.yaml

--- a/lens.cabal
+++ b/lens.cabal
@@ -18,8 +18,9 @@ tested-with:   GHC == 7.8.4
              , GHC == 8.2.2
              , GHC == 8.4.4
              , GHC == 8.6.5
-             , GHC == 8.8.3
-             , GHC == 8.10.1
+             , GHC == 8.8.4
+             , GHC == 8.10.4
+             , GHC == 9.0.1
 synopsis:      Lenses, Folds and Traversals
 description:
   This package comes \"Batteries Included\" with many useful lenses for the types

--- a/lens.cabal
+++ b/lens.cabal
@@ -347,6 +347,7 @@ test-suite templates
   other-modules:
     T799
     T917
+    T972
   ghc-options: -Wall -threaded
   hs-source-dirs: tests
   default-language: Haskell2010

--- a/tests/T917.hs
+++ b/tests/T917.hs
@@ -18,7 +18,7 @@ import Data.Proxy
 import Data.Kind
 #endif
 
--- Like Data.Functor.Const, but redfined to ensure that it is poly-kinded
+-- Like Data.Functor.Const, but redefined to ensure that it is poly-kinded
 -- across all versions of GHC, not just 8.0+
 newtype Constant a (b :: k) = Constant a
 

--- a/tests/T972.hs
+++ b/tests/T972.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+#if __GLASGOW_HASKELL__ >= 800 && __GLASGOW_HASKELL__ < 806
+{-# LANGUAGE TypeInType #-}
+#endif
+module T972 where
+
+import Control.Lens
+#if __GLASGOW_HASKELL__ >= 800
+import Data.Proxy
+#endif
+
+newtype Arc s = Arc { _unArc :: Int }
+
+data Direction = Negative | Positive
+data Dart s = Dart { _arc :: Arc s, _direction :: Direction }
+$(makeLenses ''Dart)
+
+#if __GLASGOW_HASKELL__ >= 800
+data Fancy k (a :: k) = MkFancy { _unFancy1 :: k, _unFancy2 :: Proxy a }
+$(makeLenses ''Fancy)
+#endif

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -28,6 +28,7 @@ import Control.Lens
 -- import Test.QuickCheck (quickCheck)
 import T799 ()
 import T917 ()
+import T972 ()
 
 data Bar a b c = Bar { _baz :: (a, b) }
 makeLenses ''Bar


### PR DESCRIPTION
Previously, `buildStab` would not consider kind variables when determining which type variables need to be fixed in a generated `Lens`'s type signature. This was not a problem in older versions of `lens`, which aggressively dropped kind variables, but now that `lens` attempts to include kind variables in generated type signatures, this problem has risen to the surface, resulting in the problems observed in #972.

The solution is to take the set of fixed type variables in `buildStab` and close over kind variables. For more information, refer to the comments I have left near `closeOverKinds`.

Fixes #972.