### PR TITLE
Add 'beneath'

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -65,6 +65,7 @@ module Control.Lens.Fold
   , backwards
   , repeated
   , replicated
+  , beneath
   , cycled
   , takingWhile
   , droppingWhile
@@ -278,6 +279,14 @@ replicated n0 f a = go n0 where
   go 0 = noEffect
   go n = m *> go (n - 1)
 {-# INLINE replicated #-}
+
+-- | Use a 'Fold' to work over part of a structure. This is a version of 'aside' that takes a Fold
+-- instead. The resulting 'Fold' has as many targets as the provided 'Fold'.
+--
+-- >>> [Just ('a', 10), Nothing, Just ('b', 20)] ^.. folded . beneath (_Just . _1)
+-- [(Just ('a',10),'a'),(Just ('b',20),'b')]
+beneath :: Fold s a -> Fold s (s, a);
+beneath fo f s = phantom $ foldrOf fo (\a' fa' -> f (s, a') *> fa') noEffect s
 
 -- | Transform a non-empty 'Fold' into a 'Fold1' that loops over its elements over and over.
 --

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -285,7 +285,7 @@ replicated n0 f a = go n0 where
 --
 -- >>> [Just ('a', 10), Nothing, Just ('b', 20)] ^.. folded . beneath (_Just . _1)
 -- [(Just ('a',10),'a'),(Just ('b',20),'b')]
-beneath :: Fold s a -> Fold s (s, a);
+beneath :: Fold s a -> Fold s (s, a)
 beneath fo f s = phantom $ foldrOf fo (\a' fa' -> f (s, a') *> fa') noEffect s
 
 -- | Transform a non-empty 'Fold' into a 'Fold1' that loops over its elements over and over.

--- a/src/Control/Lens/Prism.hs
+++ b/src/Control/Lens/Prism.hs
@@ -141,7 +141,7 @@ without k k' =
     Right u -> bimap Right Right (uevc u)
 {-# INLINE without #-}
 
--- | Use a 'Prism' to work over part of a structure.
+-- | Use a 'Prism' to work over part of a structure. See also 'beneath'.
 --
 aside :: APrism s t a b -> Prism (e, s) (e, t) (e, a) (e, b)
 aside k =


### PR DESCRIPTION
This PR adds a new combinator `beneath`, a Fold version of `aside`.

In our code base, we wanted this often, and `aside` wasn't enough because the nested property was usually described by an (affine) fold like `someField . _Just`. I think wanting to filter/fold all objects based on the presence of a nested property, while keeping that property around, is not an exotic thing to do. `aside` exists for the same reason.