### PR TITLE
Enable `-Wmissing-pattern-synonym-signatures`

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -306,7 +306,7 @@ library
     ghc-options: -j4
 
   ghc-options: -Wall -Wtabs -O2 -fdicts-cheap -funbox-strict-fields -fmax-simplifier-iterations=10
-               -Wno-trustworthy-safe -Wno-missing-pattern-synonym-signatures -Wno-redundant-constraints
+               -Wno-trustworthy-safe -Wmissing-pattern-synonym-signatures -Wno-redundant-constraints
 
   hs-source-dirs: src
 


### PR DESCRIPTION
Now that we require GHC 8.0 as the minimum, I no longer see any reason to use `-Wno-missing-pattern-synonym-signatures`, as we can always define pattern synonym signatures without CPP. In fact, we already do so. We might as well enable the corresponding warning to make sure this remains the case in the future.