### PR TITLE
Allow `{make,declare}Wrapped` to work with data family instances

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.13.20211030
+# version: 0.14
 #
-# REGENDATA ("0.13.20211030",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.14",["--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -20,6 +20,8 @@ jobs:
   linux:
     name: Haskell-CI - Linux - ${{ matrix.compiler }}
     runs-on: ubuntu-18.04
+    timeout-minutes:
+      60
     container:
       image: buildpack-deps:bionic
     continue-on-error: ${{ matrix.allow-failure }}
@@ -31,10 +33,10 @@ jobs:
             compilerVersion: 9.2.1
             setup-method: ghcup
             allow-failure: false
-          - compiler: ghc-9.0.1
+          - compiler: ghc-9.0.2
             compilerKind: ghc
-            compilerVersion: 9.0.1
-            setup-method: hvr-ppa
+            compilerVersion: 9.0.2
+            setup-method: ghcup
             allow-failure: false
           - compiler: ghc-8.10.7
             compilerKind: ghc
@@ -147,6 +149,10 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
+          cat >> $CABAL_CONFIG <<EOF
+          program-default-options
+            ghc-options: $GHCJOBS +RTS -M3G -RTS
+          EOF
           cat $CABAL_CONFIG
       - name: versions
         run: |
@@ -159,7 +165,7 @@ jobs:
       - name: cache (tools)
         uses: actions/cache@v2
         with:
-          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-98d26823
+          key: ${{ runner.os }}-${{ matrix.compiler }}-tools-6cd610a0
           path: ~/.haskell-ci-tools
       - name: install cabal-plan
         run: |
@@ -173,8 +179,8 @@ jobs:
       - name: install cabal-docspec
         run: |
           mkdir -p $HOME/.cabal/bin
-          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20210111/cabal-docspec-0.0.0.20210111.xz > cabal-docspec.xz
-          echo '0829bd034fba901cbcfe491d98ed8b28fd54f9cb5c91fa8e1ac62dc4413c9562  cabal-docspec.xz' | sha256sum -c -
+          curl -sL https://github.com/phadej/cabal-extras/releases/download/cabal-docspec-0.0.0.20211114/cabal-docspec-0.0.0.20211114.xz > cabal-docspec.xz
+          echo 'e224700d9e8c9ec7ec6bc3f542ba433cd9925a5d356676c62a9bd1f2c8be8f8a  cabal-docspec.xz' | sha256sum -c -
           xz -d < cabal-docspec.xz > $HOME/.cabal/bin/cabal-docspec
           rm -f cabal-docspec.xz
           chmod a+x $HOME/.cabal/bin/cabal-docspec

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -11,6 +11,9 @@
   sites to `universeOf` will not be affected by this change, although you may
   need to update your code if you define your own combinators in terms of
   `universeOf`.
+* Allow `makeWrapped` to accept the names of data constructors. This way,
+  `makeWrapped` can be used with data family instances, much like other
+  functions in `Control.Lens.TH`.
 
 5.1 [2021.11.15]
 ----------------

--- a/cabal.haskell-ci
+++ b/cabal.haskell-ci
@@ -2,7 +2,7 @@ distribution:           bionic
 no-tests-no-benchmarks: False
 unconstrained:          False
 hlint:                  True
-hlint-job:              9.0.1
+hlint-job:              9.0.2
 apt:                    freeglut3-dev
 -- irc-channels:           irc.freenode.org#haskell-lens
 irc-if-in-origin-repo:  True

--- a/examples/lens-examples.cabal
+++ b/examples/lens-examples.cabal
@@ -22,7 +22,7 @@ tested-with:   GHC == 8.0.2
              , GHC == 8.6.5
              , GHC == 8.8.4
              , GHC == 8.10.7
-             , GHC == 9.0.1
+             , GHC == 9.0.2
              , GHC == 9.2.1
 
 source-repository head

--- a/lens-properties/lens-properties.cabal
+++ b/lens-properties/lens-properties.cabal
@@ -19,7 +19,7 @@ tested-with:   GHC == 8.0.2
              , GHC == 8.6.5
              , GHC == 8.8.4
              , GHC == 8.10.7
-             , GHC == 9.0.1
+             , GHC == 9.0.2
              , GHC == 9.2.1
 
 extra-source-files:

--- a/lens.cabal
+++ b/lens.cabal
@@ -18,7 +18,7 @@ tested-with:   GHC == 8.0.2
              , GHC == 8.6.5
              , GHC == 8.8.4
              , GHC == 8.10.7
-             , GHC == 9.0.1
+             , GHC == 9.0.2
              , GHC == 9.2.1
 synopsis:      Lenses, Folds and Traversals
 description:

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -449,5 +449,23 @@ $(makeClassyPrisms ''T865)
 instance AsT866 T865 where
   _T866 = __T865 . _T866
 
+-- {make,declare}Wrapped test cases for ordinary data types
+newtype T997A a = MkT997A a
+$(makeWrapped ''T997A)
+
+$(declareWrapped [d|
+  newtype T997B b = MkT997B b
+  |])
+
+-- {make,declare}Wrapped test cases for data family instances (#997)
+data family T997FamA a
+newtype instance T997FamA a = MkT997FamA a
+$(makeWrapped 'MkT997FamA)
+
+$(declareWrapped [d|
+  data family T997FamB b
+  newtype instance T997FamB b = MkT997FamB b
+  |])
+
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
This modifies the implementations of `makeWrapped` and `declareWrapped` to use `th-abstraction`, which grants the ability to work with both ordinary data types and data family instances. An added bonus of doing this is that we can delete a fair bit of delicate, CPP-laden code that only existed to support the old implementations of `makeWrapped` and `declareWrapped`.

Fixes #997.