### PR TITLE
Version 5.1.1

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,5 @@
-next [????.??.??]
------------------
+5.1.1 [2022.05.17]
+------------------
 * Add `Data.HashSet.Lens.hashMap`, an `Iso` between a `HashSet a` and a
   `HashMap a ()`.
 * Allow building with `transformers-0.6.*` and `mtl-2.3.*`.

--- a/lens.cabal
+++ b/lens.cabal
@@ -1,6 +1,6 @@
 name:          lens
 category:      Data, Lenses, Generics
-version:       5.1
+version:       5.1.1
 license:       BSD2
 cabal-version: 1.18
 license-file:  LICENSE


### PR DESCRIPTION
This cuts a new minor release of `lens`, version 5.1.1, which includes a small number of non-breaking changes since the last Hackage release (5.1). Two of the more notable changes are fixes for #1001 and #1007.