### PR TITLE
Add `Prism`s for constructs added in `template-haskell-2.19.0.0`

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,6 @@
 5.2 [????.??.??]
 ----------------
+* Allow building with GHC 9.4.
 * The type of `universeOf` has changed:
 
   ```diff
@@ -14,6 +15,9 @@
 * Allow `makeWrapped` to accept the names of data constructors. This way,
   `makeWrapped` can be used with data family instances, much like other
   functions in `Control.Lens.TH`.
+* Define `_OpaqueP`, `_DefaultD`, `_LamCasesE`, `_PromotedInfixT`, and
+  `_PromotedUInfixT` in `Language.Haskell.TH.Lens` when building with
+  `template-haskell-2.19.0.0` (GHC 9.4) or later.
 
 5.1.1 [2022.05.17]
 ------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -196,7 +196,7 @@ library
     semigroupoids                 >= 5.0.1    && < 6,
     strict                        >= 0.4      && < 0.5,
     tagged                        >= 0.8.6    && < 1,
-    template-haskell              >= 2.11.1.0 && < 2.19,
+    template-haskell              >= 2.11.1.0 && < 2.20,
     text                          >= 1.2.3.0  && < 2.1,
     th-abstraction                >= 0.4.1    && < 0.5,
     these                         >= 1.1.1.1  && < 1.2,


### PR DESCRIPTION
This allows `lens` to build without warnings on GHC 9.4.