### PR TITLE
Support targets without signals (like WASI)

### DIFF
--- a/src/Control/Lens/Wrapped.hs
+++ b/src/Control/Lens/Wrapped.hs
@@ -1000,7 +1000,12 @@ instance Wrapped CWchar where
 
 instance Rewrapped CSigAtomic t
 instance Wrapped CSigAtomic where
-  type Unwrapped CSigAtomic = HTYPE_SIG_ATOMIC_T
+  type Unwrapped CSigAtomic =
+#if defined(HTYPE_SIG_ATOMIC_T)
+    HTYPE_SIG_ATOMIC_T
+#else
+    Int32
+#endif
   _Wrapped' = iso (\(CSigAtomic x) -> x) CSigAtomic
   {-# INLINE _Wrapped' #-}
 


### PR DESCRIPTION
The upcoming GHC WASM backend doesn't have support for posix-style asynchronous signals, cf.

 - [`CSigAtomic` definition](https://gitlab.haskell.org/ghc/ghc/-/blob/bc038c3bd45ee99db9fba23a823a906735740200/libraries/base/Foreign/C/Types.hs#L185-L193)
 - [Relevant GHC note](https://gitlab.haskell.org/ghc/ghc/-/blob/bc038c3bd45ee99db9fba23a823a906735740200/rts/include/rts/Config.h#L47-L68)
