### PR TITLE
Link to GitHub copy of lens hierarchy diagram

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -50,7 +50,7 @@ description:
   .
   <<http://i.imgur.com/ALlbPRa.png>>
   .
-  <images/Hierarchy.png (Local Copy)>
+  <https://raw.githubusercontent.com/ekmett/lens/master/images/Hierarchy.png (Local Copy)>
   .
   You can compose any two elements of the hierarchy above using @(.)@ from the @Prelude@, and you can
   use any element of the hierarchy as any type it linked to above it.


### PR DESCRIPTION
A crude but consistent workaround to the Haddock image linking woes encountered in #1022.

Fixes #1022.