### PR TITLE
Allow these-1.2, strict-0.5, assoc-1.1

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,9 +8,9 @@
 #
 # For more information, see https://github.com/haskell-CI/haskell-ci
 #
-# version: 0.15.20230227
+# version: 0.15.20230313
 #
-# REGENDATA ("0.15.20230227",["--config=cabal.haskell-ci","cabal.project"])
+# REGENDATA ("0.15.20230313",["--config=cabal.haskell-ci","cabal.project"])
 #
 name: Haskell-CI
 on:
@@ -28,11 +28,11 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.6.0.20230210
+          - compiler: ghc-9.6.1
             compilerKind: ghc
-            compilerVersion: 9.6.0.20230210
+            compilerVersion: 9.6.1
             setup-method: ghcup
-            allow-failure: true
+            allow-failure: false
           - compiler: ghc-9.4.4
             compilerKind: ghc
             compilerVersion: 9.4.4
@@ -88,9 +88,8 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
             "$HOME/.ghcup/bin/ghcup" install ghc "$HCVER" || (cat "$HOME"/.ghcup/logs/*.* && false)
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
             apt-get update
             apt-get install -y freeglut3-dev
           else
@@ -100,8 +99,7 @@ jobs:
             mkdir -p "$HOME/.ghcup/bin"
             curl -sL https://downloads.haskell.org/ghcup/0.1.18.0/x86_64-linux-ghcup-0.1.18.0 > "$HOME/.ghcup/bin/ghcup"
             chmod a+x "$HOME/.ghcup/bin/ghcup"
-            "$HOME/.ghcup/bin/ghcup" config add-release-channel https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-prereleases-0.0.7.yaml;
-            "$HOME/.ghcup/bin/ghcup" install cabal 3.9.0.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
+            "$HOME/.ghcup/bin/ghcup" install cabal 3.10.1.0 || (cat "$HOME"/.ghcup/logs/*.* && false)
           fi
         env:
           HCKIND: ${{ matrix.compilerKind }}
@@ -119,20 +117,20 @@ jobs:
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HOME/.ghcup/bin/$HCKIND-pkg-$HCVER" >> "$GITHUB_ENV"
             echo "HADDOCK=$HOME/.ghcup/bin/haddock-$HCVER" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           else
             HC=$HCDIR/bin/$HCKIND
             echo "HC=$HC" >> "$GITHUB_ENV"
             echo "HCPKG=$HCDIR/bin/$HCKIND-pkg" >> "$GITHUB_ENV"
             echo "HADDOCK=$HCDIR/bin/haddock" >> "$GITHUB_ENV"
-            echo "CABAL=$HOME/.ghcup/bin/cabal-3.9.0.0 -vnormal+nowrap" >> "$GITHUB_ENV"
+            echo "CABAL=$HOME/.ghcup/bin/cabal-3.10.1.0 -vnormal+nowrap" >> "$GITHUB_ENV"
           fi
 
           HCNUMVER=$(${HC} --numeric-version|perl -ne '/^(\d+)\.(\d+)\.(\d+)(\.(\d+))?$/; print(10000 * $1 + 100 * $2 + ($3 == 0 ? $5 != 1 : $3))')
           echo "HCNUMVER=$HCNUMVER" >> "$GITHUB_ENV"
           echo "ARG_TESTS=--enable-tests" >> "$GITHUB_ENV"
           echo "ARG_BENCH=--enable-benchmarks" >> "$GITHUB_ENV"
-          if [ $((HCNUMVER >= 90600)) -ne 0 ] ; then echo "HEADHACKAGE=true" >> "$GITHUB_ENV" ; else echo "HEADHACKAGE=false" >> "$GITHUB_ENV" ; fi
+          echo "HEADHACKAGE=false" >> "$GITHUB_ENV"
           echo "ARG_COMPILER=--$HCKIND --with-compiler=$HC" >> "$GITHUB_ENV"
           echo "GHCJSARITH=0" >> "$GITHUB_ENV"
         env:
@@ -161,18 +159,6 @@ jobs:
           repository hackage.haskell.org
             url: http://hackage.haskell.org/
           EOF
-          if $HEADHACKAGE; then
-          cat >> $CABAL_CONFIG <<EOF
-          repository head.hackage.ghc.haskell.org
-             url: https://ghc.gitlab.haskell.org/head.hackage/
-             secure: True
-             root-keys: 7541f32a4ccca4f97aea3b22f5e593ba2c0267546016b992dfadcd2fe944e55d
-                        26021a13b401500c8eb2761ca95c61f2d625bfef951b939a8124ed12ecf07329
-                        f76d08be13e9a61a377a85e2fb63f4c5435d40f8feb3e12eb05905edb8cdea89
-             key-threshold: 3
-          active-repositories: hackage.haskell.org, head.hackage.ghc.haskell.org:override
-          EOF
-          fi
           cat >> $CABAL_CONFIG <<EOF
           program-default-options
             ghc-options: $GHCJOBS +RTS -M3G -RTS
@@ -261,10 +247,9 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens-properties" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: vector-th-unbox-0.2.2:base
+          allow-newer: vector-th-unbox-0.2.2:template-haskell
           EOF
-          if $HEADHACKAGE; then
-          echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
-          fi
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: $_ installed\n" unless /^(lens|lens-examples|lens-properties)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,7 @@
 packages: .
           ./examples
           ./lens-properties
+
+-- For GHC-9.6
+allow-newer: vector-th-unbox-0.2.2:base
+allow-newer: vector-th-unbox-0.2.2:template-haskell

--- a/lens.cabal
+++ b/lens.cabal
@@ -173,7 +173,7 @@ flag j
 library
   build-depends:
     array                         >= 0.5.0.0  && < 0.6,
-    assoc                         >= 1.0.2    && < 1.1,
+    assoc                         >= 1.0.2    && < 1.2,
     base                          >= 4.9      && < 5,
     base-orphans                  >= 0.5.2    && < 1,
     bifunctors                    >= 5.5.7    && < 6,
@@ -196,12 +196,12 @@ library
     profunctors                   >= 5.5.2    && < 6,
     reflection                    >= 2.1      && < 3,
     semigroupoids                 >= 5.0.1    && < 7,
-    strict                        >= 0.4      && < 0.5,
+    strict                        >= 0.4      && < 0.6,
     tagged                        >= 0.8.6    && < 1,
     template-haskell              >= 2.11.1.0 && < 2.21,
     text                          >= 1.2.3.0  && < 2.1,
     th-abstraction                >= 0.4.1    && < 0.6,
-    these                         >= 1.1.1.1  && < 1.2,
+    these                         >= 1.1.1.1  && < 1.3,
     transformers                  >= 0.5.0.0  && < 0.7,
     transformers-compat           >= 0.5.0.4  && < 1,
     unordered-containers          >= 0.2.10   && < 0.3,


### PR DESCRIPTION
Note: there is no problem with `Bifunctor` as lens requires GHC-8.0, for which `Bifunctor` is always unique.

OTOH, `swap :: Bitraversable p =>`... has such problem, so maybe it's easiest to drop GHC-8.0 support.

Also update CI to not use head.hackage as deps are all updated