### PR TITLE
Adding checks for negative indices - Text / ByteString

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -380,6 +380,8 @@ test-suite hunit
       HUnit >= 1.2,
       lens,
       mtl,
+      text,
+      bytestring,
       test-framework       >= 0.6,
       test-framework-hunit >= 0.2
 

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -398,35 +398,43 @@ instance Unbox a => Ixed (Unboxed.Vector a) where
 
 type instance IxValue StrictT.Text = Char
 instance Ixed StrictT.Text where
-  ix e f s = case StrictT.splitAt e s of
-     (l, mr) -> case StrictT.uncons mr of
-       Nothing      -> pure s
-       Just (c, xs) -> f c <&> \d -> StrictT.concat [l, StrictT.singleton d, xs]
+  ix e f s 
+      | e < 0 = pure s
+      | otherwise = case StrictT.splitAt e s of
+            (l, mr) -> case StrictT.uncons mr of
+                Nothing      -> pure s
+                Just (c, xs) -> f c <&> \d -> StrictT.concat [l, StrictT.singleton d, xs]
   {-# INLINE ix #-}
 
 type instance IxValue LazyT.Text = Char
 instance Ixed LazyT.Text where
-  ix e f s = case LazyT.splitAt e s of
-     (l, mr) -> case LazyT.uncons mr of
-       Nothing      -> pure s
-       Just (c, xs) -> f c <&> \d -> LazyT.append l (LazyT.cons d xs)
+  ix e f s 
+        | e < 0 = pure s
+        | otherwise = case LazyT.splitAt e s of
+            (l, mr) -> case LazyT.uncons mr of
+              Nothing      -> pure s
+              Just (c, xs) -> f c <&> \d -> LazyT.append l (LazyT.cons d xs)
   {-# INLINE ix #-}
 
 type instance IxValue StrictB.ByteString = Word8
 instance Ixed StrictB.ByteString where
-  ix e f s = case StrictB.splitAt e s of
-     (l, mr) -> case StrictB.uncons mr of
-       Nothing      -> pure s
-       Just (c, xs) -> f c <&> \d -> StrictB.concat [l, StrictB.singleton d, xs]
+  ix e f s 
+        | e < 0 = pure s
+        | otherwise = case StrictB.splitAt e s of
+          (l, mr) -> case StrictB.uncons mr of
+            Nothing      -> pure s
+            Just (c, xs) -> f c <&> \d -> StrictB.concat [l, StrictB.singleton d, xs]
   {-# INLINE ix #-}
 
 type instance IxValue LazyB.ByteString = Word8
 instance Ixed LazyB.ByteString where
   -- TODO: we could be lazier, returning each chunk as it is passed
-  ix e f s = case LazyB.splitAt e s of
-     (l, mr) -> case LazyB.uncons mr of
-       Nothing      -> pure s
-       Just (c, xs) -> f c <&> \d -> LazyB.append l (LazyB.cons d xs)
+  ix e f s 
+        | e < 0 = pure s
+        | otherwise =  case LazyB.splitAt e s of
+          (l, mr) -> case LazyB.uncons mr of
+            Nothing      -> pure s
+            Just (c, xs) -> f c <&> \d -> LazyB.append l (LazyB.cons d xs)
   {-# INLINE ix #-}
 
 

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -23,6 +23,10 @@ module Main (main) where
 import Control.Lens
 import Control.Monad.State
 import Data.Char
+import qualified Data.Text as StrictT
+import qualified Data.Text.Lazy as LazyT
+import qualified Data.ByteString as StrictB
+import qualified Data.ByteString.Lazy as LazyB
 import qualified Data.List as List
 import qualified Data.Map as Map
 import Data.Map (Map)
@@ -279,6 +283,22 @@ case_write_through_list_entry =
                          , Point { _x = 4, _y = 7 }
                          , Point { _x = 8, _y = 0 } ] }
 
+case_correct_indexing_strict_text = 
+  map ((preview ?? StrictT.pack "12") . ix) [-1..2]
+    @?= [Nothing, Just '1', Just '2', Nothing]
+
+case_correct_indexing_lazy_text = 
+  map ((preview ?? LazyT.pack "12") . ix) [-1..2]
+    @?= [Nothing, Just '1', Just '2', Nothing]
+
+case_correct_indexing_strict_bytestring = 
+  map ((preview ?? StrictB.pack [1,2]) . ix) [-1..2]
+    @?= [Nothing, Just 1, Just 2, Nothing]
+
+case_correct_indexing_lazy_bytestring = 
+  map ((preview ?? LazyB.pack [1,2]) . ix) [-1..2]
+    @?= [Nothing, Just 1, Just 2, Nothing]
+
 main :: IO ()
 main = defaultMain
   [ testGroup "Main"
@@ -317,5 +337,9 @@ main = defaultMain
     , testCase "read list entry" case_read_list_entry
     , testCase "write list entry" case_write_list_entry
     , testCase "write through list entry" case_write_through_list_entry
+    , testCase "correct indexing strict text" case_correct_indexing_strict_text
+    , testCase "correct indexing lazy text" case_correct_indexing_lazy_text
+    , testCase "correct indexing strict bytestring" case_correct_indexing_strict_bytestring
+    , testCase "correct indexing lazy bytestring" case_correct_indexing_lazy_bytestring
     ]
   ]

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -283,20 +283,20 @@ case_write_through_list_entry =
                          , Point { _x = 4, _y = 7 }
                          , Point { _x = 8, _y = 0 } ] }
 
-case_correct_indexing_strict_text = 
-  map ((preview ?? StrictT.pack "12") . ix) [-1..2]
+case_correct_indexing_strict_text =
+  map (\i -> StrictT.pack "12" ^? ix i) [-1..2]
     @?= [Nothing, Just '1', Just '2', Nothing]
 
-case_correct_indexing_lazy_text = 
-  map ((preview ?? LazyT.pack "12") . ix) [-1..2]
+case_correct_indexing_lazy_text =
+  map (\i -> LazyT.pack "12" ^? ix i) [-1..2]
     @?= [Nothing, Just '1', Just '2', Nothing]
 
-case_correct_indexing_strict_bytestring = 
-  map ((preview ?? StrictB.pack [1,2]) . ix) [-1..2]
+case_correct_indexing_strict_bytestring =
+  map (\i -> StrictB.pack [1,2] ^? ix i) [-1..2]
     @?= [Nothing, Just 1, Just 2, Nothing]
 
-case_correct_indexing_lazy_bytestring = 
-  map ((preview ?? LazyB.pack [1,2]) . ix) [-1..2]
+case_correct_indexing_lazy_bytestring =
+  map (\i -> LazyB.pack [1,2] ^? ix i) [-1..2]
     @?= [Nothing, Just 1, Just 2, Nothing]
 
 main :: IO ()


### PR DESCRIPTION
Addressing the bug from https://github.com/ekmett/lens/issues/1029. Adding simple checks to make sure index into Text and ByteString must be non-negative. My first PR here so very possibly doing some things wrong and very grateful for guidance.