### PR TITLE
`containsTypeFamilies`: Don't crash if reification fails

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,3 +1,9 @@
+next [????.??.??]
+-----------------
+* Fix a bug in which the `declare*` Template Haskell functions would fail if a
+  data type's field has a type that is defined in the same Template Haskell
+  quotation.
+
 5.2.2 [2023.03.18]
 ------------------
 * Fix a bug in which calling `ix i` (where `i` is a negative number) on `Text`

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -468,5 +468,12 @@ $(declareWrapped [d|
   newtype instance T997FamB b = MkT997FamB b
   |])
 
+-- Ensure that a data type defined in a TH quote can have a field whose type
+-- references another data type defined in the same quote (#1032)
+declareFields [d|
+    data T1032A = T1032A { t1032ASubB :: T1032B }
+    data T1032B = T1032B { t1032BB :: Int }
+  |]
+
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
Instead of crashing when `reify` fails, we recover and conservatively assume that the type does not contain any type families.

Fixes #1032.