### PR TITLE
Remove docs saying toNonEmptyOf works on a Prism'

### DIFF
--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -639,7 +639,6 @@ toListOf l = foldrOf l (:) []
 -- 'toNonEmptyOf' :: 'Lens'' s a       -> s -> NonEmpty a
 -- 'toNonEmptyOf' :: 'Iso'' s a        -> s -> NonEmpty a
 -- 'toNonEmptyOf' :: 'Traversal1'' s a -> s -> NonEmpty a
--- 'toNonEmptyOf' :: 'Prism'' s a      -> s -> NonEmpty a
 -- @
 toNonEmptyOf :: Getting (NonEmptyDList a) s a -> s -> NonEmpty a
 toNonEmptyOf l = flip getNonEmptyDList [] . foldMapOf l (NonEmptyDList #. (:|))


### PR DESCRIPTION
Was working nearby and happened to notice it.