### PR TITLE
allow filepath version < 1.6, rebased

### DIFF
--- a/lens.cabal
+++ b/lens.cabal
@@ -185,7 +185,7 @@ library
     contravariant                 >= 1.4      && < 2,
     distributive                  >= 0.5.1    && < 1,
     exceptions                    >= 0.8.2.1  && < 1,
-    filepath                      >= 1.2.0.0  && < 1.5,
+    filepath                      >= 1.2.0.0  && < 1.6,
     free                          >= 5.1.5    && < 6,
     ghc-prim,
     hashable                      >= 1.2.7.0  && < 1.5,


### PR DESCRIPTION
This is #1054 but without the mtl-related changes. I also rebased this and ran the test suite using `cabal test -c 'filepath>=1.5'`.
