### PR TITLE
Allow hashable-1.5

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -223,6 +223,13 @@ jobs:
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens-properties" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods" >> cabal.project ; fi
           cat >> cabal.project <<EOF
+          allow-newer: aeson-2.2.3.0:hashable
+          allow-newer: semialign-1.3.1:hashable
+          allow-newer: strict-0.5.1:hashable
+          allow-newer: these-1.2.1:hashable
+          allow-newer: unordered-containers-0.2.20:hashable
+          allow-newer: witherable-0.5:hashable
+          allow-newer: cassava-0.5.3.1:hashable
           EOF
           $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(lens|lens-examples|lens-properties)$/; }' >> cabal.project.local
           cat cabal.project

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,12 @@
 packages: .
           ./examples
           ./lens-properties
+
+-- TODO: remove this when dependencies catch up
+allow-newer: aeson-2.2.3.0:hashable
+allow-newer: semialign-1.3.1:hashable
+allow-newer: strict-0.5.1:hashable
+allow-newer: these-1.2.1:hashable
+allow-newer: unordered-containers-0.2.20:hashable
+allow-newer: witherable-0.5:hashable
+allow-newer: cassava-0.5.3.1:hashable

--- a/lens.cabal
+++ b/lens.cabal
@@ -189,7 +189,7 @@ library
     filepath                      >= 1.2.0.0  && < 1.6,
     free                          >= 5.1.5    && < 6,
     ghc-prim,
-    hashable                      >= 1.2.7.0  && < 1.5,
+    hashable                      >= 1.2.7.0  && < 1.6,
     indexed-traversable           >= 0.1      && < 0.2,
     indexed-traversable-instances >= 0.1      && < 0.2,
     kan-extensions                >= 5        && < 6,


### PR DESCRIPTION
I took a liberty to add `allow-newer`s to `cabal.project`. Other packages in `these` and `strict` repositories themselves depend on `lens`, so having a revised `lens` (and `semigroupoids`) would help updating them in one go. I'll make another PR to remove these `allow-newer` fields once the updates are done.

EDIT: `lens` doesn't use `Hashable1` nor `Hashable2` so it's not affected by changes in `hashable-1.5`.