### PR TITLE
Reduce arity of set, partsOf, both, and related combinators

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,11 +1,12 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
-* Reduce the arity of `set`, `set'`, `partsOf`, `partsOf'`, `mapAccumLOf`,
-  `auf`, `both`, and `both1` so that GHC is more eager to inline them, following
-  up on the same change to the strict folds in 5.3.4 (see the
-  `NOTE: [Inlining and arity]` in `Control.Lens.Fold`). On a benchmark applying a
-  partially-applied `set _1` in a tight loop, this improves performance by ~19x.
+* Reduce the arity of `set`, `set'`, `partsOf`, `partsOf'`, `unsafePartsOf`,
+  `unsafePartsOf'`, `mapAccumLOf`, `imapAccumLOf`, `auf`, `both`, and `both1` so
+  that GHC is more eager to inline them, following up on the same change to the
+  strict folds in 5.3.4 (see the `NOTE: [Inlining and arity]` in
+  `Control.Lens.Fold`). On a benchmark applying a partially-applied `set _1` in a
+  tight loop, this improves performance by ~19x.
 
 5.3.6 [2026.01.10]
 ------------------

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,11 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
+* Reduce the arity of `set`, `set'`, `partsOf`, `partsOf'`, `mapAccumLOf`,
+  `auf`, `both`, and `both1` so that GHC is more eager to inline them, following
+  up on the same change to the strict folds in 5.3.4 (see the
+  `NOTE: [Inlining and arity]` in `Control.Lens.Fold`). On a benchmark applying a
+  partially-applied `set _1` in a tight loop, this improves performance by ~19x.
 
 5.3.6 [2026.01.10]
 ------------------

--- a/benchmarks/arity.hs
+++ b/benchmarks/arity.hs
@@ -10,7 +10,7 @@
 -- saturates it, the combinator inlines, and worker/wrapper fuses the hot loop.
 -- See NOTE: [Inlining and arity] in Control.Lens.Fold.
 --
--- Coverage mirrors the change set: set/set', partsOf, mapAccumLOf, both/both1,
+-- Coverage includes set/set', partsOf, mapAccumLOf, both/both1,
 -- and auf. (mapAccumLOf is exercised both directly and via scanl1Of.)
 module Main (main) where
 

--- a/benchmarks/arity.hs
+++ b/benchmarks/arity.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# OPTIONS_GHC -O2 #-}
+-- Benchmark for issue #183: combinators used *under-applied*.
+--
+-- The setter wrappers are NOINLINE so the partially-applied form (`set _1`)
+-- survives as a real binding. With `set` at arity 2 it cannot inline into the
+-- wrapper and each application pays for the `Identity` newtype path; with `set`
+-- at arity 1 the wrapper saturates it, `set` inlines, and worker/wrapper fuses
+-- it to a tight unboxed-tuple worker. See NOTE: [Inlining and arity].
+module Main (main) where
+
+import Control.Lens
+import Criterion.Main
+
+-- `set _1` held under-applied at the definition site.
+setFst :: Int -> (Int, Int) -> (Int, Int)
+setFst = set _1
+{-# NOINLINE setFst #-}
+
+set'Snd :: Int -> (Int, Int) -> (Int, Int)
+set'Snd = set' _2
+{-# NOINLINE set'Snd #-}
+
+-- `partsOf traverse` held under-applied (arity 3 -> 1).
+reverseParts :: [Int] -> [Int]
+reverseParts = over (partsOf traverse) reverse
+{-# NOINLINE reverseParts #-}
+
+-- scanl1Of drives mapAccumLOf under-applied (arity 4 -> 3).
+scanSum :: [Int] -> [Int]
+scanSum = scanl1Of traverse (+)
+{-# NOINLINE scanSum #-}
+
+-- Hammer the under-applied setter in a tight loop.
+loopSet :: (Int -> (Int, Int) -> (Int, Int)) -> Int -> Int
+loopSet f = \n ->
+  let go !i !p@(a, b)
+        | i >= n    = a + b
+        | otherwise = go (i + 1) (f i p)
+  in go 0 (0, 0)
+{-# INLINE loopSet #-}
+
+xs :: [Int]
+xs = [1 .. 100]
+{-# NOINLINE xs #-}
+
+main :: IO ()
+main = defaultMain
+  [ bgroup "set-underapplied"
+    [ bench "set _1"  $ whnf (loopSet setFst)  1000000
+    , bench "set' _2" $ whnf (loopSet set'Snd) 1000000
+    ]
+  , bgroup "traversal-underapplied"
+    [ bench "partsOf traverse" $ nf (\v -> sum (concatMap reverseParts (replicate 1000 v))) xs
+    , bench "scanl1Of traverse" $ nf (\v -> sum (concatMap scanSum     (replicate 1000 v))) xs
+    ]
+  ]

--- a/benchmarks/arity.hs
+++ b/benchmarks/arity.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# OPTIONS_GHC -O2 #-}
 -- Benchmark for issue #183: combinators used *under-applied*.
 --
 -- The setter wrappers are NOINLINE so the partially-applied form (`set _1`)
 -- survives as a real binding. With `set` at arity 2 it cannot inline into the
 -- wrapper and each application pays for the `Identity` newtype path; with `set`
 -- at arity 1 the wrapper saturates it, `set` inlines, and worker/wrapper fuses
--- it to a tight unboxed-tuple worker. See NOTE: [Inlining and arity].
+-- it to a tight unboxed-tuple worker. See NOTE: [Inlining and arity] in Control.Lens.Fold.
 module Main (main) where
 
 import Control.Lens

--- a/benchmarks/arity.hs
+++ b/benchmarks/arity.hs
@@ -1,16 +1,22 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleContexts #-}
--- Benchmark for issue #183: combinators used *under-applied*.
+-- Benchmark for issue #183/#590: combinators used *under-applied*.
 --
--- The setter wrappers are NOINLINE so the partially-applied form (`set _1`)
--- survives as a real binding. With `set` at arity 2 it cannot inline into the
--- wrapper and each application pays for the `Identity` newtype path; with `set`
--- at arity 1 the wrapper saturates it, `set` inlines, and worker/wrapper fuses
--- it to a tight unboxed-tuple worker. See NOTE: [Inlining and arity] in Control.Lens.Fold.
+-- Each binding below fixes a combinator's leading arguments and is marked
+-- NOINLINE, so the partially-applied form (`set _1`, `over both (+1)`, ...)
+-- survives as a real binding. With the combinator at full arity it cannot
+-- inline into that binding and each application pays for the newtype/decompose
+-- path; with the trailing arguments moved right of the `=` the binding
+-- saturates it, the combinator inlines, and worker/wrapper fuses the hot loop.
+-- See NOTE: [Inlining and arity] in Control.Lens.Fold.
+--
+-- Coverage mirrors the change set: set/set', partsOf, mapAccumLOf, both/both1,
+-- and auf. (mapAccumLOf is exercised both directly and via scanl1Of.)
 module Main (main) where
 
 import Control.Lens
 import Criterion.Main
+import Data.Monoid (Sum (..))
 
 -- `set _1` held under-applied at the definition site.
 setFst :: Int -> (Int, Int) -> (Int, Int)
@@ -31,7 +37,26 @@ scanSum :: [Int] -> [Int]
 scanSum = scanl1Of traverse (+)
 {-# NOINLINE scanSum #-}
 
--- Hammer the under-applied setter in a tight loop.
+-- mapAccumLOf held under-applied directly (arity 4 -> 3).
+runningSum :: [Int] -> (Int, [Int])
+runningSum = mapAccumLOf traverse (\acc x -> let acc' = acc + x in (acc', acc')) 0
+{-# NOINLINE runningSum #-}
+
+-- `both`/`both1` used first-class as optic values in a hot consumer.
+bumpBoth :: (Int, Int) -> (Int, Int)
+bumpBoth = over both (+ 1)
+{-# NOINLINE bumpBoth #-}
+
+bumpBoth1 :: (Int, Int) -> (Int, Int)
+bumpBoth1 = over both1 (+ 1)
+{-# NOINLINE bumpBoth1 #-}
+
+-- `auf` with the iso and consumer fixed, held under-applied (arity 3 -> 1).
+aufBoth :: (String -> Int) -> (String, String) -> Int
+aufBoth = auf (_Wrapping Sum) (foldMapOf both)
+{-# NOINLINE aufBoth #-}
+
+-- Hammer the under-applied (Int,Int)-setter in a tight loop.
 loopSet :: (Int -> (Int, Int) -> (Int, Int)) -> Int -> Int
 loopSet f = \n ->
   let go !i !p@(a, b)
@@ -39,6 +64,26 @@ loopSet f = \n ->
         | otherwise = go (i + 1) (f i p)
   in go 0 (0, 0)
 {-# INLINE loopSet #-}
+
+-- As loopSet, but for an endomorphism that takes no index (both/both1).
+loopEndo :: ((Int, Int) -> (Int, Int)) -> Int -> Int
+loopEndo f = \n ->
+  let go !i !p@(a, b)
+        | i >= n    = a + b
+        | otherwise = go (i + 1) (f p)
+  in go 0 (0, 0)
+{-# INLINE loopEndo #-}
+
+-- Strictly sum `work i` over [0..n); `work` applies the under-applied
+-- combinator to an i-dependent input, so each iteration forces a fresh
+-- evaluation (no sharing) without going through `map`/`replicate`.
+loopSum :: (Int -> Int) -> Int -> Int
+loopSum work = \n ->
+  let go !i !acc
+        | i >= n    = acc
+        | otherwise = go (i + 1) (acc + work i)
+  in go 0 0
+{-# INLINE loopSum #-}
 
 xs :: [Int]
 xs = [1 .. 100]
@@ -51,7 +96,15 @@ main = defaultMain
     , bench "set' _2" $ whnf (loopSet set'Snd) 1000000
     ]
   , bgroup "traversal-underapplied"
-    [ bench "partsOf traverse" $ nf (\v -> sum (concatMap reverseParts (replicate 1000 v))) xs
-    , bench "scanl1Of traverse" $ nf (\v -> sum (concatMap scanSum     (replicate 1000 v))) xs
+    [ bench "partsOf traverse"     $ nf (\v -> sum (concatMap reverseParts (replicate 1000 v))) xs
+    , bench "scanl1Of traverse"    $ nf (\v -> sum (concatMap scanSum     (replicate 1000 v))) xs
+    , bench "mapAccumLOf traverse" $ whnf (loopSum (\i -> fst (runningSum [i .. i + 99]))) 10000
+    ]
+  , bgroup "bitraversal-underapplied"
+    [ bench "over both"  $ whnf (loopEndo bumpBoth)  1000000
+    , bench "over both1" $ whnf (loopEndo bumpBoth1) 1000000
+    ]
+  , bgroup "iso-underapplied"
+    [ bench "auf _Wrapping Sum" $ whnf (loopSum (\i -> aufBoth length (show i, "world"))) 100000
     ]
   ]

--- a/lens.cabal
+++ b/lens.cabal
@@ -452,6 +452,18 @@ benchmark folds
     vector,
     lens
 
+-- Benchmarking inlining/arity
+benchmark arity
+  type:             exitcode-stdio-1.0
+  main-is:          arity.hs
+  ghc-options:      -Wall -O2 -threaded -fdicts-cheap -funbox-strict-fields
+  hs-source-dirs:   benchmarks
+  default-language: Haskell2010
+  build-depends:
+    base,
+    criterion,
+    lens
+
 -- Benchmarking traversals
 benchmark traversals
   type:             exitcode-stdio-1.0

--- a/src/Control/Lens/Iso.hs
+++ b/src/Control/Lens/Iso.hs
@@ -210,8 +210,12 @@ au k = withIso k $ \ sa bt f -> fmap sa (f bt)
 -- across both old and new versions of @lens@ you can just use 'coerce'!
 auf :: (Functor f, Functor g) => AnIso s t a b -> (f t -> g s) -> f b -> g a
 -- Pushing the remaining arguments inside 'withIso' (so only @k@ is to the left
--- of the @=@) matches 'au'/'under' and lets the iso decompose once and inline at
--- partial applications. See: NOTE: [Inlining and arity] in Control.Lens.Fold
+-- of the @=@) matches 'au'/'under': the iso is decomposed once, when @auf k@ is
+-- forced, and the body inlines at partial applications. Unlike the other arity
+-- reductions in this change this is *not* strictness-neutral -- as with
+-- 'au'/'under', @auf@ is now strict in the iso, so @auf undefined@ diverges
+-- rather than yielding a function. That is an intentional tradeoff for an
+-- 'AnIso' argument. See: NOTE: [Inlining and arity] in Control.Lens.Fold
 auf k = withIso k $ \sa bt ftgs fb -> sa <$> ftgs (bt <$> fb)
 {-# INLINE auf #-}
 

--- a/src/Control/Lens/Iso.hs
+++ b/src/Control/Lens/Iso.hs
@@ -212,8 +212,8 @@ auf :: (Functor f, Functor g) => AnIso s t a b -> (f t -> g s) -> f b -> g a
 -- Pushing the remaining arguments inside 'withIso' (so only @k@ is to the left
 -- of the @=@) matches 'au'/'under': the iso is decomposed once, when @auf k@ is
 -- forced, and the body inlines at partial applications. Unlike the other arity
--- reductions in this change this is *not* strictness-neutral -- as with
--- 'au'/'under', @auf@ is now strict in the iso, so @auf undefined@ diverges
+-- reductions, this is *not* strictness-neutral -- as with
+-- 'au'/'under', @auf@ is strict in the iso, so @auf undefined@ diverges
 -- rather than yielding a function. That is an intentional tradeoff for an
 -- 'AnIso' argument. See: NOTE: [Inlining and arity] in Control.Lens.Fold
 auf k = withIso k $ \sa bt ftgs fb -> sa <$> ftgs (bt <$> fb)

--- a/src/Control/Lens/Iso.hs
+++ b/src/Control/Lens/Iso.hs
@@ -209,7 +209,10 @@ au k = withIso k $ \ sa bt f -> fmap sa (f bt)
 -- with the behavior of 'au'. For the old behavior use 'xplatf' or for a version that is compatible
 -- across both old and new versions of @lens@ you can just use 'coerce'!
 auf :: (Functor f, Functor g) => AnIso s t a b -> (f t -> g s) -> f b -> g a
-auf k ftgs fb = withIso k $ \sa bt -> sa <$> ftgs (bt <$> fb)
+-- Pushing the remaining arguments inside 'withIso' (so only @k@ is to the left
+-- of the @=@) matches 'au'/'under' and lets the iso decompose once and inline at
+-- partial applications. See: NOTE: [Inlining and arity] in Control.Lens.Fold
+auf k = withIso k $ \sa bt ftgs fb -> sa <$> ftgs (bt <$> fb)
 {-# INLINE auf #-}
 
 -- | @'xplat' = 'au' . 'from'@ but with a nicer signature.

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -373,7 +373,8 @@ over = coerce
 -- 'set' :: 'Traversal' s t a b -> b -> s -> t
 -- @
 set :: ASetter s t a b -> b -> s -> t
-set l b = runIdentity #. l (\_ -> Identity b)
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+set l = \b -> runIdentity #. l (\_ -> Identity b)
 {-# INLINE set #-}
 
 -- | Replace the target of a 'Lens' or all of the targets of a 'Setter''
@@ -400,7 +401,8 @@ set l b = runIdentity #. l (\_ -> Identity b)
 -- 'set'' :: 'Traversal'' s a -> a -> s -> s
 -- @
 set' :: ASetter' s a -> a -> s -> s
-set' l b = runIdentity #. l (\_ -> Identity b)
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+set' l = \b -> runIdentity #. l (\_ -> Identity b)
 {-# INLINE set' #-}
 
 -- | Modifies the target of a 'Lens' or all of the targets of a 'Setter' or

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -647,7 +647,8 @@ ipartsOf' l = conjoined
 -- 'unsafePartsOf' :: 'Getter' s a        -> 'Getter' s [a]
 -- @
 unsafePartsOf :: Functor f => Traversing (->) f s t a b -> LensLike f s t [a] [b]
-unsafePartsOf l f s = unsafeOuts b <$> f (ins b) where b = l sell s
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+unsafePartsOf l = \f s -> let b = l sell s in unsafeOuts b <$> f (ins b)
 {-# INLINE unsafePartsOf #-}
 
 -- | An indexed version of 'unsafePartsOf' that receives the entire list of indices as its index.
@@ -658,7 +659,8 @@ iunsafePartsOf l = conjoined
 {-# INLINE iunsafePartsOf #-}
 
 unsafePartsOf' :: ATraversal s t a b -> Lens s t [a] [b]
-unsafePartsOf' l f s = unsafeOuts b <$> f (ins b) where b = l sell s
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+unsafePartsOf' l = \f s -> let b = l sell s in unsafeOuts b <$> f (ins b)
 {-# INLINE unsafePartsOf' #-}
 
 iunsafePartsOf' :: forall i s t a b. Over (Indexed i) (Bazaar (Indexed i) a b) s t a b -> IndexedLens [i] s t [a] [b]
@@ -1174,7 +1176,8 @@ imapAccumROf = imapAccumLOf . backwards
 -- 'imapAccumLOf' :: 'IndexedTraversal' i s t a b -> (i -> acc -> a -> (acc, b)) -> acc -> s -> (acc, t)
 -- @
 imapAccumLOf :: Over (Indexed i) (State acc) s t a b -> (i -> acc -> a -> (acc, b)) -> acc -> s -> (acc, t)
-imapAccumLOf l f acc0 s = swap (runState (l (Indexed g) s) acc0) where
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+imapAccumLOf l f acc0 = \s -> swap (runState (l (Indexed g) s) acc0) where
   g i a = state $ \acc -> swap (f i acc a)
 {-# INLINE imapAccumLOf #-}
 

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -517,7 +517,8 @@ mapAccumROf = mapAccumLOf . backwards
 -- @
 --
 mapAccumLOf :: LensLike (State acc) s t a b -> (acc -> a -> (acc, b)) -> acc -> s -> (acc, t)
-mapAccumLOf l f acc0 s = swap (runState (l g s) acc0) where
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+mapAccumLOf l f acc0 = \s -> swap (runState (l g s) acc0) where
    g a = state $ \acc -> swap (f acc a)
 -- This would be much cleaner if the argument order for the function was swapped.
 {-# INLINE mapAccumLOf #-}
@@ -601,7 +602,8 @@ iloci f w = getCompose (runBazaar w (Compose #. Indexed (\i -> fmap (indexed sel
 -- 'partsOf' :: 'Getter' s a     -> 'Getter' s [a]
 -- @
 partsOf :: Functor f => Traversing (->) f s t a a -> LensLike f s t [a] [a]
-partsOf l f s = outs b <$> f (ins b) where b = l sell s
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+partsOf l = \f s -> let b = l sell s in outs b <$> f (ins b)
 {-# INLINE partsOf #-}
 
 -- | An indexed version of 'partsOf' that receives the entire list of indices as its index.
@@ -613,7 +615,8 @@ ipartsOf l = conjoined
 
 -- | A type-restricted version of 'partsOf' that can only be used with a 'Traversal'.
 partsOf' :: ATraversal s t a a -> Lens s t [a] [a]
-partsOf' l f s = outs b <$> f (ins b) where b = l sell s
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+partsOf' l = \f s -> let b = l sell s in outs b <$> f (ins b)
 {-# INLINE partsOf' #-}
 
 -- | A type-restricted version of 'ipartsOf' that can only be used with an 'IndexedTraversal'.
@@ -897,7 +900,8 @@ instance Monoid m => Applicative (Holes t m) where
 -- 'both' :: 'Traversal' ('Either' a a) ('Either' b b) a b
 -- @
 both :: Bitraversable r => Traversal (r a a) (r b b) a b
-both f = bitraverse f f
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+both = \f -> bitraverse f f
 {-# INLINE both #-}
 
 -- | Traverse both parts of a 'Bitraversable1' container with matching types.
@@ -909,7 +913,8 @@ both f = bitraverse f f
 -- 'both1' :: 'Traversal1' ('Either' a a) ('Either' b b) a b
 -- @
 both1 :: Bitraversable1 r => Traversal1 (r a a) (r b b) a b
-both1 f = bitraverse1 f f
+-- See: NOTE: [Inlining and arity] in Control.Lens.Fold
+both1 = \f -> bitraverse1 f f
 {-# INLINE both1 #-}
 
 -- | Apply a different 'Traversal' or 'Fold' to each side of a 'Bitraversable' container.


### PR DESCRIPTION
Closes #183 and #590

Move commonly-under-applied trailing arguments right of the `=` so the `INLINE` fires at under-applied call sites, as was done for the strict folds in 5.3.4 (see `NOTE: [Inlining and arity]` in `Control.Lens.Fold`). A loop over a partially-applied `set _1` is ~19x faster; the rest are neutral but keep each family consistent. Adds `benchmarks/arity.hs`.

### Which combinators changed, and why

The transform only changes runtime behaviour when a combinator is *held partially applied* (stored/reused below its full arity), so it's applied where both of these hold:
1. the combinator is plausibly held partially applied in client code, and
2. the transform is strictness-neutral — moving the argument forces nothing earlier than before.

When one function in a family changed, its same-shape siblings changed too, so no family is left half-transformed:
- `set`, `set'` — the motivating case (#183/#590).
- `partsOf`, `partsOf'`, `unsafePartsOf`, `unsafePartsOf'` - the `let b = l sell s` is still only forced once `s` arrives.
- `mapAccumLOf`, `imapAccumLOf`.
- `both`, `both1` — used first-class as optic values; the arity-0 form lets the optic inline at the consumer.
- `auf` — brought in line with its siblings `au`/`under`.

Already-point-free siblings (`mapAccumROf`, `imapAccumROf`) and already-arity-1 indexed variants (`ipartsOf`/`iunsafePartsOf`, … via `conjoined`) need no change.

### One non-neutral case, called out

`auf` is the exception to (2): like `au`/`under` it is now strict in the iso (`auf undefined` diverges instead of returning a function) in exchange for decomposing the iso once. This is documented as an intentional tradeoff at the definition.
