### PR TITLE
Space leaks

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,9 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
+* Fix a space leak in `lastOf` over lazy `ByteString`s, which previously
+  retained memory proportional to the number of chunks; it now runs in constant
+  space.
 
 5.3.6 [2026.01.10]
 ------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -162,6 +162,10 @@ flag test-templates
   default: True
   manual: True
 
+flag test-space
+  default: True
+  manual: True
+
 -- Assert that we are trustworthy when we can
 flag trustworthy
   default: True
@@ -389,25 +393,25 @@ test-suite hunit
       tasty >= 1.4 && < 1.6,
       tasty-hunit >= 0.10 && < 0.11
 
--- Regression test for the lazy-ByteString space leak in lastOf.
+-- Regression test for the lazy-ByteString space leak in lastOf (issue #233).
 -- Uses GHC.Stats (base >= 4.10 / GHC >= 8.2); -O2 so the rewrite rule fires.
 test-suite space
   type: exitcode-stdio-1.0
   main-is: space.hs
-  -- -rtsopts so the test can re-exec itself under GHCRTS=-T -A256k: the small
-  -- nursery forces frequent GCs, so the leak's transient peak is actually
-  -- sampled (with the default nursery it can slip between major GCs).
-  ghc-options: -Wall -O2 -threaded -rtsopts
+  -- -rtsopts so the test can re-exec itself with `+RTS -T -A256k -RTS`: the
+  -- small nursery forces frequent GCs so the leak's transient peak is sampled
+  -- (with the default nursery it can slip between major GCs).
+  ghc-options: -Wall -O2 -rtsopts
   hs-source-dirs: tests
   default-language: Haskell2010
-  if impl(ghc < 8.2)
-    buildable: False
-  else
+  if flag(test-space) && impl(ghc >= 8.2)
     build-depends:
       base,
       bytestring,
       lens,
       process
+  else
+    buildable: False
 
 -- We need this dummy test-suite to add simple-reflect to the install plan
 --

--- a/lens.cabal
+++ b/lens.cabal
@@ -398,18 +398,17 @@ test-suite hunit
 test-suite space
   type: exitcode-stdio-1.0
   main-is: space.hs
-  -- -rtsopts so the test can re-exec itself with `+RTS -T -A256k -RTS`: the
-  -- small nursery forces frequent GCs so the leak's transient peak is sampled
-  -- (with the default nursery it can slip between major GCs).
-  ghc-options: -Wall -O2 -rtsopts
+  -- -T enables GHC.Stats; the small nursery (-A256k) forces frequent GCs so
+  -- the leak's transient peak is sampled (with the default nursery it can slip
+  -- between major GCs). The test verifies at startup that both are in effect.
+  ghc-options: -Wall -O2 -rtsopts "-with-rtsopts=-T -A256k"
   hs-source-dirs: tests
   default-language: Haskell2010
   if flag(test-space) && impl(ghc >= 8.2)
     build-depends:
       base,
       bytestring,
-      lens,
-      process
+      lens
   else
     buildable: False
 

--- a/lens.cabal
+++ b/lens.cabal
@@ -389,6 +389,26 @@ test-suite hunit
       tasty >= 1.4 && < 1.6,
       tasty-hunit >= 0.10 && < 0.11
 
+-- Regression test for the lazy-ByteString space leak in lastOf.
+-- Uses GHC.Stats (base >= 4.10 / GHC >= 8.2); -O2 so the rewrite rule fires.
+test-suite space
+  type: exitcode-stdio-1.0
+  main-is: space.hs
+  -- -rtsopts so the test can re-exec itself under GHCRTS=-T -A256k: the small
+  -- nursery forces frequent GCs, so the leak's transient peak is actually
+  -- sampled (with the default nursery it can slip between major GCs).
+  ghc-options: -Wall -O2 -threaded -rtsopts
+  hs-source-dirs: tests
+  default-language: Haskell2010
+  if impl(ghc < 8.2)
+    buildable: False
+  else
+    build-depends:
+      base,
+      bytestring,
+      lens,
+      process
+
 -- We need this dummy test-suite to add simple-reflect to the install plan
 --
 -- When cabal-install's extra-packages support becomes widely available

--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -32,6 +32,7 @@ import Prelude ()
 import Control.Lens.Type
 import Control.Lens.Getter
 import Control.Lens.Fold
+import Control.Lens.Internal.Fold (Rightmost(..))
 import Control.Lens.Indexed
 import Control.Lens.Internal.Prelude
 import Control.Lens.Setter
@@ -140,7 +141,33 @@ traversedLazy pafb = \lbs -> BL.foldrChunks go (\_ -> pure BL.empty) lbs 0
     traversedLazy = foldring BL.foldr :: Getting (Endo r) BL.ByteString Word8;
   "igets lazy bytestring"
     traversedLazy = ifoldring ifoldrBL :: IndexedGetting Int (Endo r) BL.ByteString Word8;
+  "lastOf lazy bytestring"
+    traversedLazy = lazyBytesRightmost :: Getting (Rightmost a) BL.ByteString Word8;
  #-}
+
+-- | 'lastOf' and other strict-to-end 'Rightmost' folds are not covered by the
+-- @Endo@ rule above, so without this they fall through to the general
+-- 'traversedLazy', whose @foldrChunks@/@<*>@ builds a lazy thunk chain over the
+-- chunk spine and retains memory proportional to the chunk count.
+--
+-- 'Rightmost' is strict-to-end (unlike the short-circuiting 'Leftmost'/'Any'),
+-- so a strict 'BL.foldl'' is sound: @acc <> 'RLeaf' w@ discards @acc@, so the
+-- fold runs in constant space. We deliberately do /not/ do this for
+-- 'firstOf'/'anyOf', whose laziness is load-bearing.
+lazyBytesRightmost :: Getting (Rightmost a) BL.ByteString Word8
+lazyBytesRightmost f = Const #. BL.foldl' (\acc w -> stepRightmost acc (getConst (f w))) mempty
+{-# INLINE lazyBytesRightmost #-}
+
+-- | One step of a strict 'Rightmost' left fold. @(<>)@ for 'Rightmost' always
+-- wraps its result in 'RStep' and is lazy in the left argument, so a plain
+-- @foldl' (<>)@ retains an O(n) thunk chain (each thunk closing over the prior
+-- accumulator). Forcing the 'RStep' payload one extra level drops that
+-- reference, giving constant space. This does not change the value: @foldl' (<>)
+-- mempty@ equals the lawful @foldr (<>) mempty@ by associativity, and the 'seq'
+-- only forces, so the rewrite stays sound.
+stepRightmost :: Rightmost a -> Rightmost a -> Rightmost a
+stepRightmost acc r = case acc <> r of s@(RStep x) -> x `seq` s; s -> s
+{-# INLINE stepRightmost #-}
 
 imapBL :: (Int -> Word8 -> Word8) -> BL.ByteString -> BL.ByteString
 imapBL f = snd . BL.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0
@@ -171,7 +198,14 @@ traversedLazy8 pafb = \lbs -> BL.foldrChunks go (\_ -> pure BL.empty) lbs 0
     traversedLazy8 = foldring BL8.foldr :: Getting (Endo r) BL8.ByteString Char;
   "igets lazy bytestring"
     traversedLazy8 = ifoldring ifoldrBL8 :: IndexedGetting Int (Endo r) BL8.ByteString Char;
+  "lastOf lazy bytestring"
+    traversedLazy8 = lazyBytesRightmost8 :: Getting (Rightmost a) BL8.ByteString Char;
  #-}
+
+-- | See 'lazyBytesRightmost'; this is the @Char@ analogue for 'traversedLazy8'.
+lazyBytesRightmost8 :: Getting (Rightmost a) BL8.ByteString Char
+lazyBytesRightmost8 f = Const #. BL8.foldl' (\acc c -> stepRightmost acc (getConst (f c))) mempty
+{-# INLINE lazyBytesRightmost8 #-}
 
 imapBL8 :: (Int -> Char -> Char) -> BL8.ByteString -> BL8.ByteString
 imapBL8 f = snd . BL8.mapAccumL (\i a -> i `seq` (i + 1, f i a)) 0

--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -159,12 +159,19 @@ lazyBytesRightmost f = Const #. BL.foldl' (\acc w -> stepRightmost acc (getConst
 {-# INLINE lazyBytesRightmost #-}
 
 -- | One step of a strict 'Rightmost' left fold. @(<>)@ for 'Rightmost' always
--- wraps its result in 'RStep' and is lazy in the left argument, so a plain
--- @foldl' (<>)@ retains an O(n) thunk chain (each thunk closing over the prior
--- accumulator). Forcing the 'RStep' payload one extra level drops that
--- reference, giving constant space. This does not change the value: @foldl' (<>)
--- mempty@ equals the lawful @foldr (<>) mempty@ by associativity, and the 'seq'
--- only forces, so the rewrite stays sound.
+-- wraps its result in 'RStep' and is lazy in the left argument; for the
+-- @'RLeaf' w@ values 'lastOf' feeds in, @acc <> 'RLeaf' w = 'RStep' ('RLeaf' w)@,
+-- so forcing that 'RStep' payload to WHNF drops @acc@ and the fold runs in
+-- constant space (a plain @foldl' (<>)@ would instead retain an O(n) chain of
+-- thunks, each closing over the prior accumulator).
+--
+-- Note this rewrite is sound even though 'Rightmost'\'s @(<>)@ is /not/
+-- value-level associative (left- vs right-nesting insert different numbers of
+-- 'RStep' layers): the only consumer of @'Getting' ('Rightmost' a)@ is 'lastOf',
+-- which observes solely 'getRightmost', and 'getRightmost' is invariant under
+-- both re-association and extra 'RStep' layers. The 'seq' only forces, so the
+-- strict left fold agrees with the lawful traversal on every observation
+-- 'lastOf' can make.
 stepRightmost :: Rightmost a -> Rightmost a -> Rightmost a
 stepRightmost acc r = case acc <> r of
                         s@(RStep x) -> x `seq` s

--- a/src/Control/Lens/Internal/ByteString.hs
+++ b/src/Control/Lens/Internal/ByteString.hs
@@ -166,7 +166,9 @@ lazyBytesRightmost f = Const #. BL.foldl' (\acc w -> stepRightmost acc (getConst
 -- mempty@ equals the lawful @foldr (<>) mempty@ by associativity, and the 'seq'
 -- only forces, so the rewrite stays sound.
 stepRightmost :: Rightmost a -> Rightmost a -> Rightmost a
-stepRightmost acc r = case acc <> r of s@(RStep x) -> x `seq` s; s -> s
+stepRightmost acc r = case acc <> r of
+                        s@(RStep x) -> x `seq` s
+                        s           -> s
 {-# INLINE stepRightmost #-}
 
 imapBL :: (Int -> Word8 -> Word8) -> BL.ByteString -> BL.ByteString

--- a/tests/space.hs
+++ b/tests/space.hs
@@ -10,13 +10,11 @@
 -- chunking heuristics (which have varied across releases).
 --
 -- The peak is transient (it only exists during the fold), so it is sampled
--- reliably only if GCs are frequent: we need a small nursery (@-A256k@) and
--- @-T@ to enable "GHC.Stats". A program cannot choose its own RTS options after
--- startup, and baking a multi-word @-with-rtsopts@ through cabal is unreliable,
--- so on first entry we re-exec ourselves passing those options as @+RTS@
--- arguments (the executable is built with @-rtsopts@, so it accepts them). We
--- pass them as arguments rather than via the @GHCRTS@ environment variable so as
--- not to disturb any @GHCRTS@ the user may have set.
+-- reliably only if GCs are frequent: the cabal stanza bakes in a small nursery
+-- (@-A256k@) plus @-T@ to enable "GHC.Stats" via @-with-rtsopts@. Because the
+-- whole test silently measures nothing if those options go missing, 'main'
+-- first verifies through "GHC.RTS.Flags" that they are actually in effect and
+-- fails loudly otherwise.
 module Main (main) where
 
 import           Control.Exception (evaluate)
@@ -25,28 +23,12 @@ import           Control.Monad (unless, when)
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import           Data.ByteString.Lazy.Lens (bytes)
+import           GHC.RTS.Flags (getGCFlags, minAllocAreaSize)
 import           GHC.Stats (getRTSStats, getRTSStatsEnabled, max_live_bytes)
-import           System.Environment (getArgs, getExecutablePath)
-import           System.Exit (exitFailure, exitWith)
+import           System.Exit (exitFailure)
 import           System.IO (hPutStrLn, stderr)
 import           System.Mem (performMajorGC)
-import           System.Process (rawSystem)
 import           Text.Printf (printf)
-
--- | Sentinel argument identifying the re-exec'd child. The RTS strips the
--- @+RTS ... -RTS@ block from the child's arguments, so this is what is left to
--- distinguish it from the initial invocation (and stops it re-exec'ing again).
-childArg :: String
-childArg = "--lens-space-test-child"
-
-main :: IO ()
-main = do
-  args <- getArgs
-  if childArg `elem` args
-    then runTest
-    else do
-      exe <- getExecutablePath
-      exitWith =<< rawSystem exe [childArg, "+RTS", "-T", "-A256k", "-RTS"]
 
 -- | A lazy 'ByteString' of @n@ fixed-size chunks. 'lastOf' must reach the end,
 -- so the whole spine is traversed; the leak (if present) retains ~one thunk per
@@ -64,31 +46,43 @@ forceLast n = do
 peakBytes :: IO Integer
 peakBytes = performMajorGC >> fmap (toInteger . max_live_bytes) getRTSStats
 
-runTest :: IO ()
-runTest = do
-  enabled <- getRTSStatsEnabled
-  if not enabled
-    -- The child is only ever reached via our own re-exec, which always passes
-    -- -T, so a disabled-stats child means the harness itself is broken. Fail
-    -- loudly rather than skip -- a silent pass would exercise nothing forever.
-    then do
-      hPutStrLn stderr "space: RTS stats not in effect after re-exec; harness broken."
-      exitFailure
-    else do
-      let small =   8 * 1000   --   8k chunks (~32 MB)
-          big   = 128 * 1000   -- 128k chunks (16x; ~512 MB)
-          -- Streaming grows by a few KB; the leak grows by ~3 MB. 256 KB sits
-          -- well inside that gap, with plenty of margin on both sides.
-          cap   = 256 * 1000
-      forceLast small
-      p1 <- peakBytes
-      forceLast big
-      p2 <- peakBytes
-      let growth = p2 - p1
-      printf "lastOf bytes peak residency: %d B (8k chunks) -> %d B (128k chunks), growth %d B\n"
-             p1 p2 growth
-      when (growth > cap) $ do
-        printf "FAIL: residency grew %d B over a 16x input increase; lastOf over a lazy ByteString is leaking (issue #233).\n"
-               growth
-        exitFailure
-      putStrLn "OK: lastOf over a lazy ByteString streams in constant space."
+-- | Fail loudly unless the RTS options this test depends on are in effect:
+-- @-T@ (so "GHC.Stats" works at all) and a small allocation area (so the
+-- transient peak is sampled often enough to be seen). Without this check, a
+-- build that lost @-with-rtsopts@ would turn the suite into a permanent silent
+-- pass that exercises nothing. Note that GHC does not relink when only
+-- link-time flags such as @-with-rtsopts@ change, so an incremental build can
+-- leave a binary with stale baked RTS options; this check catches that too.
+checkRtsOpts :: IO ()
+checkRtsOpts = do
+  statsEnabled <- getRTSStatsEnabled
+  gcFlags <- getGCFlags
+  -- \-A256k = 64 four-KiB blocks; the default is 1024. Anything in that
+  -- ballpark samples frequently enough.
+  let nurseryOk = minAllocAreaSize gcFlags <= 128
+  unless (statsEnabled && nurseryOk) $ do
+    hPutStrLn stderr "space: -T/-A256k not in effect; was -with-rtsopts dropped from the cabal\
+                     \ stanza, or did an incremental build skip the relink? (Deleting this\
+                     \ test's build directory forces a correct relink.)"
+    exitFailure
+
+main :: IO ()
+main = do
+  checkRtsOpts
+  let small =   8 * 1000   --   8k chunks (~32 MB)
+      big   = 128 * 1000   -- 128k chunks (16x; ~512 MB)
+      -- Streaming grows by a few KB; the leak grows by ~3 MB. 256 KB sits
+      -- well inside that gap, with plenty of margin on both sides.
+      cap   = 256 * 1000
+  forceLast small
+  p1 <- peakBytes
+  forceLast big
+  p2 <- peakBytes
+  let growth = p2 - p1
+  printf "lastOf bytes peak residency: %d B (8k chunks) -> %d B (128k chunks), growth %d B\n"
+         p1 p2 growth
+  when (growth > cap) $ do
+    printf "FAIL: residency grew %d B over a 16x input increase; lastOf over a lazy ByteString is leaking (issue #233).\n"
+           growth
+    exitFailure
+  putStrLn "OK: lastOf over a lazy ByteString streams in constant space."

--- a/tests/space.hs
+++ b/tests/space.hs
@@ -3,9 +3,11 @@
 --
 -- 'lastOf' over a lazy 'ByteString' must run in /constant/ space. A leaking
 -- traversal retains roughly one thunk per chunk, so peak residency grows with
--- the input length. We fold a lazily-generated 'ByteString' at two sizes (16x
--- apart) and assert that peak residency (from "GHC.Stats") does not grow: a
--- streaming fold stays flat, a leaking one jumps by megabytes.
+-- the chunk count. We fold a lazy 'ByteString' at two sizes (16x apart) and
+-- assert that peak residency (from "GHC.Stats") does not grow: a streaming fold
+-- stays flat, a leaking one jumps by megabytes. The input is built from a fixed
+-- chunk size so the leak's magnitude is independent of bytestring's internal
+-- chunking heuristics (which have varied across releases).
 --
 -- The peak is transient (it only exists during the fold), so it is sampled
 -- reliably only if GCs are frequent: we need a small nursery (@-A256k@) and
@@ -20,11 +22,13 @@ module Main (main) where
 import           Control.Exception (evaluate)
 import           Control.Lens (lastOf)
 import           Control.Monad (unless, when)
+import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import           Data.ByteString.Lazy.Lens (bytes)
 import           GHC.Stats (getRTSStats, getRTSStatsEnabled, max_live_bytes)
 import           System.Environment (getArgs, getExecutablePath)
 import           System.Exit (exitFailure, exitWith)
+import           System.IO (hPutStrLn, stderr)
 import           System.Mem (performMajorGC)
 import           System.Process (rawSystem)
 import           Text.Printf (printf)
@@ -44,11 +48,16 @@ main = do
       exe <- getExecutablePath
       exitWith =<< rawSystem exe [childArg, "+RTS", "-T", "-A256k", "-RTS"]
 
--- | Drive 'lastOf' over the whole (lazily generated) ByteString. 'lastOf' must
--- reach the end, so the entire structure is traversed.
+-- | A lazy 'ByteString' of @n@ fixed-size chunks. 'lastOf' must reach the end,
+-- so the whole spine is traversed; the leak (if present) retains ~one thunk per
+-- chunk, so its size scales with @n@.
+chunked :: Int -> BL.ByteString
+chunked n = BL.fromChunks (replicate n chunk)
+  where chunk = B.replicate 4096 7
+
 forceLast :: Int -> IO ()
 forceLast n = do
-  r <- evaluate (lastOf bytes (BL.replicate (fromIntegral n) 7))
+  r <- evaluate (lastOf bytes (chunked n))
   unless (r == Just 7) (error ("space: unexpected lastOf result " ++ show r))
 
 -- | Peak live bytes observed so far (max over all major GCs).
@@ -59,17 +68,24 @@ runTest :: IO ()
 runTest = do
   enabled <- getRTSStatsEnabled
   if not enabled
-    then putStrLn "space: RTS stats unavailable (-T not in effect?); skipping."
+    -- The child is only ever reached via our own re-exec, which always passes
+    -- -T, so a disabled-stats child means the harness itself is broken. Fail
+    -- loudly rather than skip -- a silent pass would exercise nothing forever.
+    then do
+      hPutStrLn stderr "space: RTS stats not in effect after re-exec; harness broken."
+      exitFailure
     else do
-      let small =  50 * 1000 * 1000   --  50 MB
-          big   = 800 * 1000 * 1000   -- 800 MB (16x)
-          cap   =   2 * 1000 * 1000   --   2 MB slack (a leak grows by ~4 MB here)
+      let small =   8 * 1000   --   8k chunks (~32 MB)
+          big   = 128 * 1000   -- 128k chunks (16x; ~512 MB)
+          -- Streaming grows by a few KB; the leak grows by ~3 MB. 256 KB sits
+          -- well inside that gap, with plenty of margin on both sides.
+          cap   = 256 * 1000
       forceLast small
       p1 <- peakBytes
       forceLast big
       p2 <- peakBytes
       let growth = p2 - p1
-      printf "lastOf bytes peak residency: %d B (50MB) -> %d B (800MB), growth %d B\n"
+      printf "lastOf bytes peak residency: %d B (8k chunks) -> %d B (128k chunks), growth %d B\n"
              p1 p2 growth
       when (growth > cap) $ do
         printf "FAIL: residency grew %d B over a 16x input increase; lastOf over a lazy ByteString is leaking (issue #233).\n"

--- a/tests/space.hs
+++ b/tests/space.hs
@@ -1,0 +1,74 @@
+-- | Regression test for the lazy-'ByteString' space leak in 'lastOf' /
+-- 'Rightmost' folds (see "Control.Lens.Internal.ByteString"; lens issue #233).
+--
+-- 'lastOf' over a lazy 'ByteString' must run in /constant/ space. A leaking
+-- traversal retains roughly one thunk per chunk, so peak residency grows with
+-- the input length. We fold a lazily-generated 'ByteString' at two sizes (16x
+-- apart) and assert that peak residency (from "GHC.Stats") does not grow: a
+-- streaming fold stays flat, a leaking one jumps by megabytes.
+--
+-- The peak is transient (it lives only during the fold), so it is only sampled
+-- if GCs are frequent enough; we therefore need a small nursery (@-A256k@) plus
+-- @-T@ to enable "GHC.Stats". Baking a multi-word @-with-rtsopts@ through cabal
+-- is unreliable, so on first entry we set @GHCRTS@ and re-exec ourselves -- the
+-- child (built with @-rtsopts@) then picks those options up.
+module Main (main) where
+
+import           Control.Exception (evaluate)
+import           Control.Lens (lastOf)
+import           Control.Monad (unless, when)
+import qualified Data.ByteString.Lazy as BL
+import           Data.ByteString.Lazy.Lens (bytes)
+import           GHC.Stats (getRTSStats, getRTSStatsEnabled, max_live_bytes)
+import           System.Environment (getExecutablePath, lookupEnv, setEnv)
+import           System.Exit (exitFailure, exitWith)
+import           System.Mem (performMajorGC)
+import           System.Process (rawSystem)
+import           Text.Printf (printf)
+
+reexecVar :: String
+reexecVar = "LENS_SPACE_TEST_REEXEC"
+
+main :: IO ()
+main = do
+  reentered <- lookupEnv reexecVar
+  case reentered of
+    Just _  -> runTest
+    Nothing -> do
+      setEnv reexecVar "1"
+      setEnv "GHCRTS" "-T -A256k"
+      exe <- getExecutablePath
+      exitWith =<< rawSystem exe []
+
+-- | Drive 'lastOf' over the whole (lazily generated) ByteString. 'lastOf' must
+-- reach the end, so the entire structure is traversed.
+forceLast :: Int -> IO ()
+forceLast n = do
+  r <- evaluate (lastOf bytes (BL.replicate (fromIntegral n) 7))
+  unless (r == Just 7) (error ("space: unexpected lastOf result " ++ show r))
+
+-- | Peak live bytes observed so far (max over all major GCs).
+peakBytes :: IO Integer
+peakBytes = performMajorGC >> fmap (toInteger . max_live_bytes) getRTSStats
+
+runTest :: IO ()
+runTest = do
+  enabled <- getRTSStatsEnabled
+  if not enabled
+    then putStrLn "space: RTS stats unavailable (GHCRTS -T ignored?); skipping."
+    else do
+      let small =  50 * 1000 * 1000   --  50 MB
+          big   = 800 * 1000 * 1000   -- 800 MB (16x)
+          cap   =   2 * 1000 * 1000   --   2 MB slack (a leak grows by ~4 MB here)
+      forceLast small
+      p1 <- peakBytes
+      forceLast big
+      p2 <- peakBytes
+      let growth = p2 - p1
+      printf "lastOf bytes peak residency: %d B (50MB) -> %d B (800MB), growth %d B\n"
+             p1 p2 growth
+      when (growth > cap) $ do
+        printf "FAIL: residency grew %d B over a 16x input increase; lastOf over a lazy ByteString is leaking (issue #233).\n"
+               growth
+        exitFailure
+      putStrLn "OK: lastOf over a lazy ByteString streams in constant space."

--- a/tests/space.hs
+++ b/tests/space.hs
@@ -7,11 +7,14 @@
 -- apart) and assert that peak residency (from "GHC.Stats") does not grow: a
 -- streaming fold stays flat, a leaking one jumps by megabytes.
 --
--- The peak is transient (it lives only during the fold), so it is only sampled
--- if GCs are frequent enough; we therefore need a small nursery (@-A256k@) plus
--- @-T@ to enable "GHC.Stats". Baking a multi-word @-with-rtsopts@ through cabal
--- is unreliable, so on first entry we set @GHCRTS@ and re-exec ourselves -- the
--- child (built with @-rtsopts@) then picks those options up.
+-- The peak is transient (it only exists during the fold), so it is sampled
+-- reliably only if GCs are frequent: we need a small nursery (@-A256k@) and
+-- @-T@ to enable "GHC.Stats". A program cannot choose its own RTS options after
+-- startup, and baking a multi-word @-with-rtsopts@ through cabal is unreliable,
+-- so on first entry we re-exec ourselves passing those options as @+RTS@
+-- arguments (the executable is built with @-rtsopts@, so it accepts them). We
+-- pass them as arguments rather than via the @GHCRTS@ environment variable so as
+-- not to disturb any @GHCRTS@ the user may have set.
 module Main (main) where
 
 import           Control.Exception (evaluate)
@@ -20,25 +23,26 @@ import           Control.Monad (unless, when)
 import qualified Data.ByteString.Lazy as BL
 import           Data.ByteString.Lazy.Lens (bytes)
 import           GHC.Stats (getRTSStats, getRTSStatsEnabled, max_live_bytes)
-import           System.Environment (getExecutablePath, lookupEnv, setEnv)
+import           System.Environment (getArgs, getExecutablePath)
 import           System.Exit (exitFailure, exitWith)
 import           System.Mem (performMajorGC)
 import           System.Process (rawSystem)
 import           Text.Printf (printf)
 
-reexecVar :: String
-reexecVar = "LENS_SPACE_TEST_REEXEC"
+-- | Sentinel argument identifying the re-exec'd child. The RTS strips the
+-- @+RTS ... -RTS@ block from the child's arguments, so this is what is left to
+-- distinguish it from the initial invocation (and stops it re-exec'ing again).
+childArg :: String
+childArg = "--lens-space-test-child"
 
 main :: IO ()
 main = do
-  reentered <- lookupEnv reexecVar
-  case reentered of
-    Just _  -> runTest
-    Nothing -> do
-      setEnv reexecVar "1"
-      setEnv "GHCRTS" "-T -A256k"
+  args <- getArgs
+  if childArg `elem` args
+    then runTest
+    else do
       exe <- getExecutablePath
-      exitWith =<< rawSystem exe []
+      exitWith =<< rawSystem exe [childArg, "+RTS", "-T", "-A256k", "-RTS"]
 
 -- | Drive 'lastOf' over the whole (lazily generated) ByteString. 'lastOf' must
 -- reach the end, so the entire structure is traversed.
@@ -55,7 +59,7 @@ runTest :: IO ()
 runTest = do
   enabled <- getRTSStatsEnabled
   if not enabled
-    then putStrLn "space: RTS stats unavailable (GHCRTS -T ignored?); skipping."
+    then putStrLn "space: RTS stats unavailable (-T not in effect?); skipping."
     else do
       let small =  50 * 1000 * 1000   --  50 MB
           big   = 800 * 1000 * 1000   -- 800 MB (16x)


### PR DESCRIPTION
Closes #233 

### Problem

`lastOf bytes` (and other `Rightmost` folds) over a **lazy** `ByteString` retains memory proportional to the number of chunks instead of running in constant space. This is the lazy-`ByteString` case that #233 was reopened to track. It still reproduces on GHC 9.14.1:

```haskell
lastOf bytes (BL.replicate n 7)   -- peak residency grows ~linearly with n
```

### Root cause

The rewrite rules on `traversedLazy`/`traversedLazy8` route lazy-`ByteString` folds to a streaming `BL.foldr`-based implementation only at type `Getting (Endo r)` — i.e. the right-fold-shaped getters (`lengthOf`, `sumOf`, `toListOf`, …), which therefore already stream. `lastOf` uses the `Rightmost` monoid, which is **not** `Endo`-shaped, so it misses the rule and falls through to the general `traversedLazy`, whose `foldrChunks`/`<*>` builds a lazy thunk chain over the chunk spine.

(Lazy `Text` is unaffected: its `text` traversal routes through `unpacked . traversed`, i.e. the list traversal, which streams since GHC #7556.)

### Fix

Add a `Rightmost` rule mirroring the existing `Endo` one, dispatching `lastOf`-style folds to a strict `BL.foldl'`:

```haskell
"lastOf lazy bytestring"
  traversedLazy = lazyBytesRightmost :: Getting (Rightmost a) BL.ByteString Word8;
```

One subtlety: `Rightmost`'s `(<>)` always wraps its result in `RStep <thunk>`, and the thunk closes over the accumulator, so a naïve `foldl' (<>)` is actually *worse* (an O(n) thunk chain). Forcing the `RStep` payload one extra level drops that reference, giving constant space (`stepRightmost`).

**Soundness:** `Rightmost`'s `(<>)` is *not* value-level associative (left- vs right-nesting insert different numbers of `RStep` layers), so the strict left fold does not literally rebuild the same `Rightmost` value as the lawful right fold. It is sound nonetheless: the only consumer of `Getting (Rightmost a)` is `lastOf`, which observes the result solely through `getRightmost` — and `getRightmost` is invariant under re-association and extra `RStep` layers. The `seq` only forces, so the rewrite agrees with the lawful traversal on every observation `lastOf` can make. Short-circuiting folds (`firstOf`/`anyOf`, i.e. `Leftmost`/`Any`/`All`) are deliberately **not** rerouted: their laziness is load-bearing and they already stream by stopping early.

### Results (GHC 9.14.1, `lastOf bytes` over a lazy `ByteString`)

| input | before | after |
|---|---|---|
| 40 MB | ~100 KB | ~45 KB |
| 160 MB | ~1.1 MB | ~45 KB |
| 640 MB | ~4.2 MB | ~45 KB |

i.e. O(chunks) → O(1). `lengthOf`/`firstOf`/`anyOf` and lazy `Text` are unchanged (already constant-space).

### Regression test (`tests/space.hs`)

New `space` test suite that folds a lazy `ByteString` with `lastOf bytes` at two sizes (8k vs 128k chunks) and asserts peak residency (`GHC.Stats.max_live_bytes`) doesn't scale. Details:

- The input is built with `BL.fromChunks` from fixed-size 4 KiB chunks, so the chunk count — the quantity the leak actually scales with — is exact and independent of bytestring's internal chunking heuristics (which have varied across releases).
- The leak's peak is transient, so reliable sampling needs frequent GCs: the cabal stanza bakes in `-with-rtsopts=-T -A256k` (`-T` enables `GHC.Stats`, the small nursery makes GCs frequent enough to sample the peak).
- Because the suite would silently measure nothing if those options went missing, it verifies at startup (via `GHC.Stats`/`GHC.RTS.Flags`) that they are actually in effect and fails loudly otherwise. This also catches the case where an incremental build skips the relink after a link-flag-only change, leaving stale baked options.
- Validated both ways: with the fix, residency growth is **~1 KB** → PASS; with the fix reverted, **~4 MB** → FAIL.
- Behind a `test-space` cabal flag (default on), like the other suites, and gated to GHC ≥ 8.2 (where `GHC.Stats.getRTSStats` exists); depends on `base`, `bytestring`, `lens`.

### Caveats

- Targeted at `Rightmost` (the one strict-to-end built-in fold not covered by the `Endo` rule, i.e. `lastOf`). A user folding a lazy `ByteString` via `foldMapOf` with their *own* strict-to-end lazy monoid would still hit the general path; the built-in surface is covered.
