### PR TITLE
Add lens-build: type-level completeness-checked record builder

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -219,6 +219,7 @@ jobs:
           echo "packages: $GITHUB_WORKSPACE/source/." >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./examples" >> cabal.project
           echo "packages: $GITHUB_WORKSPACE/source/./lens-properties" >> cabal.project
+          echo "packages: $GITHUB_WORKSPACE/source/./lens-build" >> cabal.project
           cat cabal.project
       - name: sdist
         run: |
@@ -236,17 +237,22 @@ jobs:
           echo "PKGDIR_lens_examples=${PKGDIR_lens_examples}" >> "$GITHUB_ENV"
           PKGDIR_lens_properties="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/lens-properties-[0-9.]*')"
           echo "PKGDIR_lens_properties=${PKGDIR_lens_properties}" >> "$GITHUB_ENV"
+          PKGDIR_lens_build="$(find "$GITHUB_WORKSPACE/unpacked" -maxdepth 1 -type d -regex '.*/lens-build-[0-9.]*')"
+          echo "PKGDIR_lens_build=${PKGDIR_lens_build}" >> "$GITHUB_ENV"
           rm -f cabal.project cabal.project.local
           touch cabal.project
           touch cabal.project.local
           echo "packages: ${PKGDIR_lens}" >> cabal.project
           echo "packages: ${PKGDIR_lens_examples}" >> cabal.project
           echo "packages: ${PKGDIR_lens_properties}" >> cabal.project
+          echo "packages: ${PKGDIR_lens_build}" >> cabal.project
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens-examples" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens-properties" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "package lens-build" >> cabal.project ; fi
           if [ $((HCNUMVER >= 80200)) -ne 0 ] ; then echo "    ghc-options: -Werror=missing-methods -Werror=missing-fields" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package lens" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
@@ -254,12 +260,14 @@ jobs:
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package lens-properties" >> cabal.project ; fi
           if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "package lens-build" >> cabal.project ; fi
+          if [ $((HCNUMVER >= 90000)) -ne 0 ] ; then echo "    ghc-options: -Werror=incomplete-patterns -Werror=incomplete-uni-patterns" >> cabal.project ; fi
           cat >> cabal.project <<EOF
           EOF
           if $HEADHACKAGE; then
           echo "allow-newer: $($HCPKG list --simple-output | sed -E 's/([a-zA-Z-]+)-[0-9.]+/*:\1,/g')" >> cabal.project
           fi
-          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(lens|lens-examples|lens-properties)$/; }' >> cabal.project.local
+          $HCPKG list --simple-output --names-only | perl -ne 'for (split /\s+/) { print "constraints: any.$_ installed\n" unless /^(lens|lens-build|lens-examples|lens-properties)$/; }' >> cabal.project.local
           cat cabal.project
           cat cabal.project.local
       - name: dump install plan
@@ -293,6 +301,8 @@ jobs:
           cd ${PKGDIR_lens_examples} || false
           ${CABAL} -vnormal check
           cd ${PKGDIR_lens_properties} || false
+          ${CABAL} -vnormal check
+          cd ${PKGDIR_lens_build} || false
           ${CABAL} -vnormal check
       - name: haddock
         run: |

--- a/.github/workflows/hlint.yml
+++ b/.github/workflows/hlint.yml
@@ -41,3 +41,13 @@ jobs:
       with:
         path: examples/
         fail-on: suggestion
+
+    - name: 'HLint config (lens-build)'
+      run: |
+        cp lens-build/.hlint.yaml .
+
+    - name: 'Run HLint (lens-build)'
+      uses: haskell-actions/hlint-run@v2
+      with:
+        path: lens-build/src/
+        fail-on: suggestion

--- a/.github/workflows/negative-test.yml
+++ b/.github/workflows/negative-test.yml
@@ -1,0 +1,26 @@
+# Asserts lens-build's compile-time guarantees: invalid uses (an incomplete
+# `build`, and makeBuild on unsupported types) must FAIL to compile with our
+# custom messages. Kept separate from the generated haskell-ci.yml so
+# `haskell-ci regenerate` can't clobber it. One GHC is enough — the messages
+# are GHC-version-independent.
+name: Negative test (lens-build)
+on:
+  - push
+  - pull_request
+jobs:
+  negative:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up GHC
+        uses: haskell-actions/setup@v2
+        with:
+          ghc-version: '9.8'    # any >= 8.8
+
+      - name: Update package index
+        run: cabal update
+
+      - name: lens-build must reject invalid uses at compile time
+        run: sh lens-build/tests/negative/run.sh

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
 packages: .
           ./examples
           ./lens-properties
+          ./lens-build

--- a/lens-build/.hlint.yaml
+++ b/lens-build/.hlint.yaml
@@ -1,0 +1,4 @@
+- arguments: [--cpp-ansi]
+- ignore: { name: Use camelCase }
+- fixity: "infixr 9 ..."
+- fixity: "infixl 1 &~"

--- a/lens-build/CHANGELOG.markdown
+++ b/lens-build/CHANGELOG.markdown
@@ -1,0 +1,5 @@
+0.1.0.0
+-------
+* Initial release. A type-level, completeness-checked record builder
+  (`record`/`field`/`build`) plus the `makeBuild` Template Haskell generator,
+  exploring the "track partial construction in the type system" idea.

--- a/lens-build/LICENSE
+++ b/lens-build/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2026, Edward A. Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/lens-build/Setup.hs
+++ b/lens-build/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/lens-build/lens-build.cabal
+++ b/lens-build/lens-build.cabal
@@ -36,6 +36,14 @@ source-repository head
   type: git
   location: https://github.com/ekmett/lens.git
 
+flag build-negative-test
+  description:
+    Build the intentionally ill-typed negative-test executable (tests/negative),
+    which MUST fail to compile. Off by default so it never affects normal builds;
+    the negative-test workflow / tests/negative/run.sh turns it on.
+  default: False
+  manual:  True
+
 library
   -- Requires the template-haskell 2.15+ (GHC 8.8+) tySynEqn / tySynInstD API.
   if impl(ghc < 8.8)
@@ -67,4 +75,67 @@ test-suite builder
     lens       >= 4   && < 6,
     lens-build
   ghc-options: -Wall
+  default-language: Haskell2010
+
+-- The negative half of the test suite: this executable is *expected to fail to
+-- compile*. Each is gated behind the manual build-negative-test flag so normal
+-- builds, the sdist, and `cabal check` ignore them; tests/negative/run.sh
+-- enables the flag and asserts each compile fails with its expected message.
+--
+-- t-missing-field exercises the builder (an incomplete `build`); the t-* below
+-- exercise the makeBuild generator's guards on unsupported input.
+executable t-missing-field
+  main-is: TMissingField.hs
+  hs-source-dirs: tests/negative
+  if !flag(build-negative-test)
+    buildable: False
+  if impl(ghc < 8.8)
+    buildable: False
+
+  build-depends:
+    base       >= 4.9 && < 5,
+    lens       >= 4   && < 6,
+    lens-build
+  default-language: Haskell2010
+
+-- makeBuild on a sum type -> "single-constructor records only"
+executable t-sum-type
+  main-is: TSumType.hs
+  hs-source-dirs: tests/negative
+  if !flag(build-negative-test)
+    buildable: False
+  if impl(ghc < 8.8)
+    buildable: False
+
+  build-depends:
+    base       >= 4.9 && < 5,
+    lens-build
+  default-language: Haskell2010
+
+-- makeBuild on a positional (non-record) constructor -> "named fields is required"
+executable t-positional
+  main-is: TPositional.hs
+  hs-source-dirs: tests/negative
+  if !flag(build-negative-test)
+    buildable: False
+  if impl(ghc < 8.8)
+    buildable: False
+
+  build-depends:
+    base       >= 4.9 && < 5,
+    lens-build
+  default-language: Haskell2010
+
+-- makeBuild on a parameterized type -> "no type parameters"
+executable t-parameterized
+  main-is: TParameterized.hs
+  hs-source-dirs: tests/negative
+  if !flag(build-negative-test)
+    buildable: False
+  if impl(ghc < 8.8)
+    buildable: False
+
+  build-depends:
+    base       >= 4.9 && < 5,
+    lens-build
   default-language: Haskell2010

--- a/lens-build/lens-build.cabal
+++ b/lens-build/lens-build.cabal
@@ -1,0 +1,70 @@
+cabal-version: >= 1.10
+name:          lens-build
+category:      Data, Lenses
+version:       0.1.0.0
+license:       BSD3
+license-file:  LICENSE
+author:        Edward A. Kmett
+maintainer:    Edward A. Kmett <ekmett@gmail.com>
+stability:     experimental
+homepage:      http://github.com/ekmett/lens/
+bug-reports:   http://github.com/ekmett/lens/issues
+copyright:     Copyright (C) 2026 Edward A. Kmett
+synopsis:      Type-level, completeness-checked record construction for lens
+description:
+  A companion to @lens@ exploring the "track partial construction in the type
+  system" idea: build a record from lens-style field assignments where omitting
+  a field is a compile-time type error rather than a silent bottom.
+build-type:    Simple
+-- The type-level/TH machinery targets the template-haskell 2.15 (GHC 8.8) and
+-- later API; older GHCs are skipped via `buildable: False` below.
+tested-with:   GHC == 8.8.4
+             , GHC == 8.10.7
+             , GHC == 9.0.2
+             , GHC == 9.2.8
+             , GHC == 9.4.8
+             , GHC == 9.6.7
+             , GHC == 9.8.4
+             , GHC == 9.10.3
+             , GHC == 9.12.2
+             , GHC == 9.14.1
+
+extra-source-files:
+  CHANGELOG.markdown
+
+source-repository head
+  type: git
+  location: https://github.com/ekmett/lens.git
+
+library
+  -- Requires the template-haskell 2.15+ (GHC 8.8+) tySynEqn / tySynInstD API.
+  if impl(ghc < 8.8)
+    buildable: False
+
+  build-depends:
+    base             >= 4.9   && < 5,
+    lens             >= 4     && < 6,
+    template-haskell >= 2.15  && < 2.25,
+    th-abstraction   >= 0.4.1 && < 0.8
+
+  exposed-modules:
+    Control.Lens.Build
+    Control.Lens.Build.TH
+
+  hs-source-dirs: src
+  ghc-options: -Wall
+  default-language: Haskell2010
+
+test-suite builder
+  type: exitcode-stdio-1.0
+  main-is: builder.hs
+  hs-source-dirs: tests
+  if impl(ghc < 8.8)
+    buildable: False
+
+  build-depends:
+    base       >= 4.9 && < 5,
+    lens       >= 4   && < 6,
+    lens-build
+  ghc-options: -Wall
+  default-language: Haskell2010

--- a/lens-build/src/Control/Lens/Build.hs
+++ b/lens-build/src/Control/Lens/Build.hs
@@ -1,0 +1,140 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE ConstraintKinds #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Lens.Build
+-- Copyright   :  (C) 2026 Edward A. Kmett
+-- License     :  BSD-style (see the file LICENSE)
+-- Stability   :  experimental
+--
+-- Construct a single-constructor record from lens-style field assignments,
+-- where /omitting a field is a compile-time type error/. This is the
+-- "track partial construction in the type system" idea.
+--
+-- The set of fields assigned so far is carried in a phantom type-level list,
+-- and 'build' only type-checks once that list covers every field of the record.
+--
+-- > data Foo = Foo { _a :: Int, _b :: Bool } deriving (Eq, Show)
+-- > makeBuild ''Foo
+-- >
+-- > foo :: Foo
+-- > foo = record & field @"a" 1 & field @"b" True & build
+--
+-- Leaving out @field \@\"b\"@ is rejected at compile time with
+-- @build: missing field "b"@.
+--
+-- @makeBuild@ is self-contained — it does /not/ require @makeLenses@. The names
+-- @field@ accepts are derived with the same @_field -> field@ convention, so
+-- they line up with the lenses if you generate those too.
+-----------------------------------------------------------------------------
+module Control.Lens.Build
+  ( -- * Building a record
+    Builder
+  , record
+  , field
+  , build
+    -- * Per-record machinery
+    -- $generated
+  , RecordBuilder(..)
+  , SetField(..)
+    -- * Completeness checking
+  , Complete
+  , AllPresent
+  , Elem
+  ) where
+
+import Data.Kind (Constraint)
+import GHC.TypeLits (Symbol, TypeError, ErrorMessage(..))
+
+-- | A partially-built record @s@, tagged with the type-level list @set@ of the
+-- field names assigned so far.
+--
+-- It is a @newtype@ (a zero-cost wrapper, erased by the compiler to a
+-- coercion) over the record itself: the underlying value starts with every
+-- field bound to @undefined@ and gets overwritten field by field. The @set@
+-- index is a /phantom/ parameter — it never appears in a constructor field, so
+-- it carries compile-time information at no runtime cost.
+--
+-- The constructor is deliberately not exported: the only way to extract the
+-- record is 'build', which refuses to compile until every field is set, so no
+-- @undefined@ can escape.
+newtype Builder s (set :: [Symbol]) = Builder s
+
+-- | The supporting instances 'RecordBuilder' and 'SetField' are tedious to
+-- write by hand; @Control.Lens.Build.TH.'Control.Lens.Build.TH.makeBuild'@
+-- generates them from a record's declaration.
+
+-- | What 'build' needs to know about a record type: its full field list and a
+-- seed value with every field bound to @undefined@.
+class RecordBuilder s where
+  -- | All of @s@'s field names (lens-style, e.g. @\"a\"@ for @_a@), in
+  -- declaration order. An /associated type family/: a type-level function whose
+  -- result is fixed per instance, so @'AllFields' Foo@ reduces to @'[\"a\", \"b\"]@.
+  type AllFields s :: [Symbol]
+  -- | A value of @s@ with every field set to @undefined@. Safe to expose only
+  -- because 'build' guarantees each field is overwritten before extraction.
+  emptyRecord :: s
+
+-- | How to set one named field of @s@.
+class SetField s (name :: Symbol) where
+  -- | The type stored in field @name@, e.g. @'FieldVal' Foo \"a\"@ reduces to @Int@.
+  type FieldVal s name
+  -- | Overwrite field @name@ with a new value.
+  setField :: FieldVal s name -> s -> s
+
+-- | Start building: an empty 'Builder' with no fields assigned yet.
+record :: RecordBuilder s => Builder s '[]
+record = Builder emptyRecord
+
+-- | Assign one field, recording its name in the type-level @set@.
+--
+-- The field name is supplied by visible type application, e.g. @field \@\"a\" 1@.
+-- Because @name@ only appears in the constraints and result, the signature is
+-- ambiguous without that application (hence @AllowAmbiguousTypes@).
+field
+  :: forall name s set
+   . SetField s name
+  => FieldVal s name              -- ^ the new value for field @name@
+  -> Builder s set                -- ^ the record so far
+  -> Builder s (name ': set)      -- ^ same record, now with @name@ recorded as set
+field x (Builder r) = Builder (setField @s @name x r)
+
+-- | Finish building. Only type-checks when @set@ covers every field of @s@;
+-- otherwise GHC reports the first missing field by name.
+build :: Complete s set => Builder s set -> s
+build (Builder r) = r
+
+-- | The constraint "@set@ contains every field of @s@". Discharged when every
+-- required field is present; otherwise reduces to a 'TypeError'.
+type Complete s set = AllPresent (AllFields s) set
+
+-- | @'AllPresent' required set@ holds iff every name in @required@ also appears
+-- in @set@. A /closed type family/ returning a 'Constraint': it recurses over
+-- @required@, demanding each element be present.
+type family AllPresent (required :: [Symbol]) (set :: [Symbol]) :: Constraint where
+  AllPresent '[]       _   = ()
+  AllPresent (r ': rs) set = (Require r (Elem r set), AllPresent rs set)
+
+-- | Is @x@ an element of the type-level list @xs@? The second clause matches a
+-- repeated variable (@x@ in both positions), which a closed type family reads
+-- as a type-equality test.
+type family Elem (x :: Symbol) (xs :: [Symbol]) :: Bool where
+  Elem _ '[]       = 'False
+  Elem x (x ': _)  = 'True
+  Elem x (_ ': ys) = Elem x ys
+
+-- | Turn "field present?" into either a satisfied constraint or a friendly,
+-- hand-written 'TypeError' naming the missing field.
+type family Require (name :: Symbol) (present :: Bool) :: Constraint where
+  Require _    'True  = ()
+  Require name 'False =
+    TypeError ('Text "build: missing field " ':<>: 'ShowType name)

--- a/lens-build/src/Control/Lens/Build/TH.hs
+++ b/lens-build/src/Control/Lens/Build/TH.hs
@@ -1,0 +1,116 @@
+{-# LANGUAGE TemplateHaskellQuotes #-}
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Lens.Build.TH
+-- Copyright   :  (C) 2026 Edward A. Kmett
+-- License     :  BSD-style (see the file LICENSE)
+-- Stability   :  experimental
+--
+-- Template Haskell that generates the 'RecordBuilder' and 'SetField' instances
+-- consumed by "Control.Lens.Build". Run it once per record:
+--
+-- > data Foo = Foo { _a :: Int, _b :: Bool } deriving (Eq, Show)
+-- > makeBuild ''Foo
+--
+-- This is independent of @makeLenses@: the generated 'setField' uses record
+-- update, not lenses. The field names it accepts are derived with lens's own
+-- @_field -> field@ convention, so they coincide with the lenses if you also
+-- run @makeLenses@ — but that is alignment, not a dependency.
+--
+-- Limitations (kept deliberately small for a first cut): single-constructor
+-- /record/ types only, and /no type parameters/ — the field-seed trick also
+-- assumes lazy fields (a strict or unboxed field would force the @undefined@
+-- seed). 'makeBuild' fails with a clear message outside that scope.
+-----------------------------------------------------------------------------
+module Control.Lens.Build.TH
+  ( makeBuild
+  ) where
+
+import Language.Haskell.TH
+import Language.Haskell.TH.Datatype
+  ( reifyDatatype
+  , DatatypeInfo(..)
+  , ConstructorInfo(..)
+  , ConstructorVariant(..)
+  )
+
+import Control.Lens.TH (underscoreNoPrefixNamer, DefName(..))
+import Control.Lens.Build
+  ( RecordBuilder(AllFields, emptyRecord)
+  , SetField(FieldVal, setField)
+  )
+
+-- | Generate the 'RecordBuilder' and per-field 'SetField' instances for a
+-- single-constructor, monomorphic record type.
+makeBuild :: Name -> DecsQ
+makeBuild tyName = do
+  di <- reifyDatatype tyName
+  case datatypeInstTypes di of
+    (_:_) ->
+      fail "makeBuild: only monomorphic records (no type parameters) are supported"
+    [] -> case datatypeCons di of
+      [con] -> case constructorVariant con of
+        RecordConstructor fieldNames ->
+          buildInstances (datatypeName di) con fieldNames
+        _ ->
+          fail "makeBuild: a single record constructor with named fields is required"
+      _ ->
+        fail "makeBuild: single-constructor records only"
+
+-- | Emit @instance RecordBuilder T@ and one @instance SetField T \"f\"@ per field.
+buildInstances :: Name -> ConstructorInfo -> [Name] -> DecsQ
+buildInstances tyName con fieldNames = do
+  let conName    = constructorName con
+      fieldTypes = constructorFields con
+      -- lens-style names ("_a" -> "a"), matching what makeLenses produces.
+      lensNames  = [ lensStr tyName fieldNames f | f <- fieldNames ]
+  recDec  <- recordBuilderInstance tyName conName fieldNames lensNames
+  setDecs <- sequence
+    [ setFieldInstance tyName fname lname fty
+    | (fname, lname, fty) <- zip3 fieldNames lensNames fieldTypes
+    ]
+  return (recDec : setDecs)
+
+-- | The lens-style 'Symbol' for a field, via lens's own 'underscoreNoPrefixNamer'
+-- (so @field \@\"a\"@ lines up with the lens @a@). Falls back to the raw field
+-- name if the field doesn't fit the underscore convention.
+lensStr :: Name -> [Name] -> Name -> String
+lensStr tyName fieldNames fld =
+  case underscoreNoPrefixNamer tyName fieldNames fld of
+    (TopName n : _) -> nameBase n
+    _               -> nameBase fld
+
+-- | @instance RecordBuilder T where type AllFields T = '[...]; emptyRecord = T undefined ...@
+recordBuilderInstance :: Name -> Name -> [Name] -> [String] -> Q Dec
+recordBuilderInstance tyName conName fieldNames lensNames =
+  instanceD (cxt []) (conT ''RecordBuilder `appT` conT tyName)
+    [ tySynInstD $ tySynEqn Nothing
+        (conT ''AllFields `appT` conT tyName)
+        (promotedList [ litT (strTyLit s) | s <- lensNames ])
+    , funD 'emptyRecord
+        [ clause []
+            (normalB (recConE conName [ fieldExp f (varE 'undefined) | f <- fieldNames ]))
+            []
+        ]
+    ]
+
+-- | @instance SetField T \"f\" where type FieldVal T \"f\" = Ty; setField x r = r { _f = x }@
+setFieldInstance :: Name -> Name -> String -> Type -> Q Dec
+setFieldInstance tyName fname lname fty = do
+  x <- newName "x"
+  r <- newName "r"
+  instanceD (cxt [])
+    (conT ''SetField `appT` conT tyName `appT` litT (strTyLit lname))
+    [ tySynInstD $ tySynEqn Nothing
+        (conT ''FieldVal `appT` conT tyName `appT` litT (strTyLit lname))
+        (return fty)
+    , funD 'setField
+        [ clause [varP x, varP r]
+            (normalB (recUpdE (varE r) [ fieldExp fname (varE x) ]))
+            []
+        ]
+    ]
+
+-- | Build a promoted type-level list @'[t1, t2, ...]@ from a list of types.
+promotedList :: [TypeQ] -> TypeQ
+promotedList = foldr (\t ts -> promotedConsT `appT` t `appT` ts) promotedNilT

--- a/lens-build/tests/builder.hs
+++ b/lens-build/tests/builder.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+module Main (main) where
+
+import Control.Lens ((&), (^.))
+import Control.Lens.TH (makeLenses)
+import Control.Lens.Build (record, field, build)
+import Control.Lens.Build.TH (makeBuild)
+import System.Exit (exitFailure)
+
+-- Case 1: makeBuild stands on its own — no makeLenses for this type.
+data Bare = Bare { _p :: Int, _q :: Int } deriving (Eq, Show)
+makeBuild ''Bare
+
+bare :: Bare
+bare = record & field @"p" 1 & field @"q" 2 & build
+
+-- Case 2: with makeLenses too, the @"a" / @"b" names line up with the lenses,
+-- so we can read the built record back through them.
+data Foo = Foo { _a :: Int, _b :: Bool } deriving (Eq, Show)
+makeLenses ''Foo   -- generates lenses  a :: Lens' Foo Int,  b :: Lens' Foo Bool
+makeBuild  ''Foo   -- generates the RecordBuilder / SetField instances
+
+foo :: Foo
+foo = record
+    & field @"a" 1
+    & field @"b" True
+    & build
+
+main :: IO ()
+main
+  | bare == Bare 1 2            -- makeBuild works with no makeLenses in sight
+  , foo == Foo 1 True           -- the built record is what we asked for
+  , foo ^. a == 1, foo ^. b     -- and @"a" / @"b" match the makeLenses lenses
+  = putStrLn "lens-build: ok"
+  | otherwise = do
+      putStrLn ("lens-build: FAILED, got " ++ show bare ++ " / " ++ show foo)
+      exitFailure

--- a/lens-build/tests/negative/TMissingField.hs
+++ b/lens-build/tests/negative/TMissingField.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | A deliberately ill-typed fixture: it MUST NOT compile.
+--
+-- It is the negative half of the test suite — proof that 'build' rejects an
+-- incomplete record at compile time, with our custom message
+-- @build: missing field \"v\"@. The @build-negative-test@ Cabal flag gates this
+-- executable so it is never part of a normal build; @tests/negative/run.sh@
+-- turns the flag on and asserts that compiling it fails with that message.
+--
+-- Do not "fix" the missing field below — failing to compile is the point.
+module Main (main) where
+
+import Control.Lens ((&))
+import Control.Lens.Build (record, field, build)
+import Control.Lens.Build.TH (makeBuild)
+
+data P = P { _u :: Int, _v :: Int }
+makeBuild ''P
+
+-- | Omits field @\"v\"@. @Complete P '["u"]@ reduces via @Elem "v" '["u"] = 'False@
+-- to our @TypeError@, so GHC rejects this binding.
+oops :: P
+oops = record & field @"u" 1 & build
+
+main :: IO ()
+main = oops `seq` pure ()

--- a/lens-build/tests/negative/TParameterized.hs
+++ b/lens-build/tests/negative/TParameterized.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A deliberately rejected fixture: it MUST NOT compile.
+--
+-- 'makeBuild' supports monomorphic records only, so a type with a parameter
+-- must be rejected at splice time with
+-- @makeBuild: only monomorphic records (no type parameters) are supported@.
+-- Gated behind the @build-negative-test@ flag; see @tests/negative/run.sh@.
+module Main (main) where
+
+import Control.Lens.Build.TH (makeBuild)
+
+data Q a = Q { _w :: a }
+
+makeBuild ''Q
+
+main :: IO ()
+main = pure ()

--- a/lens-build/tests/negative/TPositional.hs
+++ b/lens-build/tests/negative/TPositional.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A deliberately rejected fixture: it MUST NOT compile.
+--
+-- 'makeBuild' needs /named/ fields, so a single positional constructor must be
+-- rejected at splice time with
+-- @makeBuild: a single record constructor with named fields is required@.
+-- Gated behind the @build-negative-test@ flag; see @tests/negative/run.sh@.
+module Main (main) where
+
+import Control.Lens.Build.TH (makeBuild)
+
+data N = N Int Int
+
+makeBuild ''N
+
+main :: IO ()
+main = pure ()

--- a/lens-build/tests/negative/TSumType.hs
+++ b/lens-build/tests/negative/TSumType.hs
@@ -1,0 +1,17 @@
+{-# LANGUAGE TemplateHaskell #-}
+
+-- | A deliberately rejected fixture: it MUST NOT compile.
+--
+-- 'makeBuild' supports single-constructor records only, so a sum type must be
+-- rejected at splice time with @makeBuild: single-constructor records only@.
+-- Gated behind the @build-negative-test@ flag; see @tests/negative/run.sh@.
+module Main (main) where
+
+import Control.Lens.Build.TH (makeBuild)
+
+data S = A | B
+
+makeBuild ''S
+
+main :: IO ()
+main = pure ()

--- a/lens-build/tests/negative/run.sh
+++ b/lens-build/tests/negative/run.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Negative tests for lens-build: each fixture below MUST fail to compile, with a
+# specific custom message. For each one we build the gated executable and assert
+# both that the build FAILS and that the failure is our message (not some
+# unrelated error). Run from the repository root.
+set -u
+
+fail=0
+
+# check <executable> <expected substring of the error message>
+check() {
+  target=$1
+  expected=$2
+  log=$(cabal build -fbuild-negative-test "lens-build:exe:$target" 2>&1)
+  if [ $? -eq 0 ]; then
+    printf '%s\n' "$log"
+    echo "FAILED [$target]: compiled, but it must be rejected."
+    fail=1
+    return
+  fi
+  if printf '%s\n' "$log" | grep -q "$expected"; then
+    echo "ok [$target]: rejected with '$expected'"
+  else
+    printf '%s\n' "$log"
+    echo "FAILED [$target]: compilation failed, but without the expected message '$expected'."
+    fail=1
+  fi
+}
+
+# Builder usage: an incomplete build.
+check t-missing-field 'missing field'
+# makeBuild generator guards on unsupported input.
+check t-sum-type      'single-constructor records only'
+check t-positional    'named fields is required'
+check t-parameterized 'no type parameters'
+
+if [ "$fail" -eq 0 ]; then
+  echo 'negative tests: all ok'
+  exit 0
+fi
+echo 'negative tests: FAILED'
+exit 1


### PR DESCRIPTION
Closes #286 

## How

- `Builder s (set :: [Symbol])` carries the set of assigned fields in a phantom type-level list. `build` only type-checks once a closed type family confirms `set` covers every field; otherwise it reduces to a hand-written `TypeError`.
- `makeBuild` (Template Haskell) reifies a record via `th-abstraction` and emits the `RecordBuilder` / `SetField` instances. It is independent of `makeLenses` - field names use the same `_field -> field` convention, so they line up.

## Scope and limitations

Single-constructor, monomorphic records with lazy fields. GHC >= 8.8 (older compilers are skipped via `buildable: False`).