### PR TITLE
Add homogeneousOf/homogeneous and their aliases sameOf/same

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,8 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
+* Add `sameOf`/`same` to `Control.Lens.Fold` for testing whether all targets of
+  a `Fold` are equal.
 * Add `Prefixed` and `Suffixed` instances for `ZipList`, `Seq`, and the boxed,
   strict, storable, primitive, and unboxed `Vector` types, bringing them to
   parity with the existing `Cons`/`Snoc` instances.

--- a/src/Control/Lens/Fold.hs
+++ b/src/Control/Lens/Fold.hs
@@ -84,6 +84,7 @@ module Control.Lens.Fold
   , asumOf, msumOf
   , concatMapOf, concatOf
   , elemOf, notElemOf
+  , sameOf, same
   , lengthOf
   , nullOf, notNullOf
   , firstOf, first1Of, lastOf, last1Of
@@ -1200,6 +1201,54 @@ elemOf l = anyOf l . (==)
 notElemOf :: Eq a => Getting All s a -> a -> s -> Bool
 notElemOf l = allOf l . (/=)
 {-# INLINE notElemOf #-}
+
+-- | Returns 'True' if all targets of a 'Fold' are equal to one another.
+--
+-- A 'Fold' with zero or one target is trivially uniform.
+--
+-- >>> sameOf both ('a','a')
+-- True
+--
+-- >>> sameOf both ('a','b')
+-- False
+--
+-- >>> sameOf (folded.folded.both.folded) [Just ("aaaa","aa"), Nothing, Just ("a","")]
+-- True
+--
+-- Only the targets are forced; an unexamined single target is never evaluated:
+--
+-- >>> sameOf both (Left (error "boom") :: Either Int Int)
+-- True
+--
+-- @
+-- 'sameOf' :: 'Eq' a => 'Getter' s a     -> s -> 'Bool'
+-- 'sameOf' :: 'Eq' a => 'Fold' s a       -> s -> 'Bool'
+-- 'sameOf' :: 'Eq' a => 'Lens'' s a      -> s -> 'Bool'
+-- 'sameOf' :: 'Eq' a => 'Iso'' s a       -> s -> 'Bool'
+-- 'sameOf' :: 'Eq' a => 'Traversal'' s a -> s -> 'Bool'
+-- 'sameOf' :: 'Eq' a => 'Prism'' s a     -> s -> 'Bool'
+-- @
+sameOf :: Eq a => Getting (Same a) s a -> s -> Bool
+sameOf l = getSame . foldMapOf l SameOne
+{-# INLINE sameOf #-}
+
+-- | Returns 'True' if all elements of a 'Foldable' container are equal.
+--
+-- >>> same [1,1,1]
+-- True
+--
+-- >>> same [1,2,1]
+-- False
+--
+-- >>> same []
+-- True
+--
+-- @
+-- 'same' ≡ 'sameOf' 'folded'
+-- @
+same :: (Foldable f, Eq a) => f a -> Bool
+same = sameOf folded
+{-# INLINE same #-}
 
 -- | Map a function over all the targets of a 'Fold' of a container and concatenate the resulting lists.
 --

--- a/src/Control/Lens/Internal/Fold.hs
+++ b/src/Control/Lens/Internal/Fold.hs
@@ -212,13 +212,13 @@ data Same a
   | SameDiffer  -- ^ at least two targets differed
 
 instance Eq a => Semigroup (Same a) where
-  SameDiffer <> _          = SameDiffer        -- short-circuit, lazy in the right
-  SameEmpty  <> y          = y
-  x          <> SameEmpty  = x
-  SameOne a  <> SameOne b
-    | a == b               = SameOne a
-  _          <> _          = SameDiffer
-  {-# INLINE (<>) #-}
+  SameDiffer    <> _          = SameDiffer       -- short-circuit, lazy in the right
+  SameEmpty     <> y          = y
+  x@(SameOne _) <> SameEmpty  = x
+  SameOne _     <> SameDiffer = SameDiffer
+  x@(SameOne a) <> SameOne b
+    | a == b                  = x                -- reuse x; no new allocation
+    | otherwise               = SameDiffer
 
 instance Eq a => Monoid (Same a) where
   mempty = SameEmpty
@@ -232,4 +232,3 @@ instance Eq a => Monoid (Same a) where
 getSame :: Same a -> Bool
 getSame SameDiffer = False
 getSame _          = True
-{-# INLINE getSame #-}

--- a/src/Control/Lens/Internal/Fold.hs
+++ b/src/Control/Lens/Internal/Fold.hs
@@ -23,6 +23,7 @@ module Control.Lens.Internal.Fold
   , Sequenced(..)
   , Leftmost(..), getLeftmost
   , Rightmost(..), getRightmost
+  , Same(..), getSame
   , ReifiedMonoid(..)
   -- * Semigroups for folding
   , NonEmptyDList(..)
@@ -198,3 +199,37 @@ getRightmost :: Rightmost a -> Maybe a
 getRightmost RPure = Nothing
 getRightmost (RLeaf a) = Just a
 getRightmost (RStep x) = getRightmost x
+
+------------------------------------------------------------------------------
+-- Same
+------------------------------------------------------------------------------
+
+-- | Used for 'Control.Lens.Fold.sameOf'. Tracks whether all targets seen so
+-- far agree on a single value.
+data Same a
+  = SameEmpty   -- ^ no targets yet ('mempty')
+  | SameOne a   -- ^ every target so far equals this value
+  | SameDiffer  -- ^ at least two targets differed
+
+instance Eq a => Semigroup (Same a) where
+  SameDiffer <> _          = SameDiffer        -- short-circuit, lazy in the right
+  SameEmpty  <> y          = y
+  x          <> SameEmpty  = x
+  SameOne a  <> SameOne b
+    | a == b               = SameOne a
+  _          <> _          = SameDiffer
+  {-# INLINE (<>) #-}
+
+instance Eq a => Monoid (Same a) where
+  mempty = SameEmpty
+  {-# INLINE mempty #-}
+#if !(MIN_VERSION_base(4,11,0))
+  mappend = (<>)
+  {-# INLINE mappend #-}
+#endif
+
+-- | 'True' unless two targets were found to differ.
+getSame :: Same a -> Bool
+getSame SameDiffer = False
+getSame _          = True
+{-# INLINE getSame #-}

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -418,6 +418,24 @@ case_suffixed_ziplist =
 case_suffixed_ziplist_review =
   suffixed (ZipList [3,4]) # ZipList [1,2 :: Int] @?= ZipList [1,2,3,4]
 
+case_same_eq = same [1,1,1::Int] @?= True
+
+case_same_differ = same [1,2,1::Int] @?= False
+
+case_same_empty = same ([]::[Int]) @?= True
+
+case_sameOf_pair_eq = sameOf both ('a','a') @?= True
+
+case_sameOf_pair_neq = sameOf both ('a','b') @?= False
+
+case_sameOf_nest =
+  sameOf (folded.folded.both.folded)
+    [Just ("aaaa","aa"), Nothing, Just ("a","")] @?= True
+
+-- laziness: the single un-compared target must not be forced
+case_sameOf_lazy =
+  sameOf both (Left (error "boom") :: Either Int Int) @?= True
+
 main :: IO ()
 main = defaultMain $
   testGroup "Main"
@@ -487,4 +505,11 @@ main = defaultMain $
   , testCase "prefixed ziplist review" case_prefixed_ziplist_review
   , testCase "suffixed ziplist" case_suffixed_ziplist
   , testCase "suffixed ziplist review" case_suffixed_ziplist_review
+  , testCase "same equal list" case_same_eq
+  , testCase "same differing list" case_same_differ
+  , testCase "same empty list" case_same_empty
+  , testCase "sameOf equal pair" case_sameOf_pair_eq
+  , testCase "sameOf unequal pair" case_sameOf_pair_neq
+  , testCase "sameOf nested fold" case_sameOf_nest
+  , testCase "sameOf lazy in unexamined target" case_sameOf_lazy
   ]


### PR DESCRIPTION
Closes #685.

## Summary

Adds a `Fold` consumer that tests whether **all targets are equal to one another** - the optics analogue of `Data.List.Extra.allSame`.

Four exports, all surfaced through the umbrella `Control.Lens`:

| Name | Type | Role |
|------|------|------|
| `homogeneousOf` | `Eq a => Getting (Same a) s a -> s -> Bool` | primary optic consumer |
| `homogeneous` | `(Foldable f, Eq a) => f a -> Bool` | `Foldable` convenience (`= homogeneousOf folded`) |
| `sameOf` | `Eq a => Getting (Same a) s a -> s -> Bool` | short alias for `homogeneousOf` |
| `same` | `(Foldable f, Eq a) => f a -> Bool` | short alias for `homogeneous` |

```haskell
>>> homogeneousOf both ('a','a')
True
>>> homogeneousOf both ('a','b')
False
>>> homogeneous [1,1,1]
True
>>> homogeneousOf both (Left (error "boom") :: Either Int Int)  -- single target never forced
True
```

## Naming

Both stems are single words: `homogeneous` (precise) and `same` (matches FP precedent). The `*Of` forms are the optic consumers; the bare forms are the `Foldable` conveniences @Icelandjack originally requested.

## Implementation

- New `Same` monoid in `Control.Lens.Internal.Fold`, beside `Leftmost`/`Rightmost`: a three-state accumulator `SameEmpty | SameOne a | SameDiffer`.
- The `Eq a =>` `Semigroup` orders `SameDiffer <> _ = SameDiffer` first so a negative result short-circuits and stays lazy in its right argument (per @Zemyla's note in the thread).
- The `Eq a` constraint flows into the consumer signatures, consistent with `elemOf`/`notElemOf`.
