### PR TITLE
Document that `ix` focuses at most one element

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,7 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
+* Document that `ix` focuses at most one element.
 
 5.3.6 [2026.01.10]
 ------------------

--- a/src/Control/Lens/At.hs
+++ b/src/Control/Lens/At.hs
@@ -213,6 +213,13 @@ type family IxValue (m :: Type) :: Type
 
 -- | Provides a simple 'Traversal' lets you 'traverse' the value at a given
 -- key in a 'Map' or element at an ordinal position in a list or 'Seq'.
+--
+-- An instance of 'Ixed' should provide an 'ix' that focuses /at most one/
+-- element: the value at the given index, when it is present. Equivalently,
+-- 'ix' should use only 'pure' and 'fmap', never '<*>', so that it could in
+-- principle run under any @Pointed@ functor rather than requiring a full
+-- 'Applicative'. For any type that also has an 'At' instance, this already
+-- follows from the law @'ix' k ≡ 'at' k '.' 'traverse'@.
 class Ixed m where
   -- |
   -- /NB:/ Setting the value of this 'Traversal' will only set the value in


### PR DESCRIPTION
Addresses #662.

Adds a law to the `Ixed` class Haddock: `ix k` should focus **at most one** element — the value at the given index, when present. Equivalently, `ix` uses only `pure`/`fmap` and never `<*>`, so it could in principle run under any `Pointed` functor rather than a full `Applicative`. For any type with an `At` instance this already follows from the existing law `ix k ≡ at k . traverse`.

Every existing `Ixed` instance in the library already satisfies this, so the change is documentation-only (no behaviour change). CHANGELOG updated.