### PR TITLE
Add makeLens and makePrism for one-off optic construction (#710)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,12 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
+* Add `makeLens` and `makePrism` to `Control.Lens.TH`. These build a single
+  optic, as an expression, for one record field or one data constructor (e.g.
+  `over $(makeLens '_field) f x` or `preview $(makePrism 'Ctor) x`), rather than
+  declaring optics for an entire type as `makeLenses`/`makePrisms` do. The optic
+  produced matches what the corresponding bulk generator would declare for that
+  field or constructor. (#710)
 
 5.3.6 [2026.01.10]
 ------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -1,6 +1,6 @@
 name:          lens
 category:      Data, Lenses, Generics
-version:       5.3.6
+version:       5.3.7
 license:       BSD2
 cabal-version: 1.18
 license-file:  LICENSE

--- a/src/Control/Lens/Internal/FieldTH.hs
+++ b/src/Control/Lens/Internal/FieldTH.hs
@@ -32,6 +32,7 @@ module Control.Lens.Internal.FieldTH
   , makeFieldOptics
   , makeFieldOpticsForDec
   , makeFieldOpticsForDec'
+  , makeFieldOpticExp
   , HasFieldClasses
   ) where
 
@@ -81,6 +82,37 @@ makeFieldOpticsForDec rules = (`evalStateT` Set.empty) . makeFieldOpticsForDec' 
 
 makeFieldOpticsForDec' :: LensRules -> Dec -> HasFieldClasses [Dec]
 makeFieldOpticsForDec' rules = makeFieldOpticsForDatatype rules <=< lift . D.normalizeDec
+
+-- | Build the field optic for a single record field as an /expression/, given
+-- that field's selector name. This is the engine behind
+-- 'Control.Lens.TH.makeLens'. It reuses the very same scaffold and clause
+-- generator as 'makeFieldOptics'\/'makeLenses', so the optic it produces is the
+-- one 'makeLenses' would declare for that field: an 'Control.Lens.Iso.Iso' for
+-- a sole single-field constructor, a 'Control.Lens.Traversal.Traversal' for a
+-- field absent from some constructors, and a 'Control.Lens.Lens' otherwise.
+--
+-- The generated clauses are bound in a @let@ so the result is an anonymous
+-- optic expression rather than a top-level declaration. Its type is left to be
+-- inferred at the splice site.
+makeFieldOpticExp :: LensRules -> Name {- ^ record field selector -} -> ExpQ
+makeFieldOpticExp rules fieldName =
+  do info <- D.reifyDatatype fieldName
+     let s    = datatypeTypeKinded info
+         cons = D.datatypeCons     info
+     fieldCons <- traverse normalizeConstructor cons
+     let allFields = toListOf (folded . _2 . folded . _1 . folded) fieldCons
+     unless (any sameField allFields) $
+       fail $ "makeLens: " ++ nameBase fieldName
+           ++ " is not a record field of " ++ nameBase (D.datatypeName info)
+     funNm <- newName "optic"
+     let defName = TopName funNm
+         assignDef mName | maybe False sameField mName = [(defName, mName)]
+                         | otherwise                   = []
+         defCons = over (traverse . _2 . traverse . _1) assignDef fieldCons
+     (opticType, _stab, scaffolds) <- buildScaffold rules s defCons defName
+     letE [funD funNm (makeFieldClauses rules opticType scaffolds)] (varE funNm)
+  where
+  sameField n = nameBase n == nameBase fieldName
 
 -- | Compute the field optics for a deconstructed datatype Dec
 -- When possible build an Iso otherwise build one optic per field.

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -188,6 +188,8 @@ makePrism conName =
 makeConsPrisms :: Type -> [NCon] -> Maybe Name -> DecsQ
 
 -- special case: single constructor, not classy -> make iso
+-- ('makePrism' has the corresponding single-constructor Iso case; keep the two
+-- in sync.)
 makeConsPrisms t [con@(NCon _ [] [] _)] Nothing = makeConIso t con
 
 -- top-level definitions

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -20,6 +20,7 @@ module Control.Lens.Internal.PrismTH
   ( makePrisms
   , makeClassyPrisms
   , makeDecPrisms
+  , makePrism
   ) where
 
 import Control.Applicative
@@ -148,6 +149,36 @@ makeDecPrisms normal dec =
              | otherwise = Just (D.datatypeName info)
          cons = D.datatypeCons info
      makeConsPrisms (datatypeTypeKinded info) (map normalizeCon cons) cls
+
+
+-- | Build a single optic for one data constructor, as an /expression/.
+-- This is the one-off counterpart to 'makePrisms': rather than declaring a
+-- @_Ctor@ for every constructor of a type, it splices in just the optic for
+-- the named constructor, with its type inferred at the use site.
+--
+-- The kind of optic produced matches what 'makePrisms' would generate for
+-- that constructor:
+--
+-- * a 'Control.Lens.Iso.Iso' when the constructor is the type's /only/
+--   constructor (and is not existential\/GADT-like);
+-- * a 'Control.Lens.Review.Review' for an existentially quantified or GADT
+--   constructor; and
+-- * a 'Control.Lens.Prism.Prism' otherwise.
+makePrism :: Name {- ^ Data constructor name -} -> ExpQ
+makePrism conName =
+  do info <- D.reifyDatatype conName
+     let t    = datatypeTypeKinded info
+         cons = map normalizeCon (D.datatypeCons info)
+     case cons of
+       -- A type with a single, non-existential constructor yields an Iso,
+       -- exactly as the special case in 'makeConsPrisms' does.
+       [con@(NCon _ [] [] _)] -> makeConIsoExp con
+       _ -> case List.find (\con -> view nconName con == conName) cons of
+              Just con -> do stab <- computeOpticType t cons con
+                             makeConOpticExp stab cons con
+              Nothing  -> fail $ "makePrism: " ++ nameBase conName
+                              ++ " is not a data constructor of "
+                              ++ nameBase (D.datatypeName info)
 
 
 -- | Generate prisms for the given type, normalized constructors, and

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -34,6 +34,9 @@ module Control.Lens.TH
   , makeClassyPrisms
   -- ** Wrapped
   , makeWrapped
+  -- * Constructing a Single Optic as an Expression
+  , makeLens
+  , makePrism
   -- * Constructing Lenses Given a Declaration Quote
   -- ** Lenses for data fields
   , declareLenses, declareLensesFor
@@ -286,6 +289,34 @@ classyRules_
 -- @
 makeLenses :: Name -> DecsQ
 makeLenses = makeFieldOptics lensRules
+
+-- | Build the optic for a single record field, as an /expression/, given that
+-- field's selector name. This is the one-off counterpart to 'makeLenses':
+-- rather than declaring an optic for every field of a type, it splices in just
+-- the one for the named field, with its type inferred at the use site.
+--
+-- The kind of optic produced matches what 'makeLenses' would declare for that
+-- field: an 'Lens' in the usual case, a 'Traversal' for a field that is absent
+-- from some constructors, and an 'Iso' for a type's sole single-field
+-- constructor.
+--
+-- /e.g./ given
+--
+-- @
+-- data Foo = Foo { _bar :: 'Int', _baz :: 'Char' }
+-- @
+--
+-- the splice @$('makeLens' '_bar)@ is a @'Lens'' Foo 'Int'@ and can be used
+-- directly:
+--
+-- @
+-- 'Control.Lens.Setter.over' $('makeLens' '_bar) (+1) (Foo 1 \'x\') == Foo 2 \'x\'
+-- @
+--
+-- The argument must name a record field (not a positional one), since that is
+-- how the focused field is identified.
+makeLens :: Name {- ^ Record field selector name -} -> ExpQ
+makeLens = makeFieldOpticExp lensRules
 
 -- | Make lenses and traversals for a type, and create a class when the
 -- type has no arguments.

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -378,6 +378,28 @@ case_correct_indexing_lazy_bytestring =
   map (\i -> LazyB.pack [1,2] ^? ix i) [-1..2]
     @?= [Nothing, Just 1, Just 2, Nothing]
 
+-- One-off optic construction (#710): the spliced optics behave as expected.
+case_oneoff_lens_view =
+  view $(makeLens '_x) (Point 3 4) @?= 3
+
+case_oneoff_lens_set =
+  (Point 3 4 & $(makeLens '_x) .~ 9) @?= Point 9 4
+
+case_oneoff_prism_preview_hit =
+  preview $(makePrism 'SCircle) (SCircle (Point 1 2) 5) @?= Just (Point 1 2, 5)
+
+case_oneoff_prism_preview_miss =
+  preview $(makePrism 'SCircle) SVoid @?= (Nothing :: Maybe (Point, Int))
+
+-- review then preview round-trips (Shape itself has no Eq instance).
+case_oneoff_prism_review_roundtrip =
+  preview $(makePrism 'SCircle) (review $(makePrism 'SCircle) (Point 1 2, 5))
+    @?= Just (Point 1 2, 5)
+
+case_oneoff_prism_nullary =
+  (has $(makePrism 'SVoid) SVoid, has $(makePrism 'SVoid) (SCircle origin 1))
+    @?= (True, False)
+
 main :: IO ()
 main = defaultMain $
   testGroup "Main"
@@ -436,4 +458,10 @@ main = defaultMain $
   , testCase "correct indexing lazy text" case_correct_indexing_lazy_text
   , testCase "correct indexing strict bytestring" case_correct_indexing_strict_bytestring
   , testCase "correct indexing lazy bytestring" case_correct_indexing_lazy_bytestring
+  , testCase "one-off lens view" case_oneoff_lens_view
+  , testCase "one-off lens set" case_oneoff_lens_set
+  , testCase "one-off prism preview hit" case_oneoff_prism_preview_hit
+  , testCase "one-off prism preview miss" case_oneoff_prism_preview_miss
+  , testCase "one-off prism review round-trip" case_oneoff_prism_review_roundtrip
+  , testCase "one-off prism nullary" case_oneoff_prism_nullary
   ]

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -476,5 +476,41 @@ declareFields [d|
     data T1032B = T1032B { t1032BB :: Int }
   |]
 
+-- One-off optic construction as expressions (#710) -------------------------
+-- Both 'makeLens' and 'makePrism' reify their argument, so each focused data
+-- type must already be in the type environment (i.e. defined above an
+-- intervening top-level splice) before the expression splice below reifies it.
+
+-- 'makeLens' agrees with 'makeLenses': a sole single-field constructor is an
+-- 'Iso'...
+oneOffBaz :: Iso (Bar a b c) (Bar a' b' c') (a, b) (a', b')
+oneOffBaz = $(makeLens '_baz)
+
+-- ...an ordinary field is a (type-changing) 'Lens'...
+oneOffQuaffle :: Lens (Quux a b) (Quux a' b') Int Int
+oneOffQuaffle = $(makeLens '_quaffle)
+
+-- ...a field shared by every constructor is a 'Lens''...
+oneOffGaffer :: Lens' (Quark a) a
+oneOffGaffer = $(makeLens '_gaffer)
+
+-- ...and a field absent from some constructors is a 'Traversal''.
+oneOffTape :: Traversal' (Quark a) a
+oneOffTape = $(makeLens '_tape)
+
+-- 'makePrism' agrees with 'makePrisms': type-changing 'Prism's for a sum...
+data Sum710 a b = L710 a | R710 b
+$(pure [])
+
+oneOffL :: Prism (Sum710 a b) (Sum710 c b) a c
+oneOffL = $(makePrism 'L710)
+
+oneOffR :: Prism (Sum710 a b) (Sum710 a c) b c
+oneOffR = $(makePrism 'R710)
+
+-- ...and an 'Iso' for a single-constructor type.
+oneOffWrap :: Iso (T997A a) (T997A b) a b
+oneOffWrap = $(makePrism 'MkT997A)
+
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -508,9 +508,25 @@ oneOffL = $(makePrism 'L710)
 oneOffR :: Prism (Sum710 a b) (Sum710 a c) b c
 oneOffR = $(makePrism 'R710)
 
--- ...and an 'Iso' for a single-constructor type.
+-- ...a simple (non-type-changing) 'Prism'' for a monomorphic constructor, and a
+-- multi-field constructor focusing a tuple. (The polymorphic 'Poly710' pins
+-- @a@ so the other two constructors stay simple.)
+data Tri710 a = Mono710 Int | Multi710 Char Bool | Poly710 a
+$(pure [])
+
+oneOffMono :: Prism' (Tri710 a) Int
+oneOffMono = $(makePrism 'Mono710)
+
+oneOffMulti :: Prism' (Tri710 a) (Char, Bool)
+oneOffMulti = $(makePrism 'Multi710)
+
+-- ...an 'Iso' for a single-constructor type...
 oneOffWrap :: Iso (T997A a) (T997A b) a b
 oneOffWrap = $(makePrism 'MkT997A)
+
+-- ...and a 'Review' for an existentially quantified constructor.
+oneOffReview :: Review ReviewTest a
+oneOffReview = $(makePrism 'ReviewTest)
 
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
Implements #710 ([API proposed here](https://github.com/ekmett/lens/issues/710#issuecomment-4653656014)): build a single optic via Template Haskell as an *expression*, rather than declaring optics for a whole type.

Two new exports in `Control.Lens.TH`:

```haskell
makeLens  :: Name -> ExpQ   -- $(makeLens '_field)  — a record-field selector
makePrism :: Name -> ExpQ   -- $(makePrism 'Ctor)   — a data constructor
```

```haskell
over    $(makeLens '_field) f x
preview $(makePrism 'Ctor)  x
```

Each reuses the existing generation internals (`buildScaffold`/`makeFieldClauses` and `computeOpticType`/`makeConOpticExp`), so the spliced optic matches what `makeLenses`/`makePrisms` would declare for that field or constructor — a `Lens`/`Traversal`/`Iso`, or a `Prism`/`Iso`/`Review`.
