### PR TITLE
Document that Seq is an instance of Cons and Snoc

### DIFF
--- a/src/Data/Sequence/Lens.hs
+++ b/src/Data/Sequence/Lens.hs
@@ -9,6 +9,19 @@
 -- Stability   :  experimental
 -- Portability :  non-portable
 --
+-- This module provides lenses, traversals, and isomorphisms for
+-- working with 'Seq'.
+--
+-- 'Seq' is an instance of 'Control.Lens.Cons.Cons' and
+-- 'Control.Lens.Cons.Snoc', so the prisms '_Cons' and '_Snoc', along
+-- with the other facilities in "Control.Lens.Cons", work on sequences.
+--
+-- >>> Seq.fromList [a,b,c] ^? _Cons
+-- Just (a,fromList [b,c])
+--
+-- >>> Seq.fromList [a,b,c] ^? _Snoc
+-- Just (fromList [a,b],c)
+--
 ----------------------------------------------------------------------------
 module Data.Sequence.Lens
   ( viewL, viewR


### PR DESCRIPTION
Closes #780.

`Data.Sequence.Lens` had an empty module description. This adds a note to the Haddock header pointing out that `Seq` is an instance of `Cons` and `Snoc`, so the `_Cons`/`_Snoc` prisms and the rest of `Control.Lens.Cons` work on sequences.

The wording and link style mirror the existing Cons/Snoc documentation in `Data.List.Lens`, and two doctest examples are included.