### PR TITLE
Add ioverA, an indexed version of overA

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -22,6 +22,8 @@ next [????.??.??]
   produced matches what the corresponding bulk generator would declare for that
   field or constructor. (#710)
 * Document the relationship between `filtered`, `has`/`anyOf`, and `noneOf`.
+* Add `ioverA` to `Control.Lens.Lens`, an indexed variant of `overA`. The
+  supplied arrow receives the index together with the old value as a pair.
 
 5.3.6 [2026.01.10]
 ------------------

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -108,6 +108,7 @@ module Control.Lens.Lens
 
   -- * Arrow operators
   , overA
+  , ioverA
 
   -- * ALens Combinators
   , storing
@@ -1248,6 +1249,39 @@ overA :: Arrow ar => LensLike (Context a b) s t a b -> ar a b -> ar s t
 overA l p = arr (\s -> let (Context f a) = l sell s in (f, a))
             >>> second p
             >>> arr (uncurry id)
+
+-- | 'Control.Lens.Setter.iover' for Arrows: 'overA' with access to the index.
+--
+-- Unlike 'Control.Lens.Setter.iover', 'ioverA' can't accept a simple
+-- 'Control.Lens.Setter.IndexedSetter', but requires a full indexed lens, or
+-- close enough. The arrow receives the index together with the old value as
+-- a pair. For example, viewing a @(name, salary)@ pair as a salary indexed
+-- by the name:
+--
+-- >>> let salaryOf = ilens id (\(name, _) new -> (name, new))
+-- >>> ioverA salaryOf (\(name, s) -> if name == "alice" then s + 500 else s) ("alice", 1000)
+-- ("alice",1500)
+--
+-- 'ioverA' accepts any 'Arrow', so the modification can be effectful — here
+-- a 'Kleisli' arrow over 'Maybe' vetoes raises for one employee:
+--
+-- >>> let raise = Kleisli (\(name, s) -> if name == "bob" then Nothing else Just (s + 500))
+-- >>> runKleisli (ioverA salaryOf raise) ("alice", 1000)
+-- Just ("alice",1500)
+-- >>> runKleisli (ioverA salaryOf raise) ("bob", 1000)
+-- Nothing
+--
+-- When you do not need access to the index, then 'overA' is more liberal in
+-- what it can accept.
+--
+-- @
+-- ioverA :: Arrow ar => IndexedLens i s t a b -> ar (i, a) b -> ar s t
+-- @
+ioverA :: Arrow ar => Over (Indexed i) (Context (i, a) b) s t a b -> ar (i, a) b -> ar s t
+ioverA l p = arr (\s -> let (Context f ia) = l (Indexed (curry (Context id))) s in (f, ia))
+             >>> second p
+             >>> arr (uncurry id)
+{-# INLINE ioverA #-}
 
 ------------------------------------------------------------------------------
 -- Indexed

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -20,6 +20,7 @@
 -----------------------------------------------------------------------------
 module Main (main) where
 
+import Control.Arrow (Kleisli (..))
 import Control.Lens
 import Data.Data.Lens (upon)
 import Control.Applicative (ZipList(..))
@@ -432,6 +433,20 @@ case_suffixed_ziplist =
 case_suffixed_ziplist_review =
   suffixed (ZipList [3,4]) # ZipList [1,2 :: Int] @?= ZipList [1,2,3,4]
 
+-- ioverA (#772): indexed `over` for Arrows. The arrow receives the index
+-- together with the old value as a pair.
+case_ioverA_function_arrow =
+  ioverA (ilens id (\(k, _) v' -> (k, v'))) (\(k, v) -> k + v) (3, 10)
+    @?= ((3, 13) :: (Int, Int))
+
+case_ioverA_kleisli_arrow =
+  runKleisli (ioverA (ilens id (\(k, _) v' -> (k, v'))) (Kleisli (\(k, v) -> [v, v + k]))) (3, 10)
+    @?= ([(3, 10), (3, 13)] :: [(Int, Int)])
+
+case_ioverA_type_changing =
+  ioverA (ilens id (\(k, _) v' -> (k, v'))) (\(k, v) -> show (k + v)) ((3, 10) :: (Int, Int))
+    @?= (3 :: Int, "13")
+
 main :: IO ()
 main = defaultMain $
   testGroup "Main"
@@ -505,4 +520,7 @@ main = defaultMain $
   , testCase "prefixed ziplist review" case_prefixed_ziplist_review
   , testCase "suffixed ziplist" case_suffixed_ziplist
   , testCase "suffixed ziplist review" case_suffixed_ziplist_review
+  , testCase "ioverA with function arrow" case_ioverA_function_arrow
+  , testCase "ioverA with Kleisli arrow" case_ioverA_kleisli_arrow
+  , testCase "ioverA type-changing" case_ioverA_type_changing
   ]


### PR DESCRIPTION
Closes #772.

The issue asks whether there is a technical reason `overA` has no indexed
version with the "obvious" signature

```haskell
ioverA :: Arrow ar => IndexedLensLike i (Context a b) s t a b -> ar (i, a) b -> ar s t
```

There is a small one: with `Context a b` as the functor, the index has nowhere
to escape — in an indexed optic the index travels in the profunctor
(`Indexed i`), and `Context`'s value slot only holds the focus `a`. Storing the
index–value *pair* in the hole instead makes it a four-line mirror of `overA`:

```haskell
ioverA :: Arrow ar => Over (Indexed i) (Context (i, a) b) s t a b -> ar (i, a) b -> ar s t
ioverA l p = arr (\s -> let (Context f ia) = l (Indexed (curry (Context id))) s in (f, ia))
             >>> second p
             >>> arr (uncurry id)
```

`Indexed (curry (Context id))` is the indexed analogue of `sell = Context id`,
and the optic runs only once, unlike the proof of concept in the issue thread.
`Over (Indexed i) f` follows the neighbouring indexed operators (`%%@~`, `<%@~`).