### PR TITLE
Re-add Control.Monad.Primitive.Lens

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -4,8 +4,7 @@ next [????.??.??]
   `lens` 4.9. It offers `Iso`s for the conversions in
   `Control.Monad.Primitive`: `prim` (between a `PrimBase` monad and its
   underlying `State#` representation, now type-changing), and the new `st`
-  and `io` (between a `PrimBase` monad and `ST`/`IO`, respectively). This
-  reintroduces the dependency on the `primitive` package.
+  and `io` (between a `PrimBase` monad and `ST`/`IO`, respectively).
 * Add `ReifiedReview` to `Control.Lens.Reified`.
 * Fix `Data.Data.Lens.upon` (and its variants) looping forever when nested,
   e.g. `(upon.view.upon) tail`.

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,11 @@
 next [????.??.??]
 -----------------
+* Re-add the `Control.Monad.Primitive.Lens` module, which was removed in
+  `lens` 4.9. It offers `Iso`s for the conversions in
+  `Control.Monad.Primitive`: `prim` (between a `PrimBase` monad and its
+  underlying `State#` representation, now type-changing), and the new `st`
+  and `io` (between a `PrimBase` monad and `ST`/`IO`, respectively). This
+  reintroduces the dependency on the `primitive` package.
 * Add `ReifiedReview` to `Control.Lens.Reified`.
 * Add `makeLens` and `makePrism` to `Control.Lens.TH`. These build a single
   optic, as an expression, for one record field or one data constructor (e.g.

--- a/lens.cabal
+++ b/lens.cabal
@@ -194,6 +194,7 @@ library
     kan-extensions                >= 5        && < 6,
     mtl                           >= 2.2.1    && < 2.4,
     parallel                      >= 3.2.1.0  && < 3.4,
+    primitive                     >= 0.6.4    && < 0.10,
     profunctors                   >= 5.5.2    && < 6,
     reflection                    >= 2.1      && < 3,
     semigroupoids                 >= 5.0.1    && < 7,
@@ -265,6 +266,7 @@ library
     Control.Lens.Wrapped
     Control.Lens.Zoom
     Control.Monad.Error.Lens
+    Control.Monad.Primitive.Lens
     Control.Parallel.Strategies.Lens
     Control.Seq.Lens
     Data.Array.Lens

--- a/src/Control/Monad/Primitive/Lens.hs
+++ b/src/Control/Monad/Primitive/Lens.hs
@@ -1,0 +1,100 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UnboxedTuples #-}
+#ifdef TRUSTWORTHY
+{-# LANGUAGE Trustworthy #-}
+#endif
+
+#include "lens-common.h"
+
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Control.Monad.Primitive.Lens
+-- Copyright   :  (C) 2014-2026 Edward Kmett
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+-- Stability   :  provisional
+-- Portability :  non-portable
+--
+-- 'Iso's witnessing the isomorphisms offered by "Control.Monad.Primitive".
+--
+-- The generic conversion between two 'PrimBase' monads that share a
+-- 'PrimState' (that is, 'primToPrim' or 'liftPrim') is not given its own
+-- name here: it is simply 'prim' composed with its own reverse. See 'prim'.
+--
+-- The @unsafe*@ conversions in "Control.Monad.Primitive" are deliberately
+-- omitted: they coerce between monads with different 'PrimState' tokens,
+-- and so do not form lawful 'Iso's.
+----------------------------------------------------------------------------
+module Control.Monad.Primitive.Lens
+  ( prim
+  , st
+  , io
+  ) where
+
+import Control.Lens
+import Control.Monad.Primitive
+import Control.Monad.ST (ST)
+import GHC.Exts (State#)
+
+-- $setup
+-- >>> import Control.Lens
+-- >>> import Control.Monad.ST (ST, RealWorld)
+
+-- | An 'Iso' between a 'PrimBase' monad and its underlying primitive
+-- state-transformer representation.
+--
+-- @
+-- 'view' 'prim' ≡ 'internal'
+-- 'review' 'prim' ≡ 'primitive'
+-- @
+--
+-- Composing this 'Iso' with its own reverse is the bidirectional
+-- 'PrimBase'-to-'PrimBase' specialization of 'primToPrim' (or 'liftPrim'),
+-- converting directly between any two 'PrimBase' monads that share a
+-- 'PrimState' token. 'st' and 'io' compose the same way.
+--
+-- @
+-- 'prim' '.' 'from' 'prim'
+--   :: ('PrimBase' m, 'PrimBase' n, 'PrimState' m ~ 'PrimState' n)
+--   => 'Iso' (m a) (m b) (n a) (n b)
+-- @
+--
+-- >>> (pure 5 :: IO Int) ^. prim . from prim :: IO Int
+-- 5
+prim :: PrimBase m
+     => Iso (m a) (m b)
+            (State# (PrimState m) -> (# State# (PrimState m), a #))
+            (State# (PrimState m) -> (# State# (PrimState m), b #))
+prim = iso internal primitive
+{-# INLINE prim #-}
+
+-- | An 'Iso' between a 'PrimBase' monad and the 'ST' monad with the same
+-- state token.
+--
+-- @
+-- 'view' 'st' ≡ 'primToST'
+-- 'review' 'st' ≡ 'stToPrim'
+-- @
+--
+-- >>> (pure 5 :: IO Int) ^. st . io
+-- 5
+st :: PrimBase m => Iso (m a) (m b) (ST (PrimState m) a) (ST (PrimState m) b)
+st = iso primToST stToPrim
+{-# INLINE st #-}
+
+-- | An 'Iso' between a 'PrimBase' monad whose state token is 'RealWorld'
+-- and 'IO'.
+--
+-- @
+-- 'view' 'io' ≡ 'primToIO'
+-- 'review' 'io' ≡ 'ioToPrim'
+-- @
+--
+-- >>> (pure 5 :: ST RealWorld Int) ^. io
+-- 5
+io :: (PrimBase m, PrimState m ~ RealWorld) => Iso (m a) (m b) (IO a) (IO b)
+io = iso primToIO ioToPrim
+{-# INLINE io #-}

--- a/src/Control/Monad/Primitive/Lens.hs
+++ b/src/Control/Monad/Primitive/Lens.hs
@@ -7,8 +7,6 @@
 {-# LANGUAGE Trustworthy #-}
 #endif
 
-#include "lens-common.h"
-
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Control.Monad.Primitive.Lens
@@ -62,7 +60,7 @@ import GHC.Exts (State#)
 --   => 'Iso' (m a) (m b) (n a) (n b)
 -- @
 --
--- >>> (pure 5 :: IO Int) ^. prim . from prim :: IO Int
+-- >>> (pure 5 :: ST RealWorld Int) ^. prim . from prim :: IO Int
 -- 5
 prim :: PrimBase m
      => Iso (m a) (m b)


### PR DESCRIPTION
Closes #819.

`Control.Monad.Primitive.Lens` was removed in lens 4.9 only to drop the `primitive` dependency — which is now pulled in transitively via `vector` anyway. This re-adds it with three lawful `Iso`s over the conversions in `Control.Monad.Primitive`:

- `prim` — between a `PrimBase` monad and its underlying `State# -> (# State#, a #)` representation (`iso internal primitive`). This is the original optic, now generalized to be type-changing.
- `st` — between a `PrimBase` monad and `ST` with the same state token (`iso primToST stToPrim`).
- `io` — between a `PrimBase` monad whose state token is `RealWorld` and `IO` (`iso primToIO ioToPrim`).

### Notes / decisions (happy to change any of these)

- `unsafe*` excluded. Those conversions coerce between different `PrimState` tokens and aren't lawful isos, so they're deliberately left out (noted in the module haddock).
- No name for the generic `PrimBase`↔`PrimBase` conversion: it's exactly `prim . from prim`, so it's documented on `prim` rather than exported separately. Easy to add a named optic if you'd prefer.
- Naming. `st`/`io` follow the "name the iso after what `view` yields" convention (`vector`, `generic`, …). `primST`/`primIO` is the obvious alternative if the short names feel too grabby.
- `prim` is type-changing (`Iso (m a) (m b) … …`) rather than the historical `Iso'`. Strictly more general; no back-compat concern after its long absence.
