### PR TITLE
Make Control.Lens.Profunctor's from* conversions take the canonical monomorphic optics

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,10 @@
 next [????.??.??]
 -----------------
+* Change `fromLens`, `fromIso`, and `fromPrism` in `Control.Lens.Profunctor` to
+  accept the canonical monomorphic optic types `ALens`, `AnIso`, and `APrism`,
+  matching `fromSetter`/`fromTraversal` which already take `ASetter`/`ATraversal`.
+  Full polymorphic `Lens`/`Iso`/`Prism` values are still accepted unchanged; only
+  code that relied on the previous ad-hoc representations needs adjusting.
 * Add `ReifiedReview` to `Control.Lens.Reified`.
 * Reduce the arity of `set`, `set'`, `partsOf`, `partsOf'`, `unsafePartsOf`,
   `unsafePartsOf'`, `mapAccumLOf`, `imapAccumLOf`, `auf`, `both`, and `both1` so

--- a/src/Control/Lens/Profunctor.hs
+++ b/src/Control/Lens/Profunctor.hs
@@ -30,9 +30,12 @@ import Prelude ()
 
 import Control.Lens.Internal.Prelude
 import Control.Lens.Type (Optic, LensLike)
-import Control.Lens.Internal.Context (Context (..), sell)
+import Control.Lens.Internal.Context (Context (..), runPretext, sell)
 import Control.Lens.Internal.Profunctor (WrappedPafb (..))
-import Control.Lens (ASetter, ATraversal, cloneTraversal, Settable)
+import Control.Lens
+  ( ALens, AnIso, APrism, ASetter, ATraversal
+  , cloneTraversal, withIso, withPrism, Settable
+  )
 import Data.Profunctor (Star (..))
 import Data.Profunctor.Mapping (Mapping (..))
 import Data.Profunctor.Traversing (Traversing (..))
@@ -40,53 +43,58 @@ import Data.Profunctor.Traversing (Traversing (..))
 -- | Profunctor optic.
 type OpticP p s t a b = p a b -> p s t
 
+-- $setup
+-- >>> import Control.Lens
+
 --------------------------------------------------------------------------------
 -- Conversion from Van Laarhoven optics
 --------------------------------------------------------------------------------
 
 -- | Converts a 'Control.Lens.Type.Lens' to a 'Profunctor'-based one.
 --
--- @
--- 'fromLens' :: 'Control.Lens.Type.Lens' s t a b -> LensP s t a b
--- @
-fromLens :: Strong p => LensLike (Context a b) s t a b -> OpticP p s t a b
-fromLens l p =
-  dimap
-    (\s -> let Context f a = l sell s in (f, a))
-    (uncurry id)
-    (second' p)
-
--- | Converts a 'Control.Lens.Type.Iso' to a 'Profunctor'-based one.
+-- The result is a 'Strong' profunctor optic: 'second'' carries the rebuild
+-- function alongside the focus, so a single @k 'sell' s@ yields both the focus
+-- and the setter in one pass.
 --
--- @
--- 'fromIso' :: 'Control.Lens.Type.Iso' s t a b -> IsoP s t a b
--- @
-fromIso :: Profunctor p => Optic p Identity s t a b -> OpticP p s t a b
-fromIso p pab = rmap runIdentity (p (rmap Identity pab))
+-- >>> fromLens _1 (+1) (3, "hello")
+-- (4,"hello")
+fromLens :: Strong p => ALens s t a b -> OpticP p s t a b
+fromLens k p = dimap project (uncurry id) (second' p)
+  where
+    project s = case runPretext (k sell s) (Context id) of
+      Context bt a -> (bt, a)
+
+-- | Converts an 'Control.Lens.Type.Iso' to a 'Profunctor'-based one.
+--
+-- An 'Control.Lens.Type.Iso' is just a pair of mutually inverse functions, so
+-- this is exactly a 'dimap' — it adds no profunctor structure of its own.
+--
+-- >>> fromIso (iso fromEnum toEnum) succ 'a' :: Char
+-- 'b'
+fromIso :: Profunctor p => AnIso s t a b -> OpticP p s t a b
+fromIso k = withIso k dimap
 
 -- | Converts a 'Control.Lens.Type.Prism' to a 'Profunctor'-based one.
 --
--- @
--- 'fromPrism' :: 'Control.Lens.Type.Prism' s t a b -> PrismP s t a b
--- @
-fromPrism :: Choice p => Optic p Identity s t a b -> OpticP p s t a b
-fromPrism p pab = rmap runIdentity (p (rmap Identity pab))
+-- The result is a 'Choice' profunctor optic: 'right'' runs the profunctor only
+-- on the matching branch, passing a non-match through to @t@ untouched.
+--
+-- >>> fromPrism _Just (+1) (Just 3)
+-- Just 4
+--
+-- >>> fromPrism _Just (+1) Nothing
+-- Nothing
+fromPrism :: Choice p => APrism s t a b -> OpticP p s t a b
+fromPrism k = withPrism k $ \bt seta ->
+  dimap seta (either id bt) . right'
 
 -- | Converts a 'Control.Lens.Type.Setter' to a 'Profunctor'-based one.
---
--- @
--- 'fromSetter' :: 'Control.Lens.Type.Setter' s t a b -> SetterP s t a b
--- @
 fromSetter :: Mapping p => ASetter s t a b -> OpticP p s t a b
 fromSetter s = roam s'
   where
     s' f = runIdentity . s (Identity . f)
 
 -- | Converts a 'Control.Lens.Type.Traversal' to a 'Profunctor'-based one.
---
--- @
--- 'fromTraversal' :: 'Control.Lens.Type.Traversal' s t a b -> TraversalP s t a b
--- @
 fromTraversal :: Traversing p => ATraversal s t a b -> OpticP p s t a b
 fromTraversal l = wander (cloneTraversal l)
 
@@ -95,41 +103,21 @@ fromTraversal l = wander (cloneTraversal l)
 --------------------------------------------------------------------------------
 
 -- | Obtain a 'Control.Lens.Type.Prism' from a 'Profunctor'-based one.
---
--- @
--- 'toPrism' :: PrismP s t a b -> 'Control.Lens.Type.Prism' s t a b
--- @
 toPrism :: (Choice p, Applicative f) => OpticP (WrappedPafb f p) s t a b -> Optic p f s t a b
 toPrism p = unwrapPafb . p . WrapPafb
 
 -- | Obtain a 'Control.Lens.Type.Iso' from a 'Profunctor'-based one.
---
--- @
--- 'toIso' :: IsoP s t a b -> 'Control.Lens.Type.Iso' s t a b
--- @
 toIso :: (Profunctor p, Functor f) => OpticP (WrappedPafb f p) s t a b -> Optic p f s t a b
 toIso p = unwrapPafb . p . WrapPafb
 
 -- | Obtain a 'Control.Lens.Type.Lens' from a 'Profunctor'-based one.
---
--- @
--- 'toLens' :: LensP s t a b -> 'Control.Lens.Type.Lens' s t a b
--- @
 toLens :: Functor f => OpticP (Star f) s t a b -> LensLike f s t a b
 toLens p = runStar . p . Star
 
 -- | Obtain a 'Control.Lens.Type.Setter' from a 'Profunctor'-based one.
---
--- @
--- 'toSetter' :: SetterP s t a b -> 'Control.Lens.Type.Setter' s t a b
--- @
 toSetter :: Settable f => OpticP (Star f) s t a b -> LensLike f s t a b
 toSetter p = runStar . p . Star
 
 -- | Obtain a 'Control.Lens.Type.Traversal' from a 'Profunctor'-based one.
---
--- @
--- 'toTraversal' :: TraversalP s t a b -> 'Control.Lens.Type.Traversal' s t a b
--- @
 toTraversal :: Applicative f => OpticP (Star f) s t a b -> LensLike f s t a b
 toTraversal p = runStar . p . Star

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -21,6 +21,7 @@
 module Main (main) where
 
 import Control.Lens
+import Control.Lens.Profunctor (fromLens, fromIso, fromPrism, fromSetter, fromTraversal)
 import Control.Monad.State
 import Data.Char
 import qualified Data.Text as StrictT
@@ -400,6 +401,43 @@ case_oneoff_prism_nullary =
   (has $(makePrism 'SVoid) SVoid, has $(makePrism 'SVoid) (SCircle origin 1))
     @?= (True, False)
 
+-- Control.Lens.Profunctor (#971): the from* conversions all take the canonical
+-- monomorphic optics, bound here with explicit A-types. For the three that #971
+-- changed -- fromLens, fromIso, fromPrism -- the A-type is one that their old
+-- signatures would have rejected, so these cases guard the change;
+-- fromSetter/fromTraversal already accepted ASetter/ATraversal. Exercised at the
+-- function profunctor (->), where an @OpticP (->) s t a b@ is @(a -> b) -> s -> t@
+-- (i.e. 'over').
+case_profunctor_fromLens =
+  fromLens l (+1) (3, "x") @?= (4, "x")
+  where l :: ALens (Int, String) (Int, String) Int Int
+        l = _1
+
+case_profunctor_fromIso =
+  fromIso i succ 'a' @?= 'b'
+  where i :: AnIso Char Char Int Int
+        i = iso fromEnum toEnum
+
+case_profunctor_fromPrism_match =
+  fromPrism p (+1) (Just 3) @?= Just 4
+  where p :: APrism (Maybe Int) (Maybe Int) Int Int
+        p = _Just
+
+case_profunctor_fromPrism_miss =
+  fromPrism p (+1) Nothing @?= Nothing
+  where p :: APrism (Maybe Int) (Maybe Int) Int Int
+        p = _Just
+
+case_profunctor_fromSetter =
+  fromSetter s (+1) [1,2,3] @?= [2,3,4]
+  where s :: ASetter [Int] [Int] Int Int
+        s = mapped
+
+case_profunctor_fromTraversal =
+  fromTraversal t (+1) [1,2,3] @?= [2,3,4]
+  where t :: ATraversal [Int] [Int] Int Int
+        t = traversed
+
 main :: IO ()
 main = defaultMain $
   testGroup "Main"
@@ -464,4 +502,10 @@ main = defaultMain $
   , testCase "one-off prism preview miss" case_oneoff_prism_preview_miss
   , testCase "one-off prism review round-trip" case_oneoff_prism_review_roundtrip
   , testCase "one-off prism nullary" case_oneoff_prism_nullary
+  , testCase "profunctor fromLens" case_profunctor_fromLens
+  , testCase "profunctor fromIso" case_profunctor_fromIso
+  , testCase "profunctor fromPrism (match)" case_profunctor_fromPrism_match
+  , testCase "profunctor fromPrism (miss)" case_profunctor_fromPrism_miss
+  , testCase "profunctor fromSetter" case_profunctor_fromSetter
+  , testCase "profunctor fromTraversal" case_profunctor_fromTraversal
   ]


### PR DESCRIPTION
Closes #971.

`fromSetter` and `fromTraversal` already take the canonical monomorphic optics (`ASetter`/`ATraversal`), but `fromLens`/`fromIso`/`fromPrism` took ad-hoc representations:

```haskell
-- before
fromLens  :: Strong p     => LensLike (Context a b) s t a b -> OpticP p s t a b
fromIso   :: Profunctor p => Optic p Identity s t a b       -> OpticP p s t a b
fromPrism :: Choice p     => Optic p Identity s t a b       -> OpticP p s t a b

-- after
fromLens  :: Strong p     => ALens  s t a b -> OpticP p s t a b
fromIso   :: Profunctor p => AnIso  s t a b -> OpticP p s t a b
fromPrism :: Choice p     => APrism s t a b -> OpticP p s t a b
```

All five `from*` are now uniform.

### Notes

- Backwards compatibility: full polymorphic `Lens`/`Iso`/`Prism` values still typecheck against `ALens`/`AnIso`/`APrism` (they're instantiations), so the common case is unaffected. Only code that passed the previous ad-hoc representations directly needs adjusting.
- `fromLens` stays single-pass: it's reimplemented over `ALens` via `runPretext (k sell s) (Context id)`, pulling the focus and rebuild function out of one traversal — matching the old `Context`-based implementation rather than routing through `withLens`, whose `^#`/`storing` would each re-traverse. `fromIso`/`fromPrism` use `withIso`/`withPrism`, which already return plain functions.
- Docs: dropped the `@ … @` pseudo-signature blocks across the module — they referenced undefined `LensP`/`IsoP`/… names; the now-clean real signatures plus added doctests are self-documenting.
- Tests: added HUnit cases exercising all five `from*` at the function profunctor `(->)`, with inputs bound to explicit `A`-types so the three changed conversions are guarded against regressing to the old signatures.

This is PVP-breaking (changed exported signatures); folded into 5.3.7 for now — let me know if you'd prefer a 5.4 bump.
