### PR TITLE
Add Prefixed and Suffixed instances for ZipList, Seq, and Vector

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,9 @@
 next [????.??.??]
 -----------------
 * Add `ReifiedReview` to `Control.Lens.Reified`.
+* Add `Prefixed` and `Suffixed` instances for `ZipList`, `Seq`, and the boxed,
+  strict, storable, primitive, and unboxed `Vector` types, bringing them to
+  parity with the existing `Cons`/`Snoc` instances.
 * Reduce the arity of `set`, `set'`, `partsOf`, `partsOf'`, `unsafePartsOf`,
   `unsafePartsOf'`, `mapAccumLOf`, `imapAccumLOf`, `auf`, `both`, and `both1` so
   that GHC is more eager to inline them, following up on the same change to the

--- a/lens.cabal
+++ b/lens.cabal
@@ -367,11 +367,14 @@ test-suite properties
   else
     build-depends:
       base,
+      containers,
       lens,
       QuickCheck >= 2.4,
+      quickcheck-instances >= 0.3.17 && < 0.5,
       tasty >= 1.4 && < 1.6,
       tasty-quickcheck >= 0.10 && < 0.12,
-      transformers
+      transformers,
+      vector
 
 test-suite hunit
   type: exitcode-stdio-1.0

--- a/src/Control/Lens/Prism.hs
+++ b/src/Control/Lens/Prism.hs
@@ -64,12 +64,26 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.List as List
 import Data.Profunctor.Rep
+import           Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
 import qualified Data.Text as TS
 import qualified Data.Text.Lazy as TL
+import           Data.Vector (Vector)
+import qualified Data.Vector as Vector
+import           Data.Vector.Primitive (Prim)
+import qualified Data.Vector.Primitive as Prim
+import           Data.Vector.Storable (Storable)
+import qualified Data.Vector.Storable as Storable
+import           Data.Vector.Unboxed (Unbox)
+import qualified Data.Vector.Unboxed as Unbox
+#if MIN_VERSION_vector(0,13,2)
+import qualified Data.Vector.Strict as VectorStrict
+#endif
 
 -- $setup
 -- >>> :set -XNoOverloadedStrings
 -- >>> import Control.Lens
+-- >>> import qualified Data.Sequence as Seq
 -- >>> import Numeric.Natural
 -- >>> import Debug.SimpleReflect.Expr
 -- >>> import Debug.SimpleReflect.Vars as Vars hiding (f,g)
@@ -385,6 +399,31 @@ _Show = prism show $ \s -> case reads s of
   _ -> Left s
 {-# INLINE _Show #-}
 
+-- | Strip a prefix from a sequence that provides O(1) 'length' and a slicing
+-- @splitAt@ (e.g. 'Seq' and the various 'Vector's), for use where there is no
+-- native @stripPrefix@. When the prefix is longer than the sequence, @splitAt@
+-- yields the whole sequence on the left, whose length then differs from the
+-- prefix, so the equality test fails and we correctly return 'Nothing'.
+splitPrefixed :: Eq s => (s -> Int) -> (Int -> s -> (s, s)) -> s -> s -> Maybe s
+splitPrefixed len splitAt_ p s = case splitAt_ (len p) s of
+  (h, t)
+    | h == p    -> Just t
+    | otherwise -> Nothing
+{-# INLINE splitPrefixed #-}
+
+-- | Strip a suffix from a sequence with O(1) 'length' and a slicing @splitAt@.
+-- The @n < 0@ guard handles a suffix longer than the sequence without relying
+-- on @splitAt@'s behaviour for out-of-range indices.
+splitSuffixed :: Eq s => (s -> Int) -> (Int -> s -> (s, s)) -> s -> s -> Maybe s
+splitSuffixed len splitAt_ q s
+  | n < 0     = Nothing
+  | otherwise = case splitAt_ n s of
+      (h, t)
+        | t == q    -> Just h
+        | otherwise -> Nothing
+  where n = len s - len q
+{-# INLINE splitSuffixed #-}
+
 class Prefixed t where
   -- | A 'Prism' stripping a prefix from a sequence when used as a 'Traversal',
   -- or prepending that prefix when run backwards:
@@ -397,6 +436,11 @@ class Prefixed t where
   --
   -- >>> prefixed "pre" # "amble"
   -- "preamble"
+  --
+  -- It is not limited to lists; for example it also works on a 'Seq':
+  --
+  -- >>> Seq.fromList [1,2,3,4] ^? prefixed (Seq.fromList [1,2])
+  -- Just (fromList [3,4])
   prefixed :: t -> Prism' t t
 
 instance Eq a => Prefixed [a] where
@@ -419,6 +463,37 @@ instance Prefixed BL.ByteString where
   prefixed p = prism' (p <>) (BL.stripPrefix p)
   {-# INLINE prefixed #-}
 
+instance Eq a => Prefixed (ZipList a) where
+  prefixed (ZipList ps) =
+    prism' (ZipList . (ps ++) . getZipList) (fmap ZipList . List.stripPrefix ps . getZipList)
+  {-# INLINE prefixed #-}
+
+instance Eq a => Prefixed (Seq a) where
+  prefixed p = prism' (p <>) (splitPrefixed Seq.length Seq.splitAt p)
+  {-# INLINE prefixed #-}
+
+instance Eq a => Prefixed (Vector a) where
+  prefixed p = prism' (p <>) (splitPrefixed Vector.length Vector.splitAt p)
+  {-# INLINE prefixed #-}
+
+instance (Prim a, Eq a) => Prefixed (Prim.Vector a) where
+  prefixed p = prism' (p <>) (splitPrefixed Prim.length Prim.splitAt p)
+  {-# INLINE prefixed #-}
+
+instance (Storable a, Eq a) => Prefixed (Storable.Vector a) where
+  prefixed p = prism' (p <>) (splitPrefixed Storable.length Storable.splitAt p)
+  {-# INLINE prefixed #-}
+
+instance (Unbox a, Eq a) => Prefixed (Unbox.Vector a) where
+  prefixed p = prism' (p <>) (splitPrefixed Unbox.length Unbox.splitAt p)
+  {-# INLINE prefixed #-}
+
+#if MIN_VERSION_vector(0,13,2)
+instance Eq a => Prefixed (VectorStrict.Vector a) where
+  prefixed p = prism' (p <>) (splitPrefixed VectorStrict.length VectorStrict.splitAt p)
+  {-# INLINE prefixed #-}
+#endif
+
 class Suffixed t where
   -- | A 'Prism' stripping a suffix from a sequence when used as a 'Traversal',
   -- or appending that suffix when run backwards:
@@ -431,6 +506,11 @@ class Suffixed t where
   --
   -- >>> suffixed ".o" # "hello"
   -- "hello.o"
+  --
+  -- It is not limited to lists; for example it also works on a 'Seq':
+  --
+  -- >>> Seq.fromList [1,2,3,4] ^? suffixed (Seq.fromList [3,4])
+  -- Just (fromList [1,2])
   suffixed :: t -> Prism' t t
 
 instance Eq a => Suffixed [a] where
@@ -452,3 +532,34 @@ instance Suffixed BS.ByteString where
 instance Suffixed BL.ByteString where
   suffixed qs = prism' (<> qs) (BL.stripSuffix qs)
   {-# INLINE suffixed #-}
+
+instance Eq a => Suffixed (ZipList a) where
+  suffixed (ZipList qs) =
+    prism' (ZipList . (++ qs) . getZipList) (fmap ZipList . List.stripSuffix qs . getZipList)
+  {-# INLINE suffixed #-}
+
+instance Eq a => Suffixed (Seq a) where
+  suffixed q = prism' (<> q) (splitSuffixed Seq.length Seq.splitAt q)
+  {-# INLINE suffixed #-}
+
+instance Eq a => Suffixed (Vector a) where
+  suffixed q = prism' (<> q) (splitSuffixed Vector.length Vector.splitAt q)
+  {-# INLINE suffixed #-}
+
+instance (Prim a, Eq a) => Suffixed (Prim.Vector a) where
+  suffixed q = prism' (<> q) (splitSuffixed Prim.length Prim.splitAt q)
+  {-# INLINE suffixed #-}
+
+instance (Storable a, Eq a) => Suffixed (Storable.Vector a) where
+  suffixed q = prism' (<> q) (splitSuffixed Storable.length Storable.splitAt q)
+  {-# INLINE suffixed #-}
+
+instance (Unbox a, Eq a) => Suffixed (Unbox.Vector a) where
+  suffixed q = prism' (<> q) (splitSuffixed Unbox.length Unbox.splitAt q)
+  {-# INLINE suffixed #-}
+
+#if MIN_VERSION_vector(0,13,2)
+instance Eq a => Suffixed (VectorStrict.Vector a) where
+  suffixed q = prism' (<> q) (splitSuffixed VectorStrict.length VectorStrict.splitAt q)
+  {-# INLINE suffixed #-}
+#endif

--- a/tests/hunit.hs
+++ b/tests/hunit.hs
@@ -21,6 +21,7 @@
 module Main (main) where
 
 import Control.Lens
+import Control.Applicative (ZipList(..))
 import Control.Monad.State
 import Data.Char
 import qualified Data.Text as StrictT
@@ -400,6 +401,23 @@ case_oneoff_prism_nullary =
   (has $(makePrism 'SVoid) SVoid, has $(makePrism 'SVoid) (SCircle origin 1))
     @?= (True, False)
 
+-- ZipList has no QuickCheck Arbitrary/CoArbitrary/Function instances, so its
+-- Prefixed/Suffixed instances are exercised here rather than in properties.hs.
+case_prefixed_ziplist =
+  ZipList [1,2,3,4 :: Int] ^? prefixed (ZipList [1,2]) @?= Just (ZipList [3,4])
+
+case_prefixed_ziplist_miss =
+  ZipList [1,2,3 :: Int] ^? prefixed (ZipList [2,3]) @?= Nothing
+
+case_prefixed_ziplist_review =
+  prefixed (ZipList [1,2]) # ZipList [3,4 :: Int] @?= ZipList [1,2,3,4]
+
+case_suffixed_ziplist =
+  ZipList [1,2,3,4 :: Int] ^? suffixed (ZipList [3,4]) @?= Just (ZipList [1,2])
+
+case_suffixed_ziplist_review =
+  suffixed (ZipList [3,4]) # ZipList [1,2 :: Int] @?= ZipList [1,2,3,4]
+
 main :: IO ()
 main = defaultMain $
   testGroup "Main"
@@ -464,4 +482,9 @@ main = defaultMain $
   , testCase "one-off prism preview miss" case_oneoff_prism_preview_miss
   , testCase "one-off prism review round-trip" case_oneoff_prism_review_roundtrip
   , testCase "one-off prism nullary" case_oneoff_prism_nullary
+  , testCase "prefixed ziplist" case_prefixed_ziplist
+  , testCase "prefixed ziplist miss" case_prefixed_ziplist_miss
+  , testCase "prefixed ziplist review" case_prefixed_ziplist_review
+  , testCase "suffixed ziplist" case_suffixed_ziplist
+  , testCase "suffixed ziplist review" case_suffixed_ziplist_review
   ]

--- a/tests/properties.hs
+++ b/tests/properties.hs
@@ -34,6 +34,17 @@ import GHC.Exts (Constraint)
 import Numeric (showHex, showOct, showSigned)
 import Numeric.Lens
 import Control.Lens.Properties (isIso, isLens, isPrism, isSetter, isTraversal)
+import Data.Sequence (Seq)
+import Test.QuickCheck.Instances ()
+#if MIN_VERSION_quickcheck_instances(0,3,32)
+import Data.Vector (Vector)
+import qualified Data.Vector.Primitive as Prim
+import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Unboxed as Unbox
+#if MIN_VERSION_vector(0,13,2) && MIN_VERSION_quickcheck_instances(0,3,33)
+import qualified Data.Vector.Strict as VectorStrict
+#endif
+#endif
 
 #include "lens-common.h"
 
@@ -80,6 +91,29 @@ prop__Just                           = isPrism (_Just :: Prism' (Maybe Int) Int)
 
 -- Data.List.Lens
 prop_prefixed s                      = isPrism (prefixed s :: Prism' String String)
+prop_suffixed s                      = isPrism (suffixed s :: Prism' String String)
+
+-- Control.Lens.Prism: Prefixed/Suffixed for other sequences.
+-- Seq's Arbitrary/CoArbitrary/Function come from QuickCheck itself; the Vector
+-- instances come from quickcheck-instances (primitive added in 0.3.32, strict
+-- in 0.3.33), so the Vector properties are gated on its version.
+prop_prefixed_seq (s :: Seq Int)     = isPrism (prefixed s :: Prism' (Seq Int) (Seq Int))
+prop_suffixed_seq (s :: Seq Int)     = isPrism (suffixed s :: Prism' (Seq Int) (Seq Int))
+
+#if MIN_VERSION_quickcheck_instances(0,3,32)
+prop_prefixed_vector (s :: Vector Int)            = isPrism (prefixed s :: Prism' (Vector Int) (Vector Int))
+prop_suffixed_vector (s :: Vector Int)            = isPrism (suffixed s :: Prism' (Vector Int) (Vector Int))
+prop_prefixed_uvector (s :: Unbox.Vector Int)     = isPrism (prefixed s :: Prism' (Unbox.Vector Int) (Unbox.Vector Int))
+prop_suffixed_uvector (s :: Unbox.Vector Int)     = isPrism (suffixed s :: Prism' (Unbox.Vector Int) (Unbox.Vector Int))
+prop_prefixed_svector (s :: Storable.Vector Int)  = isPrism (prefixed s :: Prism' (Storable.Vector Int) (Storable.Vector Int))
+prop_suffixed_svector (s :: Storable.Vector Int)  = isPrism (suffixed s :: Prism' (Storable.Vector Int) (Storable.Vector Int))
+prop_prefixed_pvector (s :: Prim.Vector Int)      = isPrism (prefixed s :: Prism' (Prim.Vector Int) (Prim.Vector Int))
+prop_suffixed_pvector (s :: Prim.Vector Int)      = isPrism (suffixed s :: Prism' (Prim.Vector Int) (Prim.Vector Int))
+#if MIN_VERSION_vector(0,13,2) && MIN_VERSION_quickcheck_instances(0,3,33)
+prop_prefixed_strictvector (s :: VectorStrict.Vector Int) = isPrism (prefixed s :: Prism' (VectorStrict.Vector Int) (VectorStrict.Vector Int))
+prop_suffixed_strictvector (s :: VectorStrict.Vector Int) = isPrism (suffixed s :: Prism' (VectorStrict.Vector Int) (VectorStrict.Vector Int))
+#endif
+#endif
 
 -- Data.Text.Lens
 prop_text s                          = s^.Text.packed.from Text.packed == s
@@ -152,6 +186,23 @@ main = defaultMain $
   , testProperty " Right" prop__Right
   , testProperty " Just" prop__Just
   , testProperty "prefixed" prop_prefixed
+  , testProperty "suffixed" prop_suffixed
+  , testProperty "prefixed seq" prop_prefixed_seq
+  , testProperty "suffixed seq" prop_suffixed_seq
+#if MIN_VERSION_quickcheck_instances(0,3,32)
+  , testProperty "prefixed vector" prop_prefixed_vector
+  , testProperty "suffixed vector" prop_suffixed_vector
+  , testProperty "prefixed unboxed vector" prop_prefixed_uvector
+  , testProperty "suffixed unboxed vector" prop_suffixed_uvector
+  , testProperty "prefixed storable vector" prop_prefixed_svector
+  , testProperty "suffixed storable vector" prop_suffixed_svector
+  , testProperty "prefixed primitive vector" prop_prefixed_pvector
+  , testProperty "suffixed primitive vector" prop_suffixed_pvector
+#if MIN_VERSION_vector(0,13,2) && MIN_VERSION_quickcheck_instances(0,3,33)
+  , testProperty "prefixed strict vector" prop_prefixed_strictvector
+  , testProperty "suffixed strict vector" prop_suffixed_strictvector
+#endif
+#endif
   , testProperty "text" prop_text
   , testProperty "base show" prop_base_show
   , testProperty "base read" prop_base_read


### PR DESCRIPTION
Closes #989.

Implements the `Prefixed`/`Suffixed` instances requested there for the sequence types that already have `Cons`/`Snoc` instances (`Deque` excepted, per the issue).

### Implementation

`Seq` and the `Vector`s have no native `stripPrefix`/`stripSuffix`, but they do have O(1) `length` and a slicing `splitAt`, so two small shared helpers implement the strip via `splitAt` + `length` + `(==)`:

```haskell
splitPrefixed :: Eq s => (s -> Int) -> (Int -> s -> (s, s)) -> s -> s -> Maybe s
splitSuffixed :: Eq s => (s -> Int) -> (Int -> s -> (s, s)) -> s -> s -> Maybe s
```

`ZipList` reuses the existing list logic through the newtype. The strict-boxed `Vector` instance is gated on `MIN_VERSION_vector(0,13,2)`.