### PR TITLE
Extract Plated into standalone `plated` and `plated-instances` packages (#993)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,21 @@
 next [????.??.??]
 -----------------
+* Move the `Plated` class, the `[]`/`Tree` instances, and the `Generic`-based
+  `gplate`/`gplate1` (with the `GPlated`/`GPlated1` classes) into a new `plated`
+  package (depending only on `base` and `containers`), and the `Plated`
+  instances for the `free`/`comonad` type families into a companion
+  `plated-instances` package. Both are re-exported from `Control.Lens.Plated`,
+  so existing `import Control.Lens` / `import Control.Lens.Plated` code keeps
+  working, including empty `instance Plated T` declarations that rely on the
+  `Data`-based default. The split lets other libraries provide `Plated`
+  instances for their types depending only on `base` and `containers` (a GHC
+  boot library), instead of all of `lens`.
+  One behavioral note: the `Data`-based default for `plate` is now backed by a
+  portable `uniplate` defined in `plated` rather than the oracle-optimized
+  `Data.Data.Lens.uniplate`. The two compute the same traversal, but the
+  `plated` default can be slower on deeply nested non-matching structure; write
+  `plate = uniplate` (from `Data.Data.Lens`) explicitly to keep the optimized
+  version where it matters.
 * Add `ReifiedReview` to `Control.Lens.Reified`.
 * Reduce the arity of `set`, `set'`, `partsOf`, `partsOf'`, `unsafePartsOf`,
   `unsafePartsOf'`, `mapAccumLOf`, `imapAccumLOf`, `auf`, `both`, and `both1` so

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
 packages: .
           ./examples
           ./lens-properties
+          ./plated
+          ./plated-instances

--- a/lens.cabal
+++ b/lens.cabal
@@ -198,6 +198,8 @@ library
     kan-extensions                >= 5        && < 6,
     mtl                           >= 2.2.1    && < 2.4,
     parallel                      >= 3.2.1.0  && < 3.4,
+    plated                        >= 0.1      && < 0.2,
+    plated-instances              >= 0.1      && < 0.2,
     profunctors                   >= 5.5.2    && < 6,
     reflection                    >= 2.1      && < 3,
     semigroupoids                 >= 5.0.1    && < 7,

--- a/plated-instances/CHANGELOG.markdown
+++ b/plated-instances/CHANGELOG.markdown
@@ -1,0 +1,7 @@
+0.1
+---
+
+* Initial release. Provides the orphan `Plated` instances (for the class in the
+  `plated` package) for the `free` and `comonad` type families: `Free`, `FreeT`,
+  `F`, `Cofree`, and `CofreeT`. Split out of the `plated` package so that
+  depending on the `Plated` class itself does not pull in `free`/`comonad`.

--- a/plated-instances/LICENSE
+++ b/plated-instances/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2012-2016 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/plated-instances/plated-instances.cabal
+++ b/plated-instances/plated-instances.cabal
@@ -1,0 +1,54 @@
+name:          plated-instances
+category:      Data, Generics
+version:       0.1
+license:       BSD2
+cabal-version: 1.18
+license-file:  LICENSE
+author:        Edward A. Kmett
+maintainer:    Edward A. Kmett <ekmett@gmail.com>
+stability:     provisional
+homepage:      http://github.com/ekmett/lens/
+bug-reports:   http://github.com/ekmett/lens/issues
+copyright:     Copyright (C) 2012-2016 Edward A. Kmett
+synopsis:      Plated instances for the free and comonad type families
+description:
+  Orphan @Plated@ instances (for the class in the @plated@ package) for the
+  @free@ and @comonad@ type families: @Free@, @FreeT@, @F@, @Cofree@, and
+  @CofreeT@. Kept separate so that depending on the @Plated@ class itself does
+  not pull in @free@/@comonad@. Importing @Data.Plated.Instances@ brings the
+  instances into scope.
+build-type:    Simple
+tested-with:   GHC == 8.0.2
+             , GHC == 8.2.2
+             , GHC == 8.4.4
+             , GHC == 8.6.5
+             , GHC == 8.8.4
+             , GHC == 8.10.7
+             , GHC == 9.0.2
+             , GHC == 9.2.8
+             , GHC == 9.4.8
+             , GHC == 9.6.7
+             , GHC == 9.8.4
+             , GHC == 9.10.3
+             , GHC == 9.12.2
+             , GHC == 9.14.1
+extra-source-files:
+  CHANGELOG.markdown
+
+source-repository head
+  type: git
+  location: https://github.com/ekmett/lens.git
+
+library
+  build-depends:
+    base       >= 4.9      && < 5,
+    comonad    >= 5.0.7    && < 6,
+    free       >= 5.1.5    && < 6,
+    plated     >= 0.1      && < 0.2
+
+  exposed-modules:
+    Data.Plated.Instances
+
+  hs-source-dirs: src
+  ghc-options: -Wall -Wno-orphans
+  default-language: Haskell2010

--- a/plated-instances/src/Data/Plated/Instances.hs
+++ b/plated-instances/src/Data/Plated/Instances.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Plated.Instances
+-- Copyright   :  (C) 2012-16 Edward Kmett
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+-- Stability   :  provisional
+-- Portability :  non-portable
+--
+-- Orphan 'Plated' instances for the @free@ and @comonad@ type families
+-- (@Free@, @FreeT@, @F@, @Cofree@, @CofreeT@).
+--
+-- These are kept out of the @plated@ package so that depending on the 'Plated'
+-- class does not drag in @free@/@comonad@. Importing this module (even as
+-- @import Data.Plated.Instances ()@) brings the instances into scope.
+-------------------------------------------------------------------------------
+module Data.Plated.Instances () where
+
+import Data.Plated (Plated(..))
+
+import Control.Comonad.Cofree (Cofree(..))
+import qualified Control.Comonad.Trans.Cofree as CoTrans
+import Control.Monad.Free as Monad
+import Control.Monad.Free.Church as Church
+import Control.Monad.Trans.Free as Trans
+
+instance Traversable f => Plated (Monad.Free f a) where
+  plate f (Monad.Free as) = Monad.Free <$> traverse f as
+  plate _ x         = pure x
+
+instance (Traversable f, Traversable m) => Plated (Trans.FreeT f m a) where
+  plate f (Trans.FreeT xs) = Trans.FreeT <$> traverse (traverse f) xs
+
+instance Traversable f => Plated (Church.F f a) where
+  plate f = fmap Church.toF . plate (fmap Church.fromF . f . Church.toF) . Church.fromF
+
+instance (Traversable f, Traversable w) => Plated (CoTrans.CofreeT f w a) where
+  plate f (CoTrans.CofreeT xs) = CoTrans.CofreeT <$> traverse (traverse f) xs
+
+instance Traversable f => Plated (Cofree f a) where
+  plate f (a :< as) = (:<) a <$> traverse f as

--- a/plated/CHANGELOG.markdown
+++ b/plated/CHANGELOG.markdown
@@ -1,0 +1,11 @@
+0.1
+---
+
+* Initial release. The `Plated` class, its `Data`-based default for `plate`
+  (via a portable `uniplate`), the `[]` and `Data.Tree.Tree` instances, and the
+  `Generic`-based `gplate`/`gplate1` (with the `GPlated`/`GPlated1` classes) were
+  extracted from the `lens` package's `Control.Lens.Plated` module so that
+  libraries can provide `Plated` instances without depending on `lens`.
+* Instances that need heavier dependencies (`free`, `comonad`) live in the
+  companion `plated-instances` package, keeping this package's footprint to
+  `base` and `containers` (a GHC boot library).

--- a/plated/LICENSE
+++ b/plated/LICENSE
@@ -1,0 +1,26 @@
+Copyright 2012-2016 Edward Kmett
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/plated/plated.cabal
+++ b/plated/plated.cabal
@@ -1,0 +1,59 @@
+name:          plated
+category:      Data, Generics
+version:       0.1
+license:       BSD2
+cabal-version: 1.18
+license-file:  LICENSE
+author:        Edward A. Kmett
+maintainer:    Edward A. Kmett <ekmett@gmail.com>
+stability:     provisional
+homepage:      http://github.com/ekmett/lens/
+bug-reports:   http://github.com/ekmett/lens/issues
+copyright:     Copyright (C) 2012-2016 Edward A. Kmett
+synopsis:      The Plated class for self-similar recursive data
+description:
+  The @Plated@ type class describes how to extract the immediate self-similar
+  children of a recursive structure, with a @Data@-based default and a
+  @Generic@-based @gplate@/@gplate1@ for deriving it.
+  .
+  This package depends only on @base@ and @containers@ (a GHC boot library), so
+  other libraries may provide @Plated@ instances for their own types without
+  depending on @lens@ or writing orphan instances. Instances that would require
+  heavier dependencies (@free@, @comonad@) live in the companion
+  @plated-instances@ package (import @Data.Plated.Instances@ to bring them into
+  scope; it re-exports nothing else). The combinators that consume @Plated@
+  values (@rewrite@, @transform@, @universe@, ...) live in @Control.Lens.Plated@
+  in the @lens@ package, which re-exports this class unchanged.
+build-type:    Simple
+tested-with:   GHC == 8.0.2
+             , GHC == 8.2.2
+             , GHC == 8.4.4
+             , GHC == 8.6.5
+             , GHC == 8.8.4
+             , GHC == 8.10.7
+             , GHC == 9.0.2
+             , GHC == 9.2.8
+             , GHC == 9.4.8
+             , GHC == 9.6.7
+             , GHC == 9.8.4
+             , GHC == 9.10.3
+             , GHC == 9.12.2
+             , GHC == 9.14.1
+extra-source-files:
+  CHANGELOG.markdown
+
+source-repository head
+  type: git
+  location: https://github.com/ekmett/lens.git
+
+library
+  build-depends:
+    base       >= 4.9      && < 5,
+    containers >= 0.5.5.1  && < 0.9
+
+  exposed-modules:
+    Data.Plated
+
+  hs-source-dirs: src
+  ghc-options: -Wall
+  default-language: Haskell2010

--- a/plated/src/Data/Plated.hs
+++ b/plated/src/Data/Plated.hs
@@ -1,0 +1,259 @@
+{-# LANGUAGE Rank2Types #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE DefaultSignatures #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE PolyKinds #-}
+
+-------------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Plated
+-- Copyright   :  (C) 2012-16 Edward Kmett
+-- License     :  BSD-style (see the file LICENSE)
+-- Maintainer  :  Edward Kmett <ekmett@gmail.com>
+-- Stability   :  provisional
+-- Portability :  Rank2Types
+--
+-- The 'Plated' class on its own, with no dependency on @lens@, so that other
+-- libraries can provide 'Plated' instances for their types without pulling in
+-- (or writing orphan instances against) the whole of @lens@.
+--
+-- This package depends only on @base@ and @containers@ (a GHC boot library). The
+-- instances that would require heavier dependencies (@free@, @comonad@) live in
+-- the companion @plated-instances@ package; import @Data.Plated.Instances@ to
+-- bring those instances into scope (it re-exports nothing else). The rich set of
+-- combinators that operate on 'Plated' values (@rewrite@, @transform@,
+-- @universe@, @cosmos@, @holes@, @para@, ...) lives in @Control.Lens.Plated@ in
+-- the @lens@ package, which re-exports this class unchanged.
+-------------------------------------------------------------------------------
+module Data.Plated
+  (
+  -- * Plated
+    Plated(..)
+  -- * Type
+  , Traversal'
+  -- * Data
+  , uniplate
+  -- * Generics
+  , gplate
+  , gplate1
+  , GPlated
+  , GPlated1
+  ) where
+
+import Data.Data (Data, gfoldl)
+import Data.Tree (Tree(..))
+import Data.Typeable (Typeable, eqT)
+import Data.Type.Equality ((:~:)(Refl))
+import GHC.Generics
+
+-- | A @'Traversal'' s a@ — the same type @lens@ uses, written out here so that
+-- this package need not depend on @lens@. Because type synonyms are transparent,
+-- it is literally the same type as @lens@'s @Control.Lens.Type.Traversal'@, so a
+-- 'plate' defined here unifies with every @lens@ combinator unchanged.
+--
+-- Read it aloud: given an applicative effect @f@ and a way to turn each focused
+-- @a@ into an @f a@, turn a whole @s@ into an @f s@.
+type Traversal' s a = forall f. Applicative f => (a -> f a) -> s -> f s
+
+-- | A 'Plated' type is one where we know how to extract its immediate
+-- self-similar children.
+--
+-- For example, a little expression language (no @lens@ import required):
+--
+-- @
+-- import Data.Plated
+--
+-- data Expr = Val Int | Neg Expr | Add Expr Expr
+--
+-- instance 'Plated' Expr where
+--   'plate' f (Neg e)   = Neg '<$>' f e
+--   'plate' f (Add a b) = Add '<$>' f a '<*>' f b
+--   'plate' _ x         = 'pure' x
+-- @
+--
+-- If your type derives 'Data', you can omit the body entirely and let the
+-- default fire:
+--
+-- @
+-- data Expr = Val Int | Neg Expr | Add Expr Expr deriving 'Data'
+--
+-- instance 'Plated' Expr   -- 'plate' defaults to 'uniplate'
+-- @
+--
+-- or, with a 'Generic' instance, use @'plate' = 'gplate'@.
+--
+-- Note the distinction between the hand-written and 'Data'-derived
+-- definitions: the former treats only the direct @Expr@ children as
+-- descendants, while 'uniplate' will also reach @Expr@ values nested inside
+-- other types (for example, inside a list).
+--
+-- When in doubt, pick a @Traversal@ and just use the various @...Of@
+-- combinators rather than pollute 'Plated' with orphan instances!
+class Plated a where
+  -- | 'Traversal' of the immediate children of this structure.
+  --
+  -- If your type has a 'Data' instance, 'plate' defaults to 'uniplate', so you
+  -- can leave the instance body empty.
+  plate :: Traversal' a a
+  default plate :: Data a => Traversal' a a
+  plate = uniplate
+
+instance Plated [a] where
+  plate f (x:xs) = (x:) <$> f xs
+  plate _ [] = pure []
+
+instance Plated (Tree a) where
+  plate f (Node a as) = Node a <$> traverse f as
+
+-------------------------------------------------------------------------------
+-- Data
+-------------------------------------------------------------------------------
+
+-- | A portable, @base@-only implementation of @uniplate@: a 'Traversal'' over
+-- the immediate self-similar children of a 'Data' value.
+--
+-- This finds the /shallowest/ values of the same type reachable from the input,
+-- descending through values of other types along the way. For example, given
+-- @data T = T [T]@, @'uniplate'@ on a @T@ reaches the @T@s held inside the list,
+-- not the list itself.
+--
+-- @lens@'s @Data.Data.Lens.uniplate@ computes the same traversal but adds a
+-- 'Typeable' oracle that prunes descent into types that cannot contain an @a@;
+-- it is faster on deeply nested non-matching structure, but otherwise behaves
+-- identically. Prefer that one (or a hand-written 'plate') where performance
+-- matters.
+uniplate :: Data a => Traversal' a a
+uniplate f = gtraverse (descend f)
+{-# INLINE uniplate #-}
+
+-- | Visit the shallowest @a@-typed values inside any 'Data' value, descending
+-- through values whose type is not @a@.
+descend :: forall a c f. (Applicative f, Typeable a, Data c) => (a -> f a) -> c -> f c
+descend f c = case eqT :: Maybe (c :~: a) of
+  Just Refl -> f c
+  Nothing   -> gtraverse (descend f) c
+{-# INLINE descend #-}
+
+-- | An 'Applicative' analogue of @gmapM@: rebuild a 'Data' value, applying an
+-- effectful function to each immediate child.
+gtraverse :: forall a f. (Applicative f, Data a) => (forall d. Data d => d -> f d) -> a -> f a
+gtraverse f = gfoldl (\rest d -> rest <*> f d) pure
+{-# INLINE gtraverse #-}
+
+-------------------------------------------------------------------------------
+-- Generics
+-------------------------------------------------------------------------------
+
+-- | Implement 'plate' operation for a type using its 'Generic' instance.
+--
+-- Note: the behavior may be different than with 'uniplate' in some special
+-- cases. 'gplate' doesn't look through other types in a group of mutually
+-- recursive types. See @Control.Lens.Plated@ in the @lens@ package for worked
+-- examples.
+gplate :: (Generic a, GPlated a (Rep a)) => Traversal' a a
+gplate f x = GHC.Generics.to <$> gplate' f (GHC.Generics.from x)
+{-# INLINE gplate #-}
+
+class GPlated a g where
+  gplate' :: Traversal' (g p) a
+
+instance GPlated a f => GPlated a (M1 i c f) where
+  gplate' f (M1 x) = M1 <$> gplate' f x
+  {-# INLINE gplate' #-}
+
+instance (GPlated a f, GPlated a g) => GPlated a (f :+: g) where
+  gplate' f (L1 x) = L1 <$> gplate' f x
+  gplate' f (R1 x) = R1 <$> gplate' f x
+  {-# INLINE gplate' #-}
+
+instance (GPlated a f, GPlated a g) => GPlated a (f :*: g) where
+  gplate' f (x :*: y) = (:*:) <$> gplate' f x <*> gplate' f y
+  {-# INLINE gplate' #-}
+
+instance {-# OVERLAPPING #-} GPlated a (K1 i a) where
+  gplate' f (K1 x) = K1 <$> f x
+  {-# INLINE gplate' #-}
+
+instance GPlated a (K1 i b) where
+  gplate' _ = pure
+  {-# INLINE gplate' #-}
+
+instance GPlated a U1 where
+  gplate' _ = pure
+  {-# INLINE gplate' #-}
+
+instance GPlated a V1 where
+  gplate' _ v = v `seq` error "GPlated/V1"
+  {-# INLINE gplate' #-}
+
+instance GPlated a (URec b) where
+  gplate' _ = pure
+  {-# INLINE gplate' #-}
+
+-- | Implement 'plate' operation for a type using its 'Generic1' instance.
+gplate1 :: (Generic1 f, GPlated1 f (Rep1 f)) => Traversal' (f a) (f a)
+gplate1 f x = GHC.Generics.to1 <$> gplate1' f (GHC.Generics.from1 x)
+{-# INLINE gplate1 #-}
+
+class GPlated1 f g where
+  gplate1' :: Traversal' (g a) (f a)
+
+-- | recursive match
+instance GPlated1 f g => GPlated1 f (M1 i c g) where
+  gplate1' f (M1 x) = M1 <$> gplate1' f x
+  {-# INLINE gplate1' #-}
+
+-- | recursive match
+instance (GPlated1 f g, GPlated1 f h) => GPlated1 f (g :+: h) where
+  gplate1' f (L1 x) = L1 <$> gplate1' f x
+  gplate1' f (R1 x) = R1 <$> gplate1' f x
+  {-# INLINE gplate1' #-}
+
+-- | recursive match
+instance (GPlated1 f g, GPlated1 f h) => GPlated1 f (g :*: h) where
+  gplate1' f (x :*: y) = (:*:) <$> gplate1' f x <*> gplate1' f y
+  {-# INLINE gplate1' #-}
+
+-- | ignored
+instance GPlated1 f (K1 i a) where
+  gplate1' _ = pure
+  {-# INLINE gplate1' #-}
+
+-- | ignored
+instance GPlated1 f Par1 where
+  gplate1' _ = pure
+  {-# INLINE gplate1' #-}
+
+-- | ignored
+instance GPlated1 f U1 where
+  gplate1' _ = pure
+  {-# INLINE gplate1' #-}
+
+-- | ignored
+instance GPlated1 f V1 where
+  gplate1' _ = pure
+  {-# INLINE gplate1' #-}
+
+-- | match
+instance {-# OVERLAPPING #-} GPlated1 f (Rec1 f) where
+  gplate1' f (Rec1 x) = Rec1 <$> f x
+  {-# INLINE gplate1' #-}
+
+-- | ignored
+instance GPlated1 f (Rec1 g) where
+  gplate1' _ = pure
+  {-# INLINE gplate1' #-}
+
+-- | recursive match under outer 'Traversable' instance
+instance (Traversable t, GPlated1 f g) => GPlated1 f (t :.: g) where
+  gplate1' f (Comp1 x) = Comp1 <$> traverse (gplate1' f) x
+  {-# INLINE gplate1' #-}
+
+-- | ignored
+instance GPlated1 f (URec a) where
+  gplate1' _ = pure
+  {-# INLINE gplate1' #-}

--- a/src/Control/Lens/Plated.hs
+++ b/src/Control/Lens/Plated.hs
@@ -1,15 +1,18 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE PolyKinds #-}
 
 #ifdef TRUSTWORTHY
 {-# LANGUAGE Trustworthy #-} -- template-haskell
 #endif
+
+-- The 'Plated' class now lives in the standalone @plated@ package, so the
+-- 'Plated' instances for Template Haskell syntax kept here (they need 'uniplate'
+-- from @lens@) are necessarily orphans.
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 #include "lens-common.h"
 
@@ -80,6 +83,7 @@ module Control.Lens.Plated
   , parts
 
   -- * Generics
+  -- $generics
   , gplate
   , gplate1
   , GPlated
@@ -89,8 +93,6 @@ module Control.Lens.Plated
 
 import Prelude ()
 
-import Control.Comonad.Cofree
-import qualified Control.Comonad.Trans.Cofree as CoTrans
 import Control.Lens.Fold
 import Control.Lens.Getter
 import Control.Lens.Indexed
@@ -99,14 +101,16 @@ import Control.Lens.Internal.Prelude
 import Control.Lens.Type
 import Control.Lens.Setter
 import Control.Lens.Traversal
-import Control.Monad.Free as Monad
-import Control.Monad.Free.Church as Church
-import Control.Monad.Trans.Free as Trans
+-- We import the class and the generics machinery from @plated@. For @lens@'s
+-- own 'Plated' instances below (the Template Haskell ones) we use @lens@'s
+-- oracle-optimized 'uniplate' from "Data.Data.Lens", so the import list omits
+-- @plated@'s portable 'uniplate' of the same name. This is purely @lens@'s own
+-- choice and does not change the class default: a downstream empty
+-- @instance Plated T@ still inherits @plated@'s portable 'uniplate'.
+import Data.Plated (Plated(..), gplate, gplate1, GPlated, GPlated1)
+import Data.Plated.Instances ()
 import qualified Language.Haskell.TH as TH
-import Data.Data
 import Data.Data.Lens
-import Data.Tree
-import GHC.Generics
 
 -- $setup
 -- >>> :set -XDeriveGeneric -XDeriveDataTypeable
@@ -115,139 +119,21 @@ import GHC.Generics
 -- >>> import GHC.Generics (Generic)
 -- >>> import Control.Lens
 
--- | A 'Plated' type is one where we know how to extract its immediate self-similar children.
+-- The 'Plated' class, its base instances, and the 'Generic'-based 'gplate' /
+-- 'gplate1' machinery live in the standalone @plated@ package ("Data.Plated")
+-- and are re-exported above, so that other libraries may provide 'Plated'
+-- instances without depending on @lens@.
 --
--- /Example 1/:
---
--- @
--- import Control.Applicative
--- import Control.Lens
--- import Control.Lens.Plated
--- import Data.Data
--- import Data.Data.Lens ('Data.Data.Lens.uniplate')
--- @
---
--- @
--- data Expr
---   = Val 'Int'
---   | Neg Expr
---   | Add Expr Expr
---   deriving ('Eq','Ord','Show','Read','Data')
--- @
---
--- @
--- instance 'Plated' Expr where
---   'plate' f (Neg e) = Neg '<$>' f e
---   'plate' f (Add a b) = Add '<$>' f a '<*>' f b
---   'plate' _ a = 'pure' a
--- @
---
--- /or/
---
--- @
--- instance 'Plated' Expr where
---   'plate' = 'Data.Data.Lens.uniplate'
--- @
---
--- /Example 2/:
---
--- @
--- import Control.Applicative
--- import Control.Lens
--- import Control.Lens.Plated
--- import Data.Data
--- import Data.Data.Lens ('Data.Data.Lens.uniplate')
--- @
---
--- @
--- data Tree a
---   = Bin (Tree a) (Tree a)
---   | Tip a
---   deriving ('Eq','Ord','Show','Read','Data')
--- @
---
--- @
--- instance 'Plated' (Tree a) where
---   'plate' f (Bin l r) = Bin '<$>' f l '<*>' f r
---   'plate' _ t = 'pure' t
--- @
---
--- /or/
---
--- @
--- instance 'Data' a => 'Plated' (Tree a) where
---   'plate' = 'uniplate'
--- @
---
--- Note the big distinction between these two implementations.
---
--- The former will only treat children directly in this tree as descendents,
--- the latter will treat trees contained in the values under the tips also
--- as descendants!
---
--- When in doubt, pick a 'Traversal' and just use the various @...Of@ combinators
--- rather than pollute 'Plated' with orphan instances!
---
--- If you want to find something unplated and non-recursive with 'Data.Data.Lens.biplate'
--- use the @...OnOf@ variant with 'ignored', though those usecases are much better served
--- in most cases by using the existing 'Lens' combinators! e.g.
---
--- @
--- 'toListOf' 'biplate' ≡ 'universeOnOf' 'biplate' 'ignored'
--- @
---
--- This same ability to explicitly pass the 'Traversal' in question is why there is no
--- analogue to uniplate's @Biplate@.
---
--- Moreover, since we can allow custom traversals, we implement reasonable defaults for
--- polymorphic data types, that only 'Control.Traversable.traverse' into themselves, and /not/ their
--- polymorphic arguments.
-
-class Plated a where
-  -- | 'Traversal' of the immediate children of this structure.
-  --
-  -- If you're using GHC 7.2 or newer and your type has a 'Data' instance,
-  -- 'plate' will default to 'uniplate' and you can choose to not override
-  -- it with your own definition.
-  plate :: Traversal' a a
-  default plate :: Data a => Traversal' a a
-  plate = uniplate
-
-instance Plated [a] where
-  plate f (x:xs) = (x:) <$> f xs
-  plate _ [] = pure []
-
-instance Traversable f => Plated (Monad.Free f a) where
-  plate f (Monad.Free as) = Monad.Free <$> traverse f as
-  plate _ x         = pure x
-
-instance (Traversable f, Traversable m) => Plated (Trans.FreeT f m a) where
-  plate f (Trans.FreeT xs) = Trans.FreeT <$> traverse (traverse f) xs
-
-instance Traversable f => Plated (Church.F f a) where
-  plate f = fmap Church.toF . plate (fmap Church.fromF . f . Church.toF) . Church.fromF
-
--- -- This one can't work
---
--- instance (Traversable f, Traversable m) => Plated (ChurchT.FT f m a) where
---   plate f = fmap ChurchT.toFT . plate (fmap ChurchT.fromFT . f . ChurchT.toFT) . ChurchT.fromFT
-
-instance (Traversable f, Traversable w) => Plated (CoTrans.CofreeT f w a) where
-  plate f (CoTrans.CofreeT xs) = CoTrans.CofreeT <$> traverse (traverse f) xs
-
-instance Traversable f => Plated (Cofree f a) where
-  plate f (a :< as) = (:<) a <$> traverse f as
-
-instance Plated (Tree a) where
-  plate f (Node a as) = Node a <$> traverse f as
-
-{- Default uniplate instances -}
-instance Plated TH.Exp
-instance Plated TH.Dec
-instance Plated TH.Con
-instance Plated TH.Type
-instance Plated TH.Stmt
-instance Plated TH.Pat
+-- The 'Plated' instances for Template Haskell syntax stay here, because they
+-- rely on 'uniplate' (from "Data.Data.Lens"), which is part of @lens@. They are
+-- orphan instances (the class now lives in @plated@), which is unavoidable
+-- given the split.
+instance Plated TH.Exp  where plate = uniplate
+instance Plated TH.Dec  where plate = uniplate
+instance Plated TH.Con  where plate = uniplate
+instance Plated TH.Type where plate = uniplate
+instance Plated TH.Stmt where plate = uniplate
+instance Plated TH.Pat  where plate = uniplate
 
 
 infixr 9 ...
@@ -715,7 +601,11 @@ parts = partsOf plate
 -- Generics
 -------------------------------------------------------------------------------
 
--- | Implement 'plate' operation for a type using its 'Generic' instance.
+-- $generics
+-- 'gplate' implements the 'plate' operation for a type using its 'Generic'
+-- instance, and 'gplate1' does the same using 'Generic1'. Both, together with
+-- the 'GPlated' and 'GPlated1' classes, are defined in the standalone @plated@
+-- package ("Data.Plated") and re-exported here.
 --
 -- Note: the behavior may be different than with 'uniplate' in some special cases.
 -- 'gplate' doesn't look through other types in a group of mutually
@@ -750,107 +640,3 @@ parts = partsOf plate
 --
 -- >>> universeOf evenplate (E (O (E (O Z))))
 -- [E (O (E (O Z))),E (O Z),Z]
---
-gplate :: (Generic a, GPlated a (Rep a)) => Traversal' a a
-gplate f x = GHC.Generics.to <$> gplate' f (GHC.Generics.from x)
-{-# INLINE gplate #-}
-
-class GPlated a g where
-  gplate' :: Traversal' (g p) a
-
-instance GPlated a f => GPlated a (M1 i c f) where
-  gplate' f (M1 x) = M1 <$> gplate' f x
-  {-# INLINE gplate' #-}
-
-instance (GPlated a f, GPlated a g) => GPlated a (f :+: g) where
-  gplate' f (L1 x) = L1 <$> gplate' f x
-  gplate' f (R1 x) = R1 <$> gplate' f x
-  {-# INLINE gplate' #-}
-
-instance (GPlated a f, GPlated a g) => GPlated a (f :*: g) where
-  gplate' f (x :*: y) = (:*:) <$> gplate' f x <*> gplate' f y
-  {-# INLINE gplate' #-}
-
-instance {-# OVERLAPPING #-} GPlated a (K1 i a) where
-  gplate' f (K1 x) = K1 <$> f x
-  {-# INLINE gplate' #-}
-
-instance GPlated a (K1 i b) where
-  gplate' _ = pure
-  {-# INLINE gplate' #-}
-
-instance GPlated a U1 where
-  gplate' _ = pure
-  {-# INLINE gplate' #-}
-
-instance GPlated a V1 where
-  gplate' _ v = v `seq` error "GPlated/V1"
-  {-# INLINE gplate' #-}
-
-instance GPlated a (URec b) where
-  gplate' _ = pure
-  {-# INLINE gplate' #-}
-
--- | Implement 'plate' operation for a type using its 'Generic1' instance.
-gplate1 :: (Generic1 f, GPlated1 f (Rep1 f)) => Traversal' (f a) (f a)
-gplate1 f x = GHC.Generics.to1 <$> gplate1' f (GHC.Generics.from1 x)
-{-# INLINE gplate1 #-}
-
-class GPlated1 f g where
-  gplate1' :: Traversal' (g a) (f a)
-
--- | recursive match
-instance GPlated1 f g => GPlated1 f (M1 i c g) where
-  gplate1' f (M1 x) = M1 <$> gplate1' f x
-  {-# INLINE gplate1' #-}
-
--- | recursive match
-instance (GPlated1 f g, GPlated1 f h) => GPlated1 f (g :+: h) where
-  gplate1' f (L1 x) = L1 <$> gplate1' f x
-  gplate1' f (R1 x) = R1 <$> gplate1' f x
-  {-# INLINE gplate1' #-}
-
--- | recursive match
-instance (GPlated1 f g, GPlated1 f h) => GPlated1 f (g :*: h) where
-  gplate1' f (x :*: y) = (:*:) <$> gplate1' f x <*> gplate1' f y
-  {-# INLINE gplate1' #-}
-
--- | ignored
-instance GPlated1 f (K1 i a) where
-  gplate1' _ = pure
-  {-# INLINE gplate1' #-}
-
--- | ignored
-instance GPlated1 f Par1 where
-  gplate1' _ = pure
-  {-# INLINE gplate1' #-}
-
--- | ignored
-instance GPlated1 f U1 where
-  gplate1' _ = pure
-  {-# INLINE gplate1' #-}
-
--- | ignored
-instance GPlated1 f V1 where
-  gplate1' _ = pure
-  {-# INLINE gplate1' #-}
-
--- | match
-instance {-# OVERLAPPING #-} GPlated1 f (Rec1 f) where
-  gplate1' f (Rec1 x) = Rec1 <$> f x
-  {-# INLINE gplate1' #-}
-
--- | ignored
-instance GPlated1 f (Rec1 g) where
-  gplate1' _ = pure
-  {-# INLINE gplate1' #-}
-
--- | recursive match under outer 'Traversable' instance
-instance (Traversable t, GPlated1 f g) => GPlated1 f (t :.: g) where
-  gplate1' f (Comp1 x) = Comp1 <$> traverse (gplate1' f) x
-  {-# INLINE gplate1' #-}
-
--- | ignored
-instance GPlated1 f (URec a) where
-  gplate1' _ = pure
-  {-# INLINE gplate1' #-}


### PR DESCRIPTION
Closes #993.

`Plated` isn't `lens`-specific, and downstream type owners (aeson/optics/microlens ecosystems) currently can't provide `Plated` instances without depending on all of `lens` or shipping orphans. This extracts the class into small packages, mirroring the `indexed-traversable` / `indexed-traversable-instances` split.

## Package layout

- **`plated`** (depends on `base` + `containers`) — the `Plated` class with its `Data`-based default, the `[]` and `Data.Tree.Tree` instances, and the `Generic`-based `gplate`/`gplate1` (`GPlated`/`GPlated1`). `containers` is a GHC boot library, so this is effectively a `base`-only footprint, and it lets the class carry boot-library instances the way `indexed-traversable` does.
- **`plated-instances`** (`plated` + `free` + `comonad`) — the orphan `Plated` instances for the `free`/`comonad` type families (`Free`/`FreeT`/`F`/`Cofree`/`CofreeT`), kept separate so depending on the class doesn't pull in `free`.
- **`lens`** — `Control.Lens.Plated` now re-exports the class + generics from `plated`, pulls the instances in via `Data.Plated.Instances`, and keeps all the combinators (`rewrite`/`transform`/`universe`/…) plus the Template Haskell instances (as `plate = uniplate`, using lens's own optimized `uniplate`).

## Backwards compatibility

`import Control.Lens` / `import Control.Lens.Plated` code is unchanged, **including** empty `instance Plated T` declarations that rely on the `Data` default.

The one behavioral nuance: `plated`'s default `plate` is backed by a portable, `base`-only `uniplate` rather than lens's oracle-optimized `Data.Data.Lens.uniplate`. The two compute the **same** traversal (verified against each other on nested cases — lists, `Maybe`, tuples, newtypes — via `children`, `universe`, and `transform`); the portable one can just be slower on deeply nested non-matching structure. lens's own instances keep using the optimized version, and users can write `plate = Data.Data.Lens.uniplate` explicitly where it matters.

## Open questions for review

- **Package/module names** (`plated`, `plated-instances`; `Data.Plated`, `Data.Plated.Instances`) and the **initial version** (`0.1`) are bikesheds — happy to change.
- **Target-name collision:** `lens` already has a benchmark component named `plated`, so a bare `cabal build plated` is ambiguous (use `cabal build plated:lib:plated`). Might be worth renaming the benchmark.
- **CI:** `.github/workflows/haskell-ci.yml` will need regenerating (`haskell-ci`) to cover the two new packages.
- **Hackage publishing** of `plated`/`plated-instances`, and downstream adoption (e.g. `free`/`containers` providing their own instances), are follow-ups beyond this in-tree carve-out.
