### PR TITLE
Clarify outside Haddock with function-specialised type

### DIFF
--- a/src/Control/Lens/Prism.hs
+++ b/src/Control/Lens/Prism.hs
@@ -137,6 +137,9 @@ prism' bs sma = prism bs (\s -> maybe (Left s) Right (sma s))
 
 -- | Use a 'Prism' as a kind of first-class pattern.
 --
+-- The general type below generalises @(->)@ to any 'Representable' profunctor @p@.
+-- Specialised to functions (@p ~ (->)@) it reads
+--
 -- @'outside' :: 'Prism' s t a b -> 'Lens' (t -> r) (s -> r) (b -> r) (a -> r)@
 
 -- TODO: can we make this work with merely Strong?


### PR DESCRIPTION
Notes the `p ~ (->)` specialisation of `outside`'s `Representable` type in its Haddock. Comment-only.