### PR TITLE
Add makeConstructors: overloaded constructor prisms

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -74,6 +74,11 @@ next [????.??.??]
   visibly the `Review` box, which still used the long-removed four-parameter
   form — and add `images/Hierarchy.dot` as an editable Graphviz source for the
   diagram (regenerated via `scripts/hierarchy`).
+* Add `makeConstructors` to `Control.Lens.TH`: the `makePrisms` counterpart of
+  `makeFields`. Each constructor `Con` of a type `T` gets the optic `makePrisms`
+  would generate, as `_TCon`, and an instance of a per-constructor class
+  `AsCon s a | s -> a` with method `_Con :: Prism' s a`; the class is declared
+  only if not already in scope, so types with same-named constructors share it.
 
 5.3.6 [2026.01.10]
 ------------------

--- a/lens.cabal
+++ b/lens.cabal
@@ -337,6 +337,7 @@ test-suite templates
     BigRecord
     T799
     T917
+    T934
     T972
   if impl(ghc >= 9.2)
     other-modules:

--- a/src/Control/Lens/Internal/FieldTH.hs
+++ b/src/Control/Lens/Internal/FieldTH.hs
@@ -33,6 +33,7 @@ module Control.Lens.Internal.FieldTH
   , makeFieldOpticsForDec
   , makeFieldOpticsForDec'
   , makeFieldOpticExp
+  , makeClassInstance
   , HasFieldClasses
   ) where
 
@@ -410,7 +411,7 @@ makeFieldOptic rules (defName, (opticType, defType, cons)) = do
 
   def = case defName of
           TopName n      -> fun n
-          MethodName c n -> [makeFieldInstance defType c (fun n)]
+          MethodName c n -> [makeClassInstance [] c (stabToS defType) (stabToA defType) (fun n)]
 
   clauses = makeFieldClauses rules opticType cons
 
@@ -503,44 +504,41 @@ makeFieldClass defType className methodName =
   s = mkName "s"
   a = mkName "a"
 
--- | Build an instance for a field. If the field’s type contains any type
--- families, will produce an equality constraint to avoid a type family
--- application in the instance head.
-makeFieldInstance :: OpticStab -> Name -> [DecQ] -> DecQ
-makeFieldInstance defType className decs =
-  containsTypeFamilies a >>= pickInstanceDec
+-- | Build the instance @cx => className s a@ of a field or constructor
+-- class. If @a@ contains any type families, a fresh variable takes its place
+-- in the instance head, pinned by an equality constraint, to avoid a type
+-- family application there; such an instance passes only the liberal
+-- coverage condition, so its splice site needs @UndecidableInstances@.
+makeClassInstance :: Cxt -> Name -> Type -> Type -> [DecQ] -> DecQ
+makeClassInstance cx className s a decs =
+  do hasFamilies <- containsTypeFamilies a
+     (extra, a') <-
+       if hasFamilies
+         then do placeholder <- VarT <$> newName "a"
+                 return ([D.equalPred placeholder a], placeholder)
+         else return ([], a)
+     instanceD (cxt (map return (cx ++ extra)))
+               (return (className `conAppsT` [s, a']))
+               decs
+
+-- | Whether a type mentions a type family, but not a /data/ family. See #799.
+containsTypeFamilies :: Type -> Q Bool
+containsTypeFamilies = go <=< D.resolveTypeSynonyms
   where
-  s = stabToS defType
-  a = stabToA defType
+  go :: Type -> Q Bool
+  go (ConT nm) =
+    -- Note that the call to `reify` can fail if `nm` is not yet defined.
+    -- (This can actually happen if `nm` is declared in a Template Haskell
+    -- quote.) If this fails, there is no way to tell if the type contains
+    -- type families, so we recover and conservatively assume that is does not
+    -- contain any.
+    recover
+      (pure False)
+      (has (_FamilyI . _1 . _TypeFamilyD) <$> reify nm)
+  go ty = or <$> traverse go (ty ^.. plate)
 
-  containsTypeFamilies = go <=< D.resolveTypeSynonyms
-    where
-    go :: Type -> Q Bool
-    go (ConT nm) =
-      -- Note that the call to `reify` can fail if `nm` is not yet defined.
-      -- (This can actually happen if `nm` is declared in a Template Haskell
-      -- quote.) If this fails, there is no way to tell if the type contains
-      -- type families, so we recover and conservatively assume that is does not
-      -- contain any.
-      recover
-        (pure False)
-        (has (_FamilyI . _1 . _TypeFamilyD) <$> reify nm)
-    go ty = or <$> traverse go (ty ^.. plate)
-
-    -- We want to catch type families, but not *data* families. See #799.
-    _TypeFamilyD :: Getting Any Dec ()
-    _TypeFamilyD = _OpenTypeFamilyD.united <> _ClosedTypeFamilyD.united
-
-  pickInstanceDec hasFamilies
-    | hasFamilies = do
-        placeholder <- VarT <$> newName "a"
-        mkInstanceDec
-          [return (D.equalPred placeholder a)]
-          [s, placeholder]
-    | otherwise = mkInstanceDec [] [s, a]
-
-  mkInstanceDec context headTys =
-    instanceD (cxt context) (return (className `conAppsT` headTys)) decs
+  _TypeFamilyD :: Getting Any Dec ()
+  _TypeFamilyD = _OpenTypeFamilyD.united <> _ClosedTypeFamilyD.united
 
 ------------------------------------------------------------------------
 -- Optic clause generators

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -196,21 +196,14 @@ makeConsPrisms :: Type -> [NCon] -> Maybe Name -> DecsQ
 -- special case: single constructor, not classy -> make iso
 -- ('makePrism' has the corresponding single-constructor Iso case; keep the two
 -- in sync.)
-makeConsPrisms t [con@(NCon _ [] [] _)] Nothing = makeConIso t con
+makeConsPrisms t [con@(NCon _ [] [] _)] Nothing =
+  makeConIso (prismName (view nconName con)) t con
 
 -- top-level definitions
 makeConsPrisms t cons Nothing =
   fmap concat $ for cons $ \con ->
-    do let conName = view nconName con
-       stab <- computeOpticType t cons con
-       let n = prismName conName
-       copyDocs [conName] n
-       sequenceA
-         ( [ sigD n (return (quantifyType [] (stabToType Set.empty stab)))
-           , valD (varP n) (normalB (makeConOpticExp stab cons con)) []
-           ]
-           ++ inlinePragma n
-         )
+    do stab <- computeOpticType t cons con
+       makeConOptic (prismName (view nconName con)) stab cons con
 
 
 -- classy prism class and instance
@@ -304,11 +297,23 @@ makeConOpticExp stab cons con =
     ReviewType -> makeConReviewExp con
 
 
--- | Construct an iso declaration
-makeConIso :: Type -> NCon -> DecsQ
-makeConIso s con =
-  do let ty      = computeIsoType s (view nconTypes con)
-         defName = prismName (view nconName con)
+-- | Declare the optic for one constructor under the given name, inheriting
+-- the constructor's documentation.
+makeConOptic :: Name -> Stab -> [NCon] -> NCon -> DecsQ
+makeConOptic n stab cons con =
+  do copyDocs [view nconName con] n
+     sequenceA
+       ( [ sigD n (return (quantifyType [] (stabToType Set.empty stab)))
+         , valD (varP n) (normalB (makeConOpticExp stab cons con)) []
+         ]
+         ++ inlinePragma n
+       )
+
+
+-- | Declare the iso for a lone constructor under the given name.
+makeConIso :: Name -> Type -> NCon -> DecsQ
+makeConIso defName s con =
+  do let ty = computeIsoType s (view nconTypes con)
      copyDocs [view nconName con] defName
      sequenceA
        ( [ sigD       defName  ty

--- a/src/Control/Lens/Internal/PrismTH.hs
+++ b/src/Control/Lens/Internal/PrismTH.hs
@@ -19,17 +19,20 @@
 module Control.Lens.Internal.PrismTH
   ( makePrisms
   , makeClassyPrisms
+  , makeConstructors
   , makeDecPrisms
   , makePrism
   ) where
 
 import Control.Applicative
 import Control.Lens.Getter
+import Control.Lens.Internal.FieldTH (makeClassInstance)
 import Control.Lens.Internal.TH
 import Control.Lens.Lens
 import Control.Monad
 import Data.Char (isUpper)
 import qualified Data.List as List
+import Data.Maybe (fromMaybe, isNothing)
 import Data.Set.Lens
 import Data.Traversable
 import Language.Haskell.TH
@@ -185,6 +188,129 @@ makePrism conName =
               Nothing  -> fail $ "makePrism: " ++ nameBase conName
                               ++ " is not a data constructor of "
                               ++ nameBase (D.datatypeName info)
+
+
+-- | Generate overloaded constructor prisms: the 'makePrisms' counterpart of
+-- 'Control.Lens.TH.makeFields'. Each constructor gets a top-level optic
+-- named after the type and the constructor, and a class named after the
+-- constructor alone whose one method is the overloaded prism. The class is
+-- declared only when no class of that name is in scope, so a later
+-- invocation on another type with a same-named constructor just adds an
+-- instance, and both types share the method.
+--
+-- /e.g./
+--
+-- @
+-- data Type1 = One Int String | Two String
+-- makeConstructors ''Type1
+-- @
+--
+-- will create
+--
+-- @
+-- _Type1One :: Prism' Type1 (Int, String)
+-- _Type1Two :: Prism' Type1 String
+-- class AsOne s a | s -> a where
+--   _One :: Prism' s a
+-- instance AsOne Type1 (Int, String) where
+--   _One = _Type1One
+-- class AsTwo s a | s -> a where
+--   _Two :: Prism' s a
+-- instance AsTwo Type1 String where
+--   _Two = _Type1Two
+-- @
+--
+-- and then, anywhere @AsOne@ is in scope,
+--
+-- @
+-- data Type2 = One Double | More Int
+-- makeConstructors ''Type2
+-- @
+--
+-- will create
+--
+-- @
+-- _Type2One :: Prism' Type2 Double
+-- _Type2More :: Prism' Type2 Int
+-- instance AsOne Type2 Double where
+--   _One = _Type2One
+-- class AsMore s a | s -> a where
+--   _More :: Prism' s a
+-- instance AsMore Type2 Int where
+--   _More = _Type2More
+-- @
+--
+-- The top-level optics are exactly those of 'makePrisms' — an @Iso@ for a
+-- lone constructor, a @Review@ for an existentially quantified one,
+-- type-changing where possible — under longer names; the class methods are
+-- always simple prisms. The methods take the @_Con@ names 'makePrisms' would
+-- use, so apply one generator or the other to a given type, not both.
+--
+-- Only the top-level optic, with no class or instance, is generated for
+-- existentially quantified constructors, whose payload type the functional
+-- dependency could not determine, and for operator-named types or
+-- constructors, which cannot form the @AsCon@ and @_TypeCon@ identifiers
+-- (such optics are named as by 'makePrisms').
+--
+-- Class sharing is by name: @AsCon@ and @_Con@ must be in scope unqualified,
+-- and whatever is already named @AsCon@ gets the instance. A payload type
+-- mentioning a type family is hidden behind an equality constraint in the
+-- instance head, as 'Control.Lens.TH.makeFields' does; such an instance needs
+-- @UndecidableInstances@ at the splice site.
+--
+-- The top-level optics inherit their constructor's Haddock documentation,
+-- as with 'makePrisms'; the shared class methods inherit nothing.
+makeConstructors :: Name {- ^ Type constructor name -} -> DecsQ
+makeConstructors typeName =
+  do info <- D.reifyDatatype typeName
+     let t    = datatypeTypeKinded info
+         cons = map normalizeCon (D.datatypeCons info)
+     -- Constructor names are unique within a module, so unlike makeFields no
+     -- bookkeeping is needed to avoid declaring a class twice per splice.
+     fmap concat (for cons (makeConstructorDecs t (D.datatypeName info) cons))
+
+
+-- | The top-level optic for one constructor and, when it admits an
+-- overloaded @Prism'@, its class (unless already in scope) and this type's
+-- instance of it.
+makeConstructorDecs :: Type -> Name -> [NCon] -> NCon -> DecsQ
+makeConstructorDecs t typeName cons con =
+  do stab <- computeOpticType t cons con
+     let conName  = view nconName con
+         overload = isPrefixName typeName && isPrefixName conName
+         defName | overload  = mkName ('_' : nameBase typeName ++ nameBase conName)
+                 | otherwise = prismName conName
+     -- the lone-constructor Iso special case of 'makeConsPrisms' (stab still
+     -- decides the class below)
+     topLevel <- case cons of
+                   [NCon _ [] [] _] -> makeConIso defName t con
+                   _                -> makeConOptic defName stab cons con
+     overloaded <-
+       case stabType stab of
+         PrismType | overload ->
+           do let Stab cx _ _ _ _ b = stab -- b: the tuple of field types
+                  methodName = prismName conName
+                  clsBase    = "As" ++ nameBase conName
+              mcls <- lookupTypeName clsBase
+              let className = fromMaybe (mkName clsBase) mcls
+              sequenceA
+                ( [ makeConstructorClass className methodName | isNothing mcls ]
+                ++ [ makeClassInstance cx className t b
+                       (valD (varP methodName) (normalB (varE defName)) []
+                        : inlinePragma methodName) ]
+                )
+         _ -> return []
+     return (topLevel ++ overloaded)
+
+
+-- | @class AsCon s a | s -> a where _Con :: Prism' s a@
+makeConstructorClass :: Name -> Name -> DecQ
+makeConstructorClass className methodName =
+  classD (cxt []) className [D.plainTV s, D.plainTV a] [FunDep [s] [a]]
+    [sigD methodName (return (prism'TypeName `conAppsT` [VarT s, VarT a]))]
+  where
+  s = mkName "s"
+  a = mkName "a"
 
 
 -- | Generate prisms for the given type, normalized constructors, and
@@ -575,12 +701,18 @@ prismName' ::
   Bool {- ^ overlapping constructor -} ->
   Name {- ^ type constructor        -} ->
   Name {- ^ prism name              -}
-prismName' sameNameAsCon n =
-  case nameBase n of
-    [] -> error "prismName: empty name base?"
-    nb@(x:_) | isUpper x -> mkName (prefix '_' nb)
-             | otherwise -> mkName (prefix '.' nb) -- operator
+prismName' sameNameAsCon n
+  | null nb        = error "prismName: empty name base?"
+  | isPrefixName n = mkName (prefix '_' nb)
+  | otherwise      = mkName (prefix '.' nb) -- operator
   where
+    nb = nameBase n
     prefix :: Char -> String -> String
     prefix char str | sameNameAsCon = char:char:str
                     | otherwise     =      char:str
+
+-- | Whether a name is spelled as an identifier rather than an operator.
+isPrefixName :: Name -> Bool
+isPrefixName n = case nameBase n of
+                   c:_ -> isUpper c
+                   []  -> False

--- a/src/Control/Lens/TH.hs
+++ b/src/Control/Lens/TH.hs
@@ -32,6 +32,7 @@ module Control.Lens.TH
   -- ** Prisms
   , makePrisms
   , makeClassyPrisms
+  , makeConstructors
   -- ** Wrapped
   , makeWrapped
   -- * Constructing a Single Optic as an Expression

--- a/tests/T934.hs
+++ b/tests/T934.hs
@@ -1,0 +1,19 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TemplateHaskell #-}
+-- | 'makeConstructors' on a type whose constructor name is reused by a type
+-- in templates.hs, which must pick up the class declared here instead of
+-- redeclaring it.
+module T934 where
+
+import Control.Lens
+
+data T934 = T934One Int String | T934Two String
+makeConstructors ''T934
+
+checkT934One :: Prism' T934 (Int, String)
+checkT934One = _T934One
+
+checkT934Two :: AsT934Two t a => Prism' t a
+checkT934Two = _T934Two

--- a/tests/templates.hs
+++ b/tests/templates.hs
@@ -33,6 +33,7 @@ import Language.Haskell.TH (recover)
 import BigRecord ()
 import T799 ()
 import T917 ()
+import T934 (T934, AsT934One (..))
 import T972 ()
 
 data Bar a b c = Bar { _baz :: (a, b) }
@@ -611,6 +612,108 @@ oneOffWrap = $(makePrism 'MkT997A)
 -- ...and a 'Review' for an existentially quantified constructor.
 oneOffReview :: Review ReviewTest a
 oneOffReview = $(makePrism 'ReviewTest)
+
+-- 'makeConstructors' (#934): overloaded constructor prisms. T934One is also a
+-- constructor of T934.T934, whose AsT934One class is in scope and is reused
+-- rather than redeclared.
+data T934Other a = T934One Double | T934Poly a
+makeConstructors ''T934Other
+
+checkT934OneShared :: AsT934One t a => Prism' t a
+checkT934OneShared = _T934One
+
+checkT934OneHere :: Prism' (T934Other a) Double
+checkT934OneHere = _T934One
+
+checkT934OneThere :: Prism' T934 (Int, String)
+checkT934OneThere = _T934One
+
+checkT934OneTop :: Prism' (T934Other a) Double
+checkT934OneTop = _T934OtherT934One
+
+checkT934Poly :: Prism' (T934Other a) a
+checkT934Poly = _T934Poly
+
+checkT934PolyTop :: Prism (T934Other a) (T934Other b) a b
+checkT934PolyTop = _T934OtherT934Poly
+
+-- Nullary and record constructors; a type sharing its constructor's name
+data T934Rec = T934Nil | T934Rec { _t934Field :: Int, _t934Flag :: Bool }
+makeConstructors ''T934Rec
+
+checkT934Nil :: Prism' T934Rec ()
+checkT934Nil = _T934Nil
+
+checkT934Rec :: Prism' T934Rec (Int, Bool)
+checkT934Rec = _T934Rec
+
+checkT934RecTop :: Prism' T934Rec (Int, Bool)
+checkT934RecTop = _T934RecT934Rec
+
+-- A lone constructor gets an Iso, as with makePrisms
+newtype T934Lone a = T934Lone a
+makeConstructors ''T934Lone
+
+checkT934LoneIso :: Iso (T934Lone a) (T934Lone b) a b
+checkT934LoneIso = _T934LoneT934Lone
+
+checkT934Lone :: Prism' (T934Lone a) a
+checkT934Lone = _T934Lone
+
+data T934Pair a b = T934Pair a b
+makeConstructors ''T934Pair
+
+checkT934PairIso :: Iso (T934Pair a b) (T934Pair a' b') (a, b) (a', b')
+checkT934PairIso = _T934PairT934Pair
+
+checkT934Pair :: Prism' (T934Pair a b) (a, b)
+checkT934Pair = _T934Pair
+
+-- A GADT constructor's equality refinement goes on its instance
+data T934G a where
+  T934GI :: Int -> T934G Int
+  T934GA :: a -> T934G a
+makeConstructors ''T934G
+
+checkT934GI :: Prism' (T934G Int) Int
+checkT934GI = _T934GI
+
+-- A type-family payload is hidden behind an equality constraint in the
+-- instance head, as makeFields does (#799)
+type family T934Fam a
+data T934TF a = T934TF (T934Fam a) | T934TFOther
+makeConstructors ''T934TF
+
+checkT934TF :: Prism' (T934TF a) (T934Fam a)
+checkT934TF = _T934TF
+
+-- Existential and operator constructors, and operator-named types, get their
+-- top-level optic only; the classes declared below would clash with
+-- generated ones.
+data T934Edge where
+  T934Ex    :: a -> T934Edge
+  (:+++)    :: Int -> Int -> T934Edge
+  T934Plain :: Bool -> T934Edge
+makeConstructors ''T934Edge
+
+class AsT934Ex s a | s -> a
+
+checkT934Ex :: Review T934Edge a
+checkT934Ex = _T934EdgeT934Ex
+
+checkT934Op :: Prism' T934Edge (Int, Int)
+checkT934Op = (.:+++)
+
+checkT934Plain :: AsT934Plain t a => Prism' t a
+checkT934Plain = _T934Plain
+
+data a :+++: b = T934InL a | T934InR b
+makeConstructors ''(:+++:)
+
+class AsT934InL s a | s -> a
+
+checkT934InL :: Prism (a :+++: b) (a' :+++: b) a a'
+checkT934InL = _T934InL
 
 main :: IO ()
 main = putStrLn "test/templates.hs: ok"


### PR DESCRIPTION
Fixes #934.

`makeConstructors ''T` makes, for each constructor `Con`, `class AsCon s a | s -> a` with method `_Con :: Prism' s a`, and `T`'s instance of it. No top-level optics.

It only declares the class if no class of that name is in scope. So two types with a constructor of the same name share one class — the same way `makeFields` shares its `Has*` classes.

Some things the issue didn't settle. I picked these; happy to change any:

- **Existential constructors get nothing.** The payload type isn't fixed by the type, so the functional dependency's coverage condition rejects the instance — the liberal one too.
- **Operator-named constructors get nothing.** There is no way to spell `AsCon` for them. Operator-named types are fine.
- **A lone constructor gets a `Prism'`**, not the `Iso` `makePrisms` would make. The class method is always a simple `Prism'`; `makePrisms` remains the way to get the `Iso` or a type-changing `Prism`.
- **Payloads with a type family** go behind an equality constraint, as in #799. Splices like that need `UndecidableInstances`.
- **`makeClassInstance` sits in `FieldTH`** (commit 1). `Internal.TH` would be a cycle through `Language.Haskell.TH.Lens`.
- **The name `makeConstructors`** is the one from the issue thread.

No `makeConstructorsWith` or `declareConstructors` yet; see the review discussion.
