### PR TITLE
Add bimapped and setterUnion: diagonal setters (#975)

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,11 @@
 next [????.??.??]
 -----------------
+* Add `bimapped` to `Control.Lens.Setter`: a `Setter` that maps over both
+  parameters of a `Bifunctor` with the same function. Unlike `both`, it
+  requires only `Bifunctor` rather than `Bitraversable`.
+* Add `setterUnion` to `Control.Lens.Unsound`: apply the same function through
+  two `ASetter`s. Only a lawful `Setter` when the two setters touch disjoint
+  parts of the structure.
 * Add `fromMaybeOf` to `Control.Lens.Fold`: return the first target of a
   `Fold` or `Traversal`, or a caller-supplied default if there are none. This
   generalizes `fromMaybe` to any `Fold`: `fromMaybe = fromMaybeOf traverse`.

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -43,6 +43,7 @@ module Control.Lens.Setter
   , cloneIndexedSetter
   -- * Common Setters
   , mapped
+  , bimapped
   , contramapped
   , argument
   -- * Functional Combinators
@@ -89,6 +90,7 @@ import Control.Monad (liftM)
 import Control.Monad.Reader.Class as Reader
 import Control.Monad.State.Class  as State
 import Control.Monad.Writer.Class as Writer
+import Data.Bifunctor (Bifunctor, bimap)
 
 -- $setup
 -- >>> import Control.Lens
@@ -209,6 +211,33 @@ lifted :: Monad m => Setter (m a) (m b) a b
 lifted = sets liftM
 {-# INLINE lifted #-}
 {-# DEPRECATED lifted "Use `mapped` instead; since GHC 7.10 `Functor` is a superclass of `Monad`, so `mapped` subsumes `lifted`." #-}
+
+-- | This 'Setter' can be used to map over both parameters of a 'Bifunctor'
+-- with the same function.
+--
+-- Unlike 'Control.Lens.Traversal.both', this requires only a 'Bifunctor'
+-- rather than a 'Data.Bitraversable.Bitraversable', so it works for
+-- bifunctors whose parameters sit in positions that cannot be traversed.
+--
+-- @
+-- 'bimap' f f ≡ 'over' 'bimapped' f
+-- @
+--
+-- >>> over bimapped (+1) (1,2)
+-- (2,3)
+--
+-- >>> over bimapped negate (Left 3 :: Either Int Int)
+-- Left (-3)
+--
+-- @
+-- 'bimapped' :: 'Setter' (a, a)         (b, b)         a b
+-- 'bimapped' :: 'Setter' ('Either' a a) ('Either' b b) a b
+-- @
+--
+-- If you want an 'IndexPreservingSetter' use @'setting' (\\f -> 'bimap' f f)@.
+bimapped :: Bifunctor p => Setter (p a a) (p b b) a b
+bimapped = sets (\f -> bimap f f)
+{-# INLINE bimapped #-}
 
 -- | This 'Setter' can be used to map over all of the inputs to a 'Contravariant'.
 --

--- a/src/Control/Lens/Traversal.hs
+++ b/src/Control/Lens/Traversal.hs
@@ -897,6 +897,9 @@ instance Monoid m => Applicative (Holes t m) where
 -- >>> ("hello","world")^.both
 -- "helloworld"
 --
+-- For a container that is only a 'Data.Bifunctor.Bifunctor', use
+-- 'Control.Lens.Setter.bimapped'.
+--
 -- @
 -- 'both' :: 'Traversal' (a, a)       (b, b)       a b
 -- 'both' :: 'Traversal' ('Either' a a) ('Either' b b) a b

--- a/src/Control/Lens/Unsound.hs
+++ b/src/Control/Lens/Unsound.hs
@@ -28,6 +28,7 @@ module Control.Lens.Unsound
     lensProduct
   , prismSum
   , adjoin
+  , setterUnion
   ) where
 
 import Control.Lens
@@ -99,3 +100,49 @@ prismSum k k' =
 adjoin :: Traversal' s a -> Traversal' s a -> Traversal' s a
 adjoin t1 t2 =
     lensProduct (partsOf t1) (partsOf t2) . both . each
+
+-- | A union of setters: apply the same function through both of them.
+--
+-- Unlike `adjoin`, this needs only 'ASetter's, so it reaches targets that
+-- cannot be traversed. In exchange the result is write-only: unlike `adjoin`
+-- there is nothing to read back through.
+--
+-- Result is only a valid t'Setter' if the input setters touch disjoint parts of
+-- the structure. Otherwise the composition law
+--
+-- @
+-- 'Control.Lens.Setter.over' l f '.' 'Control.Lens.Setter.over' l g ≡ 'Control.Lens.Setter.over' l (f '.' g)
+-- @
+--
+-- is violated, because @f@ is applied once per setter on the left but the
+-- composite is applied once per setter on the right:
+--
+-- >>> let badSetter :: Setter' Int Int; badSetter = setterUnion id id
+-- >>> over badSetter (+1) (over badSetter (*2) 1)
+-- 6
+--
+-- >>> over badSetter ((+1) . (*2)) 1
+-- 7
+--
+-- On disjoint setters it behaves as expected:
+--
+-- >>> let (f, _, g) = over (setterUnion (_1 . mapped) (_3 . mapped)) (*2) ((+1), 'x', (+10))
+-- >>> (f 1, g 1)
+-- (4,22)
+--
+-- The second setter runs first, and the structure it produces is what the first
+-- setter consumes, so the two may change the type in sequence:
+--
+-- >>> over (setterUnion _2 _1) show (1 :: Int, 2 :: Int)
+-- ("1","2")
+--
+-- @
+-- 'setterUnion' :: 'Setter'' s a -> 'Setter'' s a -> 'Setter'' s a
+-- @
+--
+-- Are you looking for 'Control.Lens.Setter.bimapped' or
+-- 'Control.Lens.Traversal.both'?
+--
+setterUnion :: ASetter x o a b -> ASetter i x a b -> IndexPreservingSetter i o a b
+setterUnion l1 l2 = setting (\f -> over l1 f . over l2 f)
+{-# INLINE setterUnion #-}

--- a/tests/properties.hs
+++ b/tests/properties.hs
@@ -34,6 +34,7 @@ import GHC.Exts (Constraint)
 import Numeric (showHex, showOct, showSigned)
 import Numeric.Lens
 import Control.Lens.Properties (isIso, isLens, isPrism, isSetter, isTraversal)
+import Control.Lens.Unsound (setterUnion)
 import Data.Sequence (Seq)
 import Test.QuickCheck.Instances ()
 #if MIN_VERSION_quickcheck_instances(0,3,32)
@@ -77,6 +78,8 @@ prop_2_2                             = isLens (_2._2 :: Lens' (Int,(Int,Bool),Do
 -- Control.Lens.Setter
 prop_mapped                          = isSetter (mapped :: Setter' [Int] Int)
 prop_mapped_mapped                   = isSetter (mapped.mapped :: Setter' [Maybe Int] Int)
+prop_bimapped_pair                   = isSetter (bimapped :: Setter' (Int,Int) Int)
+prop_bimapped_either                 = isSetter (bimapped :: Setter' (Either Int Int) Int)
 
 prop_both                            = isTraversal (both           :: Traversal' (Int,Int) Int)
 prop_traverseLeft                    = isTraversal (_Left          :: Traversal' (Either Int Bool) Int)
@@ -88,6 +91,11 @@ prop_simple                          = isIso (simple :: Iso' Int Int)
 prop__Left                           = isPrism (_Left :: Prism' (Either Int Bool) Int)
 prop__Right                          = isPrism (_Right :: Prism' (Either Int Bool) Bool)
 prop__Just                           = isPrism (_Just :: Prism' (Maybe Int) Int)
+
+-- Control.Lens.Unsound
+-- setterUnion is only lawful on disjoint setters; the overlapping case is
+-- documented as broken in its Haddock and is deliberately not asserted here.
+prop_setterUnion_disjoint            = isSetter (setterUnion _1 _2 :: Setter' (Int,Int) Int)
 
 -- Data.List.Lens
 prop_prefixed s                      = isPrism (prefixed s :: Prism' String String)
@@ -178,6 +186,8 @@ main = defaultMain $
   , testProperty "2 2" prop_2_2
   , testProperty "mapped" prop_mapped
   , testProperty "mapped mapped" prop_mapped_mapped
+  , testProperty "bimapped pair" prop_bimapped_pair
+  , testProperty "bimapped either" prop_bimapped_either
   , testProperty "both" prop_both
   , testProperty "traverseLeft" prop_traverseLeft
   , testProperty "traverseRight" prop_traverseRight
@@ -185,6 +195,7 @@ main = defaultMain $
   , testProperty " Left" prop__Left
   , testProperty " Right" prop__Right
   , testProperty " Just" prop__Just
+  , testProperty "setterUnion disjoint" prop_setterUnion_disjoint
   , testProperty "prefixed" prop_prefixed
   , testProperty "suffixed" prop_suffixed
   , testProperty "prefixed seq" prop_prefixed_seq


### PR DESCRIPTION
Closes #975.

- `bimapped :: Bifunctor p => Setter (p a a) (p b b) a b` in `Control.Lens.Setter`: `both` for bifunctors that are not `Bitraversable`.
- `setterUnion :: ASetter x o a b -> ASetter i x a b -> IndexPreservingSetter i o a b` in `Control.Lens.Unsound`: apply one function through two setters. Lawful only when they are disjoint.

Two things need a maintainer's call:

1. The name `setterUnion` follows `lensProduct` / `prismSum`. Alternatives: `adjoinSetters`, `setterParComp`.
2. It returns `IndexPreservingSetter` (via `setting`) so `iover (itraversed . setterUnion _1 _2)` keeps its index; `lensProduct` and `adjoin` return the plain simple types. Happy to switch if preferred.
